### PR TITLE
Fix Compilation errors for privilege and Zifenci tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [3.6.4] - 2023-05-04
+- In Zifencei test, updated the ISA string `zifencei` for `march` flag of toolchain.
+- Set the default definition of `RVMODEL_FENCEI` to `nop` in trap-handler.
+
 ## [3.6.3] - 2023-02-28
 - Split LI() macro for RV32 and RV64 to eliminate warning messages.
 - Reduce the use of LA() macro by declaring fixed size offsets in save area.

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -138,8 +138,19 @@
   #define EXCPT_CAUSE_MSK ((1<<4)-1)
 #endif
 
+//==========================================================================================
+// By default, it is defined as nop for the implementation that does not support Zifencei
+// Implementations that support Zifencei may use the fence.i instruction.
+// This only gets executed if xTVEC is not writable to point to the trap trampoline, 
+// and if it isn't writable, the model better have the zifencei extension implemented.
+//==========================================================================================
+
 #ifndef   RVMODEL_FENCEI
-  #define RVMODEL_FENCEI fence.i                                // make sure ifetches get new code
+  #ifndef ZIFENCE
+       #define RVMODEL_FENCEI nop
+  #else                            
+       #define RVMODEL_FENCEI fence.i 
+    #endif
 #endif
 
 #ifndef UNROLLSZ
@@ -900,7 +911,7 @@ init_\__MODE__\()tramp: /**** copy trampoline at mtvec tgt; t4->t2->t1  t3=end o
         bne     t3, t2, overwt_tt_\__MODE__\()loop      // haven't reached end of save area,  loop
 //----------------------------------------------------------------------
   endcopy_\__MODE__\()tramp:                    // vector table not writeable, restore
-        RVMODEL_FENCEI                          // make sure ifetches get new code
+        RVMODEL_FENCEI                          // By default it is defined as nop. See the definition
         csrr    t1, CSR_XSCRATCH                // reload trapreg_sv from scratch
         sw      t2, trampend_addr(t1)           // save copy progress
         beq     t3,t2, rvtest_\__MODE__\()prolog_done //full loop, don't exit

--- a/riscv-test-suite/rv32i_m/Zifencei/src/Fencei.S
+++ b/riscv-test-suite/rv32i_m/Zifencei/src/Fencei.S
@@ -10,7 +10,7 @@
 #include "arch_test.h"
 
 # Test Virtual Machine (TVM) used by program.
-RVTEST_ISA("RV32I")
+RVTEST_ISA("RV32I_Zifencei")
 
 # Test code region
 .section .text.init

--- a/riscv-test-suite/rv64i_m/Zifencei/src/Fencei.S
+++ b/riscv-test-suite/rv64i_m/Zifencei/src/Fencei.S
@@ -9,7 +9,7 @@
 #include "arch_test.h"
 
 # Test Virtual Machine (TVM) used by program.
-RVTEST_ISA("RV64I")
+RVTEST_ISA("RV64I_Zifencei")
 
 # Test code region
 .section .text.init


### PR DESCRIPTION
### Related Issue

This PR fixes #343.

### Description
- The default definition of `RVMODEL_FENCEI` is set to `nop` instruction. This stops the compilation when running tests (using the latest GNU toolchain) on the implementation that does not support `Zifencei`. Implementation may change the definition of `RVMODEL_FENCEI` in the `model_test.h`. 
- The ISA string is updated for `Zifencei` tests (RV32 and RV64) which is required by `march` of the latest toolchain.