### PR TITLE
fix in few RVTEST_CASE strings and JALR macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## [2.5.3] - 2021-10-14
+  - fix the lower case `i` in the `RVTEST_CASE` macros used in the shift operation tests.
+  - fix to jalr macros - this does not affect coverage or reference signatures at this point.
+
 ## [2.5.2] - 2021-10-14
   - update format for aes32 and sm4 instructions
   - update reference signature for sha256 and sm3 instructions in rv64i_m/K_unratified

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -676,12 +676,12 @@ rvtest_data_end:
     jalr x0,0(tempreg)                       ;\
 6:  LA(tempreg, 4f                          ) ;\
     jalr x0,0(tempreg)                        ;\
-1:  .if adj & 2 == 2                         ;\
+1:  .if (adj & 2 == 2) && (label == 1b)      ;\
     .fill 2,1,0x00                          ;\
     .endif                                    ;\
     xori rd,rd, 0x1                           ;\
     beq x0,x0,6b                               ;\
-    .if adj & 2 == 2                              ;\
+    .if (adj & 2 == 2) && (label == 1b)     ;\
     .fill 2,1,0x00                          ;\
     .endif                                    ;\
     .if (imm/2) - 2 >= 0                      ;\
@@ -708,19 +708,22 @@ rvtest_data_end:
     .else                                     ;\
         .set num,0                            ;\
     .endif                                    ;\
+    .if (adj & 2 == 2) && num >= 2           ;\
+        .set num, num-2                     ;\
+    .endif                                    ;\
     .if label == 1b                          ;\
         .set num,0                            ;\
     .endif                                    ;\
     .rept num                                 ;\
     nop                                       ;\
     .endr                                     ;\
-3:  .if adj & 2 == 2                              ;\
+3:  .if (adj & 2 == 2) && (label == 3f)      ;\
     .fill 2,1,0x00                          ;\
     .endif                                    ;\
     xori rd,rd, 0x3                           ;\
     LA(tempreg, 4f                          ) ;\
     jalr x0,0(tempreg)                        ;\
-    .if adj&2 == 2                              ;\
+    .if (adj&2 == 2) && (label == 3f)       ;\
     .fill 2,1,0x00                     ;\
     .endif                                    ;\
 4: LA(tempreg, 5b                            ) ;\

--- a/riscv-test-suite/rv32i_m/I/src/sll-01.S
+++ b/riscv-test-suite/rv32i_m/I/src/sll-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32i")
+RVTEST_ISA("RV32I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/I/src/sra-01.S
+++ b/riscv-test-suite/rv32i_m/I/src/sra-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32i")
+RVTEST_ISA("RV32I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/I/src/srl-01.S
+++ b/riscv-test-suite/rv32i_m/I/src/srl-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32i")
+RVTEST_ISA("RV32I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/sll-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/sll-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/sllw-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/sllw-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/sra-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/sra-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/sraw-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/sraw-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/srl-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/srl-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/srlw-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/srlw-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point


### PR DESCRIPTION
  - fix the lower case `i` in the `RVTEST_CASE` macros used in the shift operation tests.
  - fix to jalr macros - this does not affect coverage or reference signatures at this point.