### PR TITLE
Fix load unsigned instructions in fcvt tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [3.1.2] - 2022-07-19
+## [3.2.0] - 2022-07-19
   - Add definition of LREGWU according to XLEN.
   - Fix corresponding fcvt.\*.wu tests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [3.1.2] - 2022-07-19
+  - Add definition of LREGWU according to XLEN.
+  - Fix corresponding fcvt.s.wu tests.
+
 ## [3.1.1] - 2022-07-07
   - Fix definition of FPID macro to add load instruction.
   - Fix nan boxing macro to use correct endianness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [3.1.2] - 2022-07-19
   - Add definition of LREGWU according to XLEN.
-  - Fix corresponding fcvt.s.wu tests.
+  - Fix corresponding fcvt.\*.wu tests.
 
 ## [3.1.1] - 2022-07-07
   - Fix definition of FPID macro to add load instruction.

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -67,6 +67,7 @@
 #if XLEN==64
   #define SREG sd
   #define LREG ld
+  #define LREGWU lwu
   #define REGWIDTH 8
   #define MASK 0xFFFFFFFFFFFFFFFF
 
@@ -74,6 +75,7 @@
   #if XLEN==32
     #define SREG sw
     #define LREG lw
+    #define LREGWU lw
     #define REGWIDTH 4
   #define MASK 0xFFFFFFFF
 

--- a/riscv-test-suite/rv32i_m/D/src/fcvt.d.wu_b25-01.S
+++ b/riscv-test-suite/rv32i_m/D/src/fcvt.d.wu_b25-01.S
@@ -39,201 +39,201 @@ inst_0:// rs1==x8, rd==f28,rs1_val == 0 and  fcsr == 0 and rm_val == 7
 /* opcode: fcvt.d.wu ; op1:x8; dest:f28; op1val:0x0; valaddr_reg:x11;
 val_offset:0*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f28, x8, 0, 0, x11, 0*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f28, x8, 0, 0, x11, 0*4, x16, x5, x10,LREGWU)
 
 inst_1:// rs1==x28, rd==f18,rs1_val == 1 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x28; dest:f18; op1val:0x1; valaddr_reg:x11;
 val_offset:1*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f18, x28, 0, 0, x11, 1*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f18, x28, 0, 0, x11, 1*4, x16, x5, x10,LREGWU)
 
 inst_2:// rs1==x30, rd==f3,rs1_val == 2454155456 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x30; dest:f3; op1val:0x924770c0; valaddr_reg:x11;
 val_offset:2*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f3, x30, 0, 0, x11, 2*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f3, x30, 0, 0, x11, 2*4, x16, x5, x10,LREGWU)
 
 inst_3:// rs1==x27, rd==f23,rs1_val == 4294967295 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x27; dest:f23; op1val:0xffffffff; valaddr_reg:x11;
 val_offset:3*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f23, x27, 0, 0, x11, 3*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f23, x27, 0, 0, x11, 3*4, x16, x5, x10,LREGWU)
 
 inst_4:// rs1==x4, rd==f22,
 /* opcode: fcvt.d.wu ; op1:x4; dest:f22; op1val:0x0; valaddr_reg:x11;
 val_offset:4*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f22, x4, 0, 0, x11, 4*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f22, x4, 0, 0, x11, 4*4, x16, x5, x10,LREGWU)
 
 inst_5:// rs1==x15, rd==f12,
 /* opcode: fcvt.d.wu ; op1:x15; dest:f12; op1val:0x0; valaddr_reg:x11;
 val_offset:5*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f12, x15, 0, 0, x11, 5*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f12, x15, 0, 0, x11, 5*4, x16, x5, x10,LREGWU)
 
 inst_6:// rs1==x23, rd==f19,
 /* opcode: fcvt.d.wu ; op1:x23; dest:f19; op1val:0x0; valaddr_reg:x11;
 val_offset:6*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f19, x23, 0, 0, x11, 6*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f19, x23, 0, 0, x11, 6*4, x16, x5, x10,LREGWU)
 
 inst_7:// rs1==x3, rd==f2,
 /* opcode: fcvt.d.wu ; op1:x3; dest:f2; op1val:0x0; valaddr_reg:x11;
 val_offset:7*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f2, x3, 0, 0, x11, 7*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f2, x3, 0, 0, x11, 7*4, x16, x5, x10,LREGWU)
 
 inst_8:// rs1==x6, rd==f26,
 /* opcode: fcvt.d.wu ; op1:x6; dest:f26; op1val:0x0; valaddr_reg:x11;
 val_offset:8*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f26, x6, 0, 0, x11, 8*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f26, x6, 0, 0, x11, 8*4, x16, x5, x10,LREGWU)
 
 inst_9:// rs1==x1, rd==f15,
 /* opcode: fcvt.d.wu ; op1:x1; dest:f15; op1val:0x0; valaddr_reg:x11;
 val_offset:9*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f15, x1, 0, 0, x11, 9*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f15, x1, 0, 0, x11, 9*4, x16, x5, x10,LREGWU)
 
 inst_10:// rs1==x13, rd==f10,
 /* opcode: fcvt.d.wu ; op1:x13; dest:f10; op1val:0x0; valaddr_reg:x11;
 val_offset:10*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f10, x13, 0, 0, x11, 10*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f10, x13, 0, 0, x11, 10*4, x16, x5, x10,LREGWU)
 
 inst_11:// rs1==x20, rd==f14,
 /* opcode: fcvt.d.wu ; op1:x20; dest:f14; op1val:0x0; valaddr_reg:x11;
 val_offset:11*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f14, x20, 0, 0, x11, 11*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f14, x20, 0, 0, x11, 11*4, x16, x5, x10,LREGWU)
 
 inst_12:// rs1==x21, rd==f20,
 /* opcode: fcvt.d.wu ; op1:x21; dest:f20; op1val:0x0; valaddr_reg:x11;
 val_offset:12*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f20, x21, 0, 0, x11, 12*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f20, x21, 0, 0, x11, 12*4, x16, x5, x10,LREGWU)
 
 inst_13:// rs1==x22, rd==f30,
 /* opcode: fcvt.d.wu ; op1:x22; dest:f30; op1val:0x0; valaddr_reg:x11;
 val_offset:13*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f30, x22, 0, 0, x11, 13*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f30, x22, 0, 0, x11, 13*4, x16, x5, x10,LREGWU)
 
 inst_14:// rs1==x14, rd==f9,
 /* opcode: fcvt.d.wu ; op1:x14; dest:f9; op1val:0x0; valaddr_reg:x11;
 val_offset:14*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f9, x14, 0, 0, x11, 14*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f9, x14, 0, 0, x11, 14*4, x16, x5, x10,LREGWU)
 
 inst_15:// rs1==x12, rd==f0,
 /* opcode: fcvt.d.wu ; op1:x12; dest:f0; op1val:0x0; valaddr_reg:x11;
 val_offset:15*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f0, x12, 0, 0, x11, 15*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f0, x12, 0, 0, x11, 15*4, x16, x5, x10,LREGWU)
 
 inst_16:// rs1==x2, rd==f29,
 /* opcode: fcvt.d.wu ; op1:x2; dest:f29; op1val:0x0; valaddr_reg:x11;
 val_offset:16*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f29, x2, 0, 0, x11, 16*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f29, x2, 0, 0, x11, 16*4, x16, x5, x10,LREGWU)
 
 inst_17:// rs1==x26, rd==f6,
 /* opcode: fcvt.d.wu ; op1:x26; dest:f6; op1val:0x0; valaddr_reg:x11;
 val_offset:17*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f6, x26, 0, 0, x11, 17*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f6, x26, 0, 0, x11, 17*4, x16, x5, x10,LREGWU)
 
 inst_18:// rs1==x19, rd==f24,
 /* opcode: fcvt.d.wu ; op1:x19; dest:f24; op1val:0x0; valaddr_reg:x11;
 val_offset:18*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f24, x19, 0, 0, x11, 18*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f24, x19, 0, 0, x11, 18*4, x16, x5, x10,LREGWU)
 
 inst_19:// rs1==x17, rd==f25,
 /* opcode: fcvt.d.wu ; op1:x17; dest:f25; op1val:0x0; valaddr_reg:x11;
 val_offset:19*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f25, x17, 0, 0, x11, 19*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f25, x17, 0, 0, x11, 19*4, x16, x5, x10,LREGWU)
 
 inst_20:// rs1==x29, rd==f17,
 /* opcode: fcvt.d.wu ; op1:x29; dest:f17; op1val:0x0; valaddr_reg:x11;
 val_offset:20*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f17, x29, 0, 0, x11, 20*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f17, x29, 0, 0, x11, 20*4, x16, x5, x10,LREGWU)
 
 inst_21:// rs1==x18, rd==f5,
 /* opcode: fcvt.d.wu ; op1:x18; dest:f5; op1val:0x0; valaddr_reg:x11;
 val_offset:21*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f5, x18, 0, 0, x11, 21*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f5, x18, 0, 0, x11, 21*4, x16, x5, x10,LREGWU)
 
 inst_22:// rs1==x9, rd==f16,
 /* opcode: fcvt.d.wu ; op1:x9; dest:f16; op1val:0x0; valaddr_reg:x11;
 val_offset:22*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f16, x9, 0, 0, x11, 22*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f16, x9, 0, 0, x11, 22*4, x16, x5, x10,LREGWU)
 
 inst_23:// rs1==x7, rd==f7,
 /* opcode: fcvt.d.wu ; op1:x7; dest:f7; op1val:0x0; valaddr_reg:x11;
 val_offset:23*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f7, x7, 0, 0, x11, 23*4, x16, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f7, x7, 0, 0, x11, 23*4, x16, x5, x10,LREGWU)
 RVTEST_VALBASEUPD(x3,test_dataset_1)
 
 inst_24:// rs1==x31, rd==f1,
 /* opcode: fcvt.d.wu ; op1:x31; dest:f1; op1val:0x0; valaddr_reg:x3;
 val_offset:0*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f1, x31, 0, 0, x3, 0*4, x4, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f1, x31, 0, 0, x3, 0*4, x4, x5, x10,LREGWU)
 
 inst_25:// rs1==x11, rd==f21,
 /* opcode: fcvt.d.wu ; op1:x11; dest:f21; op1val:0x0; valaddr_reg:x3;
 val_offset:1*4; correctval:0; testreg:x10;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f21, x11, 0, 0, x3, 1*4, x4, x5, x10,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f21, x11, 0, 0, x3, 1*4, x4, x5, x10,LREGWU)
 
 inst_26:// rs1==x16, rd==f31,
 /* opcode: fcvt.d.wu ; op1:x16; dest:f31; op1val:0x0; valaddr_reg:x3;
 val_offset:2*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f31, x16, 0, 0, x3, 2*4, x4, x5, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f31, x16, 0, 0, x3, 2*4, x4, x5, x2,LREGWU)
 RVTEST_SIGBASE(x1,signature_x1_0)
 
 inst_27:// rs1==x25, rd==f13,
 /* opcode: fcvt.d.wu ; op1:x25; dest:f13; op1val:0x0; valaddr_reg:x3;
 val_offset:3*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f13, x25, 0, 0, x3, 3*4, x4, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f13, x25, 0, 0, x3, 3*4, x4, x1, x2,LREGWU)
 
 inst_28:// rs1==x0, rd==f11,
 /* opcode: fcvt.d.wu ; op1:x0; dest:f11; op1val:0x0; valaddr_reg:x3;
 val_offset:4*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f11, x0, 0, 0, x3, 4*4, x4, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f11, x0, 0, 0, x3, 4*4, x4, x1, x2,LREGWU)
 
 inst_29:// rs1==x5, rd==f4,
 /* opcode: fcvt.d.wu ; op1:x5; dest:f4; op1val:0x0; valaddr_reg:x3;
 val_offset:5*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f4, x5, 0, 0, x3, 5*4, x4, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f4, x5, 0, 0, x3, 5*4, x4, x1, x2,LREGWU)
 
 inst_30:// rs1==x10, rd==f8,
 /* opcode: fcvt.d.wu ; op1:x10; dest:f8; op1val:0x0; valaddr_reg:x3;
 val_offset:6*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f8, x10, 0, 0, x3, 6*4, x4, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f8, x10, 0, 0, x3, 6*4, x4, x1, x2,LREGWU)
 
 inst_31:// rs1==x24, rd==f27,
 /* opcode: fcvt.d.wu ; op1:x24; dest:f27; op1val:0x0; valaddr_reg:x3;
 val_offset:7*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f27, x24, 0, 0, x3, 7*4, x4, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f27, x24, 0, 0, x3, 7*4, x4, x1, x2,LREGWU)
 
 inst_32:// 
 /* opcode: fcvt.d.wu ; op1:x31; dest:f31; op1val:0x0; valaddr_reg:x3;
 val_offset:8*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f31, x31, 0, 0, x3, 8*4, x4, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f31, x31, 0, 0, x3, 8*4, x4, x1, x2,LREGWU)
 #endif
 
 

--- a/riscv-test-suite/rv32i_m/D/src/fcvt.d.wu_b26-01.S
+++ b/riscv-test-suite/rv32i_m/D/src/fcvt.d.wu_b26-01.S
@@ -39,201 +39,201 @@ inst_0:// rs1==x22, rd==f2,rs1_val == 0 and  fcsr == 0 and rm_val == 7
 /* opcode: fcvt.d.wu ; op1:x22; dest:f2; op1val:0x0; valaddr_reg:x13;
 val_offset:0*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f2, x22, 0, 0, x13, 0*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f2, x22, 0, 0, x13, 0*4, x15, x10, x3,LREGWU)
 
 inst_1:// rs1==x2, rd==f14,rs1_val == 1 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x2; dest:f14; op1val:0x1; valaddr_reg:x13;
 val_offset:1*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f14, x2, 0, 0, x13, 1*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f14, x2, 0, 0, x13, 1*4, x15, x10, x3,LREGWU)
 
 inst_2:// rs1==x7, rd==f11,rs1_val == 1027494066 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x7; dest:f11; op1val:0x3d3e50b2; valaddr_reg:x13;
 val_offset:2*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f11, x7, 0, 0, x13, 2*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f11, x7, 0, 0, x13, 2*4, x15, x10, x3,LREGWU)
 
 inst_3:// rs1==x16, rd==f5,rs1_val == 107790943 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x16; dest:f5; op1val:0x66cc25f; valaddr_reg:x13;
 val_offset:3*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f5, x16, 0, 0, x13, 3*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f5, x16, 0, 0, x13, 3*4, x15, x10, x3,LREGWU)
 
 inst_4:// rs1==x28, rd==f7,rs1_val == 1094 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x28; dest:f7; op1val:0x446; valaddr_reg:x13;
 val_offset:4*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f7, x28, 0, 0, x13, 4*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f7, x28, 0, 0, x13, 4*4, x15, x10, x3,LREGWU)
 
 inst_5:// rs1==x6, rd==f20,rs1_val == 123 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x6; dest:f20; op1val:0x7b; valaddr_reg:x13;
 val_offset:5*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f20, x6, 0, 0, x13, 5*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f20, x6, 0, 0, x13, 5*4, x15, x10, x3,LREGWU)
 
 inst_6:// rs1==x11, rd==f15,rs1_val == 12789625 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x11; dest:f15; op1val:0xc32779; valaddr_reg:x13;
 val_offset:6*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f15, x11, 0, 0, x13, 6*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f15, x11, 0, 0, x13, 6*4, x15, x10, x3,LREGWU)
 
 inst_7:// rs1==x30, rd==f10,rs1_val == 15 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x30; dest:f10; op1val:0xf; valaddr_reg:x13;
 val_offset:7*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f10, x30, 0, 0, x13, 7*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f10, x30, 0, 0, x13, 7*4, x15, x10, x3,LREGWU)
 
 inst_8:// rs1==x27, rd==f3,rs1_val == 1587807073 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x27; dest:f3; op1val:0x5ea40361; valaddr_reg:x13;
 val_offset:8*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f3, x27, 0, 0, x13, 8*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f3, x27, 0, 0, x13, 8*4, x15, x10, x3,LREGWU)
 
 inst_9:// rs1==x14, rd==f13,rs1_val == 16 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x14; dest:f13; op1val:0x10; valaddr_reg:x13;
 val_offset:9*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f13, x14, 0, 0, x13, 9*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f13, x14, 0, 0, x13, 9*4, x15, x10, x3,LREGWU)
 
 inst_10:// rs1==x26, rd==f21,rs1_val == 1848861 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x26; dest:f21; op1val:0x1c361d; valaddr_reg:x13;
 val_offset:10*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f21, x26, 0, 0, x13, 10*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f21, x26, 0, 0, x13, 10*4, x15, x10, x3,LREGWU)
 
 inst_11:// rs1==x17, rd==f26,rs1_val == 2 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x17; dest:f26; op1val:0x2; valaddr_reg:x13;
 val_offset:11*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f26, x17, 0, 0, x13, 11*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f26, x17, 0, 0, x13, 11*4, x15, x10, x3,LREGWU)
 
 inst_12:// rs1==x5, rd==f4,rs1_val == 231549045 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x5; dest:f4; op1val:0xdcd2875; valaddr_reg:x13;
 val_offset:12*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f4, x5, 0, 0, x13, 12*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f4, x5, 0, 0, x13, 12*4, x15, x10, x3,LREGWU)
 
 inst_13:// rs1==x12, rd==f22,rs1_val == 241276 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x12; dest:f22; op1val:0x3ae7c; valaddr_reg:x13;
 val_offset:13*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f22, x12, 0, 0, x13, 13*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f22, x12, 0, 0, x13, 13*4, x15, x10, x3,LREGWU)
 
 inst_14:// rs1==x18, rd==f19,rs1_val == 24575 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x18; dest:f19; op1val:0x5fff; valaddr_reg:x13;
 val_offset:14*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f19, x18, 0, 0, x13, 14*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f19, x18, 0, 0, x13, 14*4, x15, x10, x3,LREGWU)
 
 inst_15:// rs1==x4, rd==f0,rs1_val == 253 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x4; dest:f0; op1val:0xfd; valaddr_reg:x13;
 val_offset:15*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f0, x4, 0, 0, x13, 15*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f0, x4, 0, 0, x13, 15*4, x15, x10, x3,LREGWU)
 
 inst_16:// rs1==x0, rd==f31,rs1_val == 32105925 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x0; dest:f31; op1val:0x0; valaddr_reg:x13;
 val_offset:16*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f31, x0, 0, 0, x13, 16*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f31, x0, 0, 0, x13, 16*4, x15, x10, x3,LREGWU)
 
 inst_17:// rs1==x20, rd==f8,rs1_val == 334857 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x20; dest:f8; op1val:0x51c09; valaddr_reg:x13;
 val_offset:17*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f8, x20, 0, 0, x13, 17*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f8, x20, 0, 0, x13, 17*4, x15, x10, x3,LREGWU)
 
 inst_18:// rs1==x24, rd==f24,rs1_val == 339827553 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x24; dest:f24; op1val:0x14415b61; valaddr_reg:x13;
 val_offset:18*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f24, x24, 0, 0, x13, 18*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f24, x24, 0, 0, x13, 18*4, x15, x10, x3,LREGWU)
 
 inst_19:// rs1==x9, rd==f29,rs1_val == 3864061 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x9; dest:f29; op1val:0x3af5fd; valaddr_reg:x13;
 val_offset:19*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f29, x9, 0, 0, x13, 19*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f29, x9, 0, 0, x13, 19*4, x15, x10, x3,LREGWU)
 
 inst_20:// rs1==x8, rd==f28,rs1_val == 398 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x8; dest:f28; op1val:0x18e; valaddr_reg:x13;
 val_offset:20*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f28, x8, 0, 0, x13, 20*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f28, x8, 0, 0, x13, 20*4, x15, x10, x3,LREGWU)
 
 inst_21:// rs1==x29, rd==f25,rs1_val == 4055 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x29; dest:f25; op1val:0xfd7; valaddr_reg:x13;
 val_offset:21*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f25, x29, 0, 0, x13, 21*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f25, x29, 0, 0, x13, 21*4, x15, x10, x3,LREGWU)
 
 inst_22:// rs1==x1, rd==f16,rs1_val == 45 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x1; dest:f16; op1val:0x2d; valaddr_reg:x13;
 val_offset:22*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f16, x1, 0, 0, x13, 22*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f16, x1, 0, 0, x13, 22*4, x15, x10, x3,LREGWU)
 
 inst_23:// rs1==x23, rd==f18,rs1_val == 45276376 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x23; dest:f18; op1val:0x2b2dcd8; valaddr_reg:x13;
 val_offset:23*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f18, x23, 0, 0, x13, 23*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f18, x23, 0, 0, x13, 23*4, x15, x10, x3,LREGWU)
 
 inst_24:// rs1==x21, rd==f1,rs1_val == 56436 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x21; dest:f1; op1val:0xdc74; valaddr_reg:x13;
 val_offset:24*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f1, x21, 0, 0, x13, 24*4, x15, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f1, x21, 0, 0, x13, 24*4, x15, x10, x3,LREGWU)
 RVTEST_VALBASEUPD(x4,test_dataset_1)
 
 inst_25:// rs1==x25, rd==f23,rs1_val == 6573466 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x25; dest:f23; op1val:0x644d9a; valaddr_reg:x4;
 val_offset:0*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f23, x25, 0, 0, x4, 0*4, x5, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f23, x25, 0, 0, x4, 0*4, x5, x10, x3,LREGWU)
 
 inst_26:// rs1==x15, rd==f30,rs1_val == 676 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x15; dest:f30; op1val:0x2a4; valaddr_reg:x4;
 val_offset:1*4; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f30, x15, 0, 0, x4, 1*4, x5, x10, x3,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f30, x15, 0, 0, x4, 1*4, x5, x10, x3,LREGWU)
 
 inst_27:// rs1==x3, rd==f9,rs1_val == 6781 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x3; dest:f9; op1val:0x1a7d; valaddr_reg:x4;
 val_offset:2*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f9, x3, 0, 0, x4, 2*4, x5, x10, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f9, x3, 0, 0, x4, 2*4, x5, x10, x2,LREGWU)
 RVTEST_SIGBASE(x1,signature_x1_0)
 
 inst_28:// rs1==x19, rd==f12,rs1_val == 7 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x19; dest:f12; op1val:0x7; valaddr_reg:x4;
 val_offset:3*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f12, x19, 0, 0, x4, 3*4, x5, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f12, x19, 0, 0, x4, 3*4, x5, x1, x2,LREGWU)
 
 inst_29:// rs1==x31, rd==f27,rs1_val == 71376 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x31; dest:f27; op1val:0x116d0; valaddr_reg:x4;
 val_offset:4*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f27, x31, 0, 0, x4, 4*4, x5, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f27, x31, 0, 0, x4, 4*4, x5, x1, x2,LREGWU)
 
 inst_30:// rs1==x10, rd==f6,rs1_val == 896618 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x10; dest:f6; op1val:0xdae6a; valaddr_reg:x4;
 val_offset:5*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f6, x10, 0, 0, x4, 5*4, x5, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f6, x10, 0, 0, x4, 5*4, x5, x1, x2,LREGWU)
 
 inst_31:// rs1==x13, rd==f17,rs1_val == 9438 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x13; dest:f17; op1val:0x24de; valaddr_reg:x4;
 val_offset:6*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f17, x13, 0, 0, x4, 6*4, x5, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f17, x13, 0, 0, x4, 6*4, x5, x1, x2,LREGWU)
 
 inst_32:// rs1_val == 32105925 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.d.wu ; op1:x31; dest:f31; op1val:0x1e9e5c5; valaddr_reg:x4;
 val_offset:7*4; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP_NRM(fcvt.d.wu, f31, x31, 0, 0, x4, 7*4, x5, x1, x2,lwu)
+TEST_FPIO_OP_NRM(fcvt.d.wu, f31, x31, 0, 0, x4, 7*4, x5, x1, x2,LREGWU)
 #endif
 
 

--- a/riscv-test-suite/rv32i_m/F/src/fcvt.s.wu_b25-01.S
+++ b/riscv-test-suite/rv32i_m/F/src/fcvt.s.wu_b25-01.S
@@ -39,201 +39,201 @@ inst_0:// rs1==x3, rd==f26,rs1_val == 0 and  fcsr == 0 and rm_val == 7
 /* opcode: fcvt.s.wu ; op1:x3; dest:f26; op1val:0x0; valaddr_reg:x14;
 val_offset:0*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f26, x3, dyn, 0, 0, x14, 0*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f26, x3, dyn, 0, 0, x14, 0*4, x22, x8, x20,LREGWU)
 
 inst_1:// rs1==x18, rd==f11,rs1_val == 1 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x18; dest:f11; op1val:0x1; valaddr_reg:x14;
 val_offset:1*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f11, x18, dyn, 0, 0, x14, 1*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f11, x18, dyn, 0, 0, x14, 1*4, x22, x8, x20,LREGWU)
 
 inst_2:// rs1==x19, rd==f10,rs1_val == 2454155456 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x19; dest:f10; op1val:0x924770c0; valaddr_reg:x14;
 val_offset:2*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f10, x19, dyn, 0, 0, x14, 2*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f10, x19, dyn, 0, 0, x14, 2*4, x22, x8, x20,LREGWU)
 
 inst_3:// rs1==x11, rd==f9,rs1_val == 4294967295 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x11; dest:f9; op1val:0xffffffff; valaddr_reg:x14;
 val_offset:3*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f9, x11, dyn, 0, 0, x14, 3*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f9, x11, dyn, 0, 0, x14, 3*4, x22, x8, x20,LREGWU)
 
 inst_4:// rs1==x2, rd==f1,
 /* opcode: fcvt.s.wu ; op1:x2; dest:f1; op1val:0x0; valaddr_reg:x14;
 val_offset:4*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f1, x2, dyn, 0, 0, x14, 4*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f1, x2, dyn, 0, 0, x14, 4*4, x22, x8, x20,LREGWU)
 
 inst_5:// rs1==x21, rd==f24,
 /* opcode: fcvt.s.wu ; op1:x21; dest:f24; op1val:0x0; valaddr_reg:x14;
 val_offset:5*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f24, x21, dyn, 0, 0, x14, 5*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f24, x21, dyn, 0, 0, x14, 5*4, x22, x8, x20,LREGWU)
 
 inst_6:// rs1==x12, rd==f17,
 /* opcode: fcvt.s.wu ; op1:x12; dest:f17; op1val:0x0; valaddr_reg:x14;
 val_offset:6*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f17, x12, dyn, 0, 0, x14, 6*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f17, x12, dyn, 0, 0, x14, 6*4, x22, x8, x20,LREGWU)
 
 inst_7:// rs1==x4, rd==f23,
 /* opcode: fcvt.s.wu ; op1:x4; dest:f23; op1val:0x0; valaddr_reg:x14;
 val_offset:7*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f23, x4, dyn, 0, 0, x14, 7*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f23, x4, dyn, 0, 0, x14, 7*4, x22, x8, x20,LREGWU)
 
 inst_8:// rs1==x24, rd==f13,
 /* opcode: fcvt.s.wu ; op1:x24; dest:f13; op1val:0x0; valaddr_reg:x14;
 val_offset:8*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f13, x24, dyn, 0, 0, x14, 8*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f13, x24, dyn, 0, 0, x14, 8*4, x22, x8, x20,LREGWU)
 
 inst_9:// rs1==x9, rd==f21,
 /* opcode: fcvt.s.wu ; op1:x9; dest:f21; op1val:0x0; valaddr_reg:x14;
 val_offset:9*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f21, x9, dyn, 0, 0, x14, 9*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f21, x9, dyn, 0, 0, x14, 9*4, x22, x8, x20,LREGWU)
 
 inst_10:// rs1==x29, rd==f2,
 /* opcode: fcvt.s.wu ; op1:x29; dest:f2; op1val:0x0; valaddr_reg:x14;
 val_offset:10*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f2, x29, dyn, 0, 0, x14, 10*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f2, x29, dyn, 0, 0, x14, 10*4, x22, x8, x20,LREGWU)
 
 inst_11:// rs1==x5, rd==f30,
 /* opcode: fcvt.s.wu ; op1:x5; dest:f30; op1val:0x0; valaddr_reg:x14;
 val_offset:11*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f30, x5, dyn, 0, 0, x14, 11*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f30, x5, dyn, 0, 0, x14, 11*4, x22, x8, x20,LREGWU)
 
 inst_12:// rs1==x30, rd==f0,
 /* opcode: fcvt.s.wu ; op1:x30; dest:f0; op1val:0x0; valaddr_reg:x14;
 val_offset:12*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f0, x30, dyn, 0, 0, x14, 12*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f0, x30, dyn, 0, 0, x14, 12*4, x22, x8, x20,LREGWU)
 
 inst_13:// rs1==x6, rd==f5,
 /* opcode: fcvt.s.wu ; op1:x6; dest:f5; op1val:0x0; valaddr_reg:x14;
 val_offset:13*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f5, x6, dyn, 0, 0, x14, 13*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f5, x6, dyn, 0, 0, x14, 13*4, x22, x8, x20,LREGWU)
 
 inst_14:// rs1==x17, rd==f7,
 /* opcode: fcvt.s.wu ; op1:x17; dest:f7; op1val:0x0; valaddr_reg:x14;
 val_offset:14*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f7, x17, dyn, 0, 0, x14, 14*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f7, x17, dyn, 0, 0, x14, 14*4, x22, x8, x20,LREGWU)
 
 inst_15:// rs1==x7, rd==f12,
 /* opcode: fcvt.s.wu ; op1:x7; dest:f12; op1val:0x0; valaddr_reg:x14;
 val_offset:15*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f12, x7, dyn, 0, 0, x14, 15*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f12, x7, dyn, 0, 0, x14, 15*4, x22, x8, x20,LREGWU)
 
 inst_16:// rs1==x15, rd==f3,
 /* opcode: fcvt.s.wu ; op1:x15; dest:f3; op1val:0x0; valaddr_reg:x14;
 val_offset:16*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f3, x15, dyn, 0, 0, x14, 16*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f3, x15, dyn, 0, 0, x14, 16*4, x22, x8, x20,LREGWU)
 
 inst_17:// rs1==x26, rd==f25,
 /* opcode: fcvt.s.wu ; op1:x26; dest:f25; op1val:0x0; valaddr_reg:x14;
 val_offset:17*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f25, x26, dyn, 0, 0, x14, 17*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f25, x26, dyn, 0, 0, x14, 17*4, x22, x8, x20,LREGWU)
 
 inst_18:// rs1==x31, rd==f27,
 /* opcode: fcvt.s.wu ; op1:x31; dest:f27; op1val:0x0; valaddr_reg:x14;
 val_offset:18*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f27, x31, dyn, 0, 0, x14, 18*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f27, x31, dyn, 0, 0, x14, 18*4, x22, x8, x20,LREGWU)
 
 inst_19:// rs1==x16, rd==f31,
 /* opcode: fcvt.s.wu ; op1:x16; dest:f31; op1val:0x0; valaddr_reg:x14;
 val_offset:19*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f31, x16, dyn, 0, 0, x14, 19*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f31, x16, dyn, 0, 0, x14, 19*4, x22, x8, x20,LREGWU)
 
 inst_20:// rs1==x25, rd==f20,
 /* opcode: fcvt.s.wu ; op1:x25; dest:f20; op1val:0x0; valaddr_reg:x14;
 val_offset:20*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f20, x25, dyn, 0, 0, x14, 20*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f20, x25, dyn, 0, 0, x14, 20*4, x22, x8, x20,LREGWU)
 
 inst_21:// rs1==x0, rd==f4,
 /* opcode: fcvt.s.wu ; op1:x0; dest:f4; op1val:0x0; valaddr_reg:x14;
 val_offset:21*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f4, x0, dyn, 0, 0, x14, 21*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f4, x0, dyn, 0, 0, x14, 21*4, x22, x8, x20,LREGWU)
 
 inst_22:// rs1==x10, rd==f29,
 /* opcode: fcvt.s.wu ; op1:x10; dest:f29; op1val:0x0; valaddr_reg:x14;
 val_offset:22*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f29, x10, dyn, 0, 0, x14, 22*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f29, x10, dyn, 0, 0, x14, 22*4, x22, x8, x20,LREGWU)
 
 inst_23:// rs1==x13, rd==f14,
 /* opcode: fcvt.s.wu ; op1:x13; dest:f14; op1val:0x0; valaddr_reg:x14;
 val_offset:23*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f14, x13, dyn, 0, 0, x14, 23*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f14, x13, dyn, 0, 0, x14, 23*4, x22, x8, x20,LREGWU)
 
 inst_24:// rs1==x1, rd==f6,
 /* opcode: fcvt.s.wu ; op1:x1; dest:f6; op1val:0x0; valaddr_reg:x14;
 val_offset:24*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f6, x1, dyn, 0, 0, x14, 24*4, x22, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f6, x1, dyn, 0, 0, x14, 24*4, x22, x8, x20,LREGWU)
 RVTEST_VALBASEUPD(x3,test_dataset_1)
 
 inst_25:// rs1==x27, rd==f19,
 /* opcode: fcvt.s.wu ; op1:x27; dest:f19; op1val:0x0; valaddr_reg:x3;
 val_offset:0*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f19, x27, dyn, 0, 0, x3, 0*4, x4, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f19, x27, dyn, 0, 0, x3, 0*4, x4, x8, x20,LREGWU)
 
 inst_26:// rs1==x14, rd==f15,
 /* opcode: fcvt.s.wu ; op1:x14; dest:f15; op1val:0x0; valaddr_reg:x3;
 val_offset:1*4; rmval:dyn; correctval:0; testreg:x20;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f15, x14, dyn, 0, 0, x3, 1*4, x4, x8, x20,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f15, x14, dyn, 0, 0, x3, 1*4, x4, x8, x20,LREGWU)
 
 inst_27:// rs1==x28, rd==f18,
 /* opcode: fcvt.s.wu ; op1:x28; dest:f18; op1val:0x0; valaddr_reg:x3;
 val_offset:2*4; rmval:dyn; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f18, x28, dyn, 0, 0, x3, 2*4, x4, x8, x2,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f18, x28, dyn, 0, 0, x3, 2*4, x4, x8, x2,LREGWU)
 RVTEST_SIGBASE(x1,signature_x1_0)
 
 inst_28:// rs1==x8, rd==f28,
 /* opcode: fcvt.s.wu ; op1:x8; dest:f28; op1val:0x0; valaddr_reg:x3;
 val_offset:3*4; rmval:dyn; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f28, x8, dyn, 0, 0, x3, 3*4, x4, x1, x2,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f28, x8, dyn, 0, 0, x3, 3*4, x4, x1, x2,LREGWU)
 
 inst_29:// rs1==x22, rd==f16,
 /* opcode: fcvt.s.wu ; op1:x22; dest:f16; op1val:0x0; valaddr_reg:x3;
 val_offset:4*4; rmval:dyn; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f16, x22, dyn, 0, 0, x3, 4*4, x4, x1, x2,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f16, x22, dyn, 0, 0, x3, 4*4, x4, x1, x2,LREGWU)
 
 inst_30:// rs1==x23, rd==f22,
 /* opcode: fcvt.s.wu ; op1:x23; dest:f22; op1val:0x0; valaddr_reg:x3;
 val_offset:5*4; rmval:dyn; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f22, x23, dyn, 0, 0, x3, 5*4, x4, x1, x2,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f22, x23, dyn, 0, 0, x3, 5*4, x4, x1, x2,LREGWU)
 
 inst_31:// rs1==x20, rd==f8,
 /* opcode: fcvt.s.wu ; op1:x20; dest:f8; op1val:0x0; valaddr_reg:x3;
 val_offset:6*4; rmval:dyn; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f8, x20, dyn, 0, 0, x3, 6*4, x4, x1, x2,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f8, x20, dyn, 0, 0, x3, 6*4, x4, x1, x2,LREGWU)
 
 inst_32:// 
 /* opcode: fcvt.s.wu ; op1:x31; dest:f31; op1val:0x0; valaddr_reg:x3;
 val_offset:7*4; rmval:dyn; correctval:0; testreg:x2;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f31, x31, dyn, 0, 0, x3, 7*4, x4, x1, x2,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f31, x31, dyn, 0, 0, x3, 7*4, x4, x1, x2,LREGWU)
 #endif
 
 

--- a/riscv-test-suite/rv32i_m/F/src/fcvt.s.wu_b26-01.S
+++ b/riscv-test-suite/rv32i_m/F/src/fcvt.s.wu_b26-01.S
@@ -39,201 +39,201 @@ inst_0:// rs1==x16, rd==f9,rs1_val == 0 and  fcsr == 0 and rm_val == 7
 /* opcode: fcvt.s.wu ; op1:x16; dest:f9; op1val:0x0; valaddr_reg:x3;
 val_offset:0*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f9, x16, dyn, 0, 0, x3, 0*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f9, x16, dyn, 0, 0, x3, 0*4, x10, x1, x4,LREGWU)
 
 inst_1:// rs1==x7, rd==f10,rs1_val == 1 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x7; dest:f10; op1val:0x1; valaddr_reg:x3;
 val_offset:1*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f10, x7, dyn, 0, 0, x3, 1*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f10, x7, dyn, 0, 0, x3, 1*4, x10, x1, x4,LREGWU)
 
 inst_2:// rs1==x5, rd==f21,rs1_val == 1027494066 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x5; dest:f21; op1val:0x3d3e50b2; valaddr_reg:x3;
 val_offset:2*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f21, x5, dyn, 0, 0, x3, 2*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f21, x5, dyn, 0, 0, x3, 2*4, x10, x1, x4,LREGWU)
 
 inst_3:// rs1==x18, rd==f23,rs1_val == 107790943 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x18; dest:f23; op1val:0x66cc25f; valaddr_reg:x3;
 val_offset:3*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f23, x18, dyn, 0, 0, x3, 3*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f23, x18, dyn, 0, 0, x3, 3*4, x10, x1, x4,LREGWU)
 
 inst_4:// rs1==x28, rd==f18,rs1_val == 1094 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x28; dest:f18; op1val:0x446; valaddr_reg:x3;
 val_offset:4*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f18, x28, dyn, 0, 0, x3, 4*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f18, x28, dyn, 0, 0, x3, 4*4, x10, x1, x4,LREGWU)
 
 inst_5:// rs1==x8, rd==f16,rs1_val == 123 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x8; dest:f16; op1val:0x7b; valaddr_reg:x3;
 val_offset:5*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f16, x8, dyn, 0, 0, x3, 5*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f16, x8, dyn, 0, 0, x3, 5*4, x10, x1, x4,LREGWU)
 
 inst_6:// rs1==x30, rd==f29,rs1_val == 12789625 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x30; dest:f29; op1val:0xc32779; valaddr_reg:x3;
 val_offset:6*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f29, x30, dyn, 0, 0, x3, 6*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f29, x30, dyn, 0, 0, x3, 6*4, x10, x1, x4,LREGWU)
 
 inst_7:// rs1==x27, rd==f26,rs1_val == 15 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x27; dest:f26; op1val:0xf; valaddr_reg:x3;
 val_offset:7*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f26, x27, dyn, 0, 0, x3, 7*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f26, x27, dyn, 0, 0, x3, 7*4, x10, x1, x4,LREGWU)
 
 inst_8:// rs1==x9, rd==f14,rs1_val == 1587807073 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x9; dest:f14; op1val:0x5ea40361; valaddr_reg:x3;
 val_offset:8*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f14, x9, dyn, 0, 0, x3, 8*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f14, x9, dyn, 0, 0, x3, 8*4, x10, x1, x4,LREGWU)
 
 inst_9:// rs1==x20, rd==f11,rs1_val == 16 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x20; dest:f11; op1val:0x10; valaddr_reg:x3;
 val_offset:9*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f11, x20, dyn, 0, 0, x3, 9*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f11, x20, dyn, 0, 0, x3, 9*4, x10, x1, x4,LREGWU)
 
 inst_10:// rs1==x17, rd==f6,rs1_val == 1848861 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x17; dest:f6; op1val:0x1c361d; valaddr_reg:x3;
 val_offset:10*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f6, x17, dyn, 0, 0, x3, 10*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f6, x17, dyn, 0, 0, x3, 10*4, x10, x1, x4,LREGWU)
 
 inst_11:// rs1==x29, rd==f3,rs1_val == 2 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x29; dest:f3; op1val:0x2; valaddr_reg:x3;
 val_offset:11*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f3, x29, dyn, 0, 0, x3, 11*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f3, x29, dyn, 0, 0, x3, 11*4, x10, x1, x4,LREGWU)
 
 inst_12:// rs1==x26, rd==f19,rs1_val == 231549045 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x26; dest:f19; op1val:0xdcd2875; valaddr_reg:x3;
 val_offset:12*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f19, x26, dyn, 0, 0, x3, 12*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f19, x26, dyn, 0, 0, x3, 12*4, x10, x1, x4,LREGWU)
 
 inst_13:// rs1==x6, rd==f17,rs1_val == 241276 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x6; dest:f17; op1val:0x3ae7c; valaddr_reg:x3;
 val_offset:13*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f17, x6, dyn, 0, 0, x3, 13*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f17, x6, dyn, 0, 0, x3, 13*4, x10, x1, x4,LREGWU)
 
 inst_14:// rs1==x25, rd==f24,rs1_val == 24575 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x25; dest:f24; op1val:0x5fff; valaddr_reg:x3;
 val_offset:14*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f24, x25, dyn, 0, 0, x3, 14*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f24, x25, dyn, 0, 0, x3, 14*4, x10, x1, x4,LREGWU)
 
 inst_15:// rs1==x21, rd==f4,rs1_val == 253 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x21; dest:f4; op1val:0xfd; valaddr_reg:x3;
 val_offset:15*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f4, x21, dyn, 0, 0, x3, 15*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f4, x21, dyn, 0, 0, x3, 15*4, x10, x1, x4,LREGWU)
 
 inst_16:// rs1==x24, rd==f8,rs1_val == 32105925 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x24; dest:f8; op1val:0x1e9e5c5; valaddr_reg:x3;
 val_offset:16*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f8, x24, dyn, 0, 0, x3, 16*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f8, x24, dyn, 0, 0, x3, 16*4, x10, x1, x4,LREGWU)
 
 inst_17:// rs1==x13, rd==f1,rs1_val == 334857 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x13; dest:f1; op1val:0x51c09; valaddr_reg:x3;
 val_offset:17*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f1, x13, dyn, 0, 0, x3, 17*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f1, x13, dyn, 0, 0, x3, 17*4, x10, x1, x4,LREGWU)
 
 inst_18:// rs1==x0, rd==f5,rs1_val == 339827553 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x0; dest:f5; op1val:0x0; valaddr_reg:x3;
 val_offset:18*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f5, x0, dyn, 0, 0, x3, 18*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f5, x0, dyn, 0, 0, x3, 18*4, x10, x1, x4,LREGWU)
 
 inst_19:// rs1==x12, rd==f12,rs1_val == 3864061 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x12; dest:f12; op1val:0x3af5fd; valaddr_reg:x3;
 val_offset:19*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f12, x12, dyn, 0, 0, x3, 19*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f12, x12, dyn, 0, 0, x3, 19*4, x10, x1, x4,LREGWU)
 
 inst_20:// rs1==x22, rd==f31,rs1_val == 398 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x22; dest:f31; op1val:0x18e; valaddr_reg:x3;
 val_offset:20*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f31, x22, dyn, 0, 0, x3, 20*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f31, x22, dyn, 0, 0, x3, 20*4, x10, x1, x4,LREGWU)
 
 inst_21:// rs1==x2, rd==f25,rs1_val == 4055 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x2; dest:f25; op1val:0xfd7; valaddr_reg:x3;
 val_offset:21*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f25, x2, dyn, 0, 0, x3, 21*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f25, x2, dyn, 0, 0, x3, 21*4, x10, x1, x4,LREGWU)
 
 inst_22:// rs1==x19, rd==f28,rs1_val == 45 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x19; dest:f28; op1val:0x2d; valaddr_reg:x3;
 val_offset:22*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f28, x19, dyn, 0, 0, x3, 22*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f28, x19, dyn, 0, 0, x3, 22*4, x10, x1, x4,LREGWU)
 
 inst_23:// rs1==x31, rd==f27,rs1_val == 45276376 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x31; dest:f27; op1val:0x2b2dcd8; valaddr_reg:x3;
 val_offset:23*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f27, x31, dyn, 0, 0, x3, 23*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f27, x31, dyn, 0, 0, x3, 23*4, x10, x1, x4,LREGWU)
 
 inst_24:// rs1==x14, rd==f2,rs1_val == 56436 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x14; dest:f2; op1val:0xdc74; valaddr_reg:x3;
 val_offset:24*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f2, x14, dyn, 0, 0, x3, 24*4, x10, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f2, x14, dyn, 0, 0, x3, 24*4, x10, x1, x4,LREGWU)
 RVTEST_VALBASEUPD(x5,test_dataset_1)
 
 inst_25:// rs1==x15, rd==f15,rs1_val == 6573466 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x15; dest:f15; op1val:0x644d9a; valaddr_reg:x5;
 val_offset:0*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f15, x15, dyn, 0, 0, x5, 0*4, x6, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f15, x15, dyn, 0, 0, x5, 0*4, x6, x1, x4,LREGWU)
 
 inst_26:// rs1==x3, rd==f20,rs1_val == 676 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x3; dest:f20; op1val:0x2a4; valaddr_reg:x5;
 val_offset:1*4; rmval:dyn; correctval:0; testreg:x4;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f20, x3, dyn, 0, 0, x5, 1*4, x6, x1, x4,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f20, x3, dyn, 0, 0, x5, 1*4, x6, x1, x4,LREGWU)
 
 inst_27:// rs1==x23, rd==f13,rs1_val == 6781 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x23; dest:f13; op1val:0x1a7d; valaddr_reg:x5;
 val_offset:2*4; rmval:dyn; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f13, x23, dyn, 0, 0, x5, 2*4, x6, x1, x3,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f13, x23, dyn, 0, 0, x5, 2*4, x6, x1, x3,LREGWU)
 RVTEST_SIGBASE(x2,signature_x2_0)
 
 inst_28:// rs1==x1, rd==f7,rs1_val == 7 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x1; dest:f7; op1val:0x7; valaddr_reg:x5;
 val_offset:3*4; rmval:dyn; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f7, x1, dyn, 0, 0, x5, 3*4, x6, x2, x3,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f7, x1, dyn, 0, 0, x5, 3*4, x6, x2, x3,LREGWU)
 
 inst_29:// rs1==x11, rd==f22,rs1_val == 71376 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x11; dest:f22; op1val:0x116d0; valaddr_reg:x5;
 val_offset:4*4; rmval:dyn; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f22, x11, dyn, 0, 0, x5, 4*4, x6, x2, x3,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f22, x11, dyn, 0, 0, x5, 4*4, x6, x2, x3,LREGWU)
 
 inst_30:// rs1==x4, rd==f0,rs1_val == 896618 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x4; dest:f0; op1val:0xdae6a; valaddr_reg:x5;
 val_offset:5*4; rmval:dyn; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f0, x4, dyn, 0, 0, x5, 5*4, x6, x2, x3,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f0, x4, dyn, 0, 0, x5, 5*4, x6, x2, x3,LREGWU)
 
 inst_31:// rs1==x10, rd==f30,rs1_val == 9438 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x10; dest:f30; op1val:0x24de; valaddr_reg:x5;
 val_offset:6*4; rmval:dyn; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f30, x10, dyn, 0, 0, x5, 6*4, x6, x2, x3,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f30, x10, dyn, 0, 0, x5, 6*4, x6, x2, x3,LREGWU)
 
 inst_32:// rs1_val == 339827553 and  fcsr == 0 and rm_val == 7  
 /* opcode: fcvt.s.wu ; op1:x31; dest:f31; op1val:0x14415b61; valaddr_reg:x5;
 val_offset:7*4; rmval:dyn; correctval:0; testreg:x3;
 fcsr_val: 0*/
-TEST_FPIO_OP(fcvt.s.wu, f31, x31, dyn, 0, 0, x5, 7*4, x6, x2, x3,lwu)
+TEST_FPIO_OP(fcvt.s.wu, f31, x31, dyn, 0, 0, x5, 7*4, x6, x2, x3,LREGWU)
 #endif
 
 


### PR DESCRIPTION
  - Add definition of LREGWU according to XLEN.
  - Fix corresponding fcvt.*.wu tests.