### PR TITLE
fix `arch_test.h`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [3.4.1] - 2022-09-11
+  - Fix trailing space in arch_test.h
+
 ## [3.4.0] - 2022-08-18
   - Added tests for Bitmanip and Crypto scalar extensions
   

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -915,7 +915,7 @@ RVTEST_SIGUPD(swreg,flagreg,offset+SIGALIGN)
 
 #define TEST_LOAD_F(swreg,testreg,fcsr_val,rs1,destreg,imm_val,inst,adj,flagreg)        ;\
 LA(rs1,rvtest_data+adj-imm_val)                                                         ;\
-LI(testreg, fcsr_val)                                                                   ;\ 
+LI(testreg, fcsr_val)                                                                   ;\
 csrw fcsr, testreg                                                                      ;\
 inst destreg, imm_val(rs1)                                                              ;\
 nop                                                                                     ;\


### PR DESCRIPTION
I'm getting the below error since ea3f151c0aaca474baa45537f09a02c756ab43c1
```
ERROR | In file included from /home/lee/src/zriscv/riscof/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/add-01.S:19:
/home/lee/src/zriscv/riscof/riscv-arch-test/riscv-test-suite/env/arch_test.h:918:90: warning: backslash and newline separated by space
  918 | LI(testreg, fcsr_val)                                                                   ;\
      |
```