### PR TITLE
fix error on BSD diff

### DIFF
--- a/riscv-test-env/verify.sh
+++ b/riscv-test-env/verify.sh
@@ -29,7 +29,7 @@ do
         continue
     fi
     #diff --ignore-case --strip-trailing-cr ${ref} ${sig} &> /dev/null
-    diff --ignore-case --ignore-trailing-space --strip-trailing-cr <(grep -o '^[^#]*' ${ref}) ${sig} &> /dev/null
+    diff --ignore-case --ignore-all-space --strip-trailing-cr <(grep -o '^[^#]*' ${ref}) ${sig} &> /dev/null
     if [ $? == 0 ]
     then
         echo -e "\e[32m ... OK \e[39m"


### PR DESCRIPTION
BSD diff does not support option --ignore-trailing-space, change to --ignore-all-space.