### PR TITLE
Fix fpid macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [3.1.1] - 2022-07-07
+  - Fix definition of FPID macro to add load instruction.
+  - Fix nan boxing macro to use correct endianness.
+
 ## [3.1.0] - 2022-07-05
   - Update floating point tests and macros to ensure flags are cleared & correct rounding modes are used.
 

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -94,7 +94,7 @@
         #define SIGALIGN 8
     #else
         #define SIGALIGN 4
-    #endif  
+    #endif
   #endif
 #endif
 
@@ -112,6 +112,11 @@
 #endif
 
 #define NAN_BOXED(__val__,__width__,__max__)    \
+    .if __width__ == 32                        ;\
+        .word __val__                          ;\
+    .else                                      ;\
+        .dword __val__                         ;\
+    .endif                                     ;\
     .if __max__ > __width__                    ;\
         .set pref_bytes,(__max__-__width__)/32 ;\
     .else                                      ;\
@@ -119,12 +124,8 @@
     .endif                                     ;\
     .rept pref_bytes                           ;\
         .word 0xffffffff                       ;\
-    .endr                                      ;\
-    .if __width__ == 32                        ;\
-        .word __val__                          ;\
-    .else                                      ;\
-        .dword __val__                         ;\
-    .endif;
+    .endr                                      ;
+
 
 #define ZERO_EXTEND(__val__,__width__,__max__)  \
     .if __max__ > __width__                    ;\
@@ -980,9 +981,9 @@ RVTEST_SIGUPD_F(swreg,destreg,flagreg,offset)
     )
     
 //Tests for floating-point instructions with a single register operand and integer destination register
-#define TEST_FPID_OP( inst, destreg, freg, rm, fcsr_val, correctval, valaddr_reg, val_offset, flagreg, swreg, testreg) \
+#define TEST_FPID_OP( inst, destreg, freg, rm, fcsr_val, correctval, valaddr_reg, val_offset, flagreg, swreg, testreg,load_instr) \
     TEST_CASE_FID(testreg, destreg, correctval, swreg, flagreg, \
-      LOAD_MEM_VAL(FLREG, valaddr_reg, freg, val_offset, testreg); \
+      LOAD_MEM_VAL(load_instr, valaddr_reg, freg, val_offset, testreg); \
       li testreg, fcsr_val; csrw fcsr, testreg; \
       inst destreg, freg, rm; \
       csrr flagreg, fcsr      ; \


### PR DESCRIPTION
- Fix definition of FPID macro to add load instruction.
- Fix nan boxing macro to use correct endianness.