### PR TITLE
Fix `c.ebreak` test condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [3.6.5] - 2023-05-06
+- Fix test condition in RVTEST_CASE for `c.ebreak` (RV32 and RV64) test. 
+
 ## [3.6.4] - 2023-05-04
 - In Zifencei test, updated the ISA string `zifencei` for `march` flag of toolchain.
 - Set the default definition of `RVMODEL_FENCEI` to `nop` in trap-handler.

--- a/riscv-test-suite/rv32i_m/C/src/cebreak-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/cebreak-01.S
@@ -19,7 +19,7 @@ RVMODEL_BOOT
 RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
-    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*.C*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",cebreak)
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*C.*Zicsr); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",cebreak)
 
     # ---------------------------------------------------------------------------------------------
 

--- a/riscv-test-suite/rv64i_m/C/src/cebreak-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/cebreak-01.S
@@ -20,7 +20,7 @@ RVMODEL_BOOT
 RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
-    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*.C*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",cebreak)
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*C.*Zicsr); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",cebreak)
 
     # ---------------------------------------------------------------------------------------------
     LA(     x1,test_A_res)


### PR DESCRIPTION
### Related Issue

This PR resolves #344.

### Description
- Test condition in the `RVTEST_CASE` function is updated. Now, RISCOF picks the `c.ebreak` test only when the `C` (along with `I` and `Zicsr`) extension is enabled.