### PR TITLE
Patch for canary definition. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [3.5.2] - 2022-11-22
+  - Fix Canary definition according to sigalign.
+
 ## [3.5.1] - 2022-10-28
   - Add test cases for P-ext
   - Correct TEST_PKRR_OP() macro in arch_test.h 

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -70,8 +70,7 @@
   #define LREGWU lwu
   #define REGWIDTH 8
   #define MASK 0xFFFFFFFFFFFFFFFF
-  #define CANARY \
-      .dword 0x6F5CA309E7D4B281
+
 
 #else 
   #if XLEN==32
@@ -80,8 +79,7 @@
     #define LREGWU lw
     #define REGWIDTH 4
   #define MASK 0xFFFFFFFF
-  #define CANARY \
-      .word 0x6F5CA309
+
 
   #endif
 #endif
@@ -102,6 +100,14 @@
         #define SIGALIGN 4
     #endif
   #endif
+#endif
+
+#if SIGALIGN==8
+  #define CANARY \
+      .dword 0x6F5CA309E7D4B281
+#else
+  #define CANARY \
+      .word 0x6F5CA309 
 #endif
 
 #define MMODE_SIG 3


### PR DESCRIPTION
Fix Canary definition according to sigalign instead of xlen. 