### PR TITLE
fix the lower case `i` in the `RVTEST_CASE` macros used in the shift …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+
+## [2.5.3] - 2021-10-15
+  - fix the lower case `i` in the `RVTEST_CASE` macros used in the shift operation tests.
+
 ## [2.5.2] - 2021-10-14
   - update format for aes32 and sm4 instructions
   - update reference signature for sha256 and sm3 instructions in rv64i_m/K_unratified

--- a/riscv-test-suite/rv32i_m/I/src/sll-01.S
+++ b/riscv-test-suite/rv32i_m/I/src/sll-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32i")
+RVTEST_ISA("RV32I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/I/src/sra-01.S
+++ b/riscv-test-suite/rv32i_m/I/src/sra-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32i")
+RVTEST_ISA("RV32I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/I/src/srl-01.S
+++ b/riscv-test-suite/rv32i_m/I/src/srl-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32i")
+RVTEST_ISA("RV32I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/sll-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/sll-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/sllw-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/sllw-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/sra-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/sra-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/sraw-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/sraw-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/srl-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/srl-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/I/src/srlw-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/srlw-01.S
@@ -17,7 +17,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64i")
+RVTEST_ISA("RV64I")
 
 .section .text.init
 .globl rvtest_entry_point


### PR DESCRIPTION
fix the lower case `i` in the `RVTEST_CASE` macros used in the shift operation tests.