### PR TITLE
Trap Handler Updates (Issue#403 & Goto_Lower_Mode macro updates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## [3.8.1] - 2023-11-01
+- Updated trap handler to avoid using mstatush when used for Priv Arch 1.11
+- Updated GOTO_Lower_Mode macro to adjust the save area when switching to Umode.
+
 ## [3.8.0] - 2023-10-26
 - Updated trap handler to handle delegated exceptions in S-mode for both bare and virtual modes.
 - Added Hypervisor mode support in Trap handler

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -849,7 +849,7 @@ RVMODEL_DATA_END        /* model specific stuff */
         /**** set MEPC to mret+4; requires relocating the pc   ****/
 .if     (\LMODE\() == Vmode)     // get trapsig_ptr & init val up 2 save areas (M<-S<-V)
         LREG    T1, code_bgn_off + 2*sv_area_sz(sp)
-.elseif (\LMODE\() == Smode)     // get trapsig_ptr & init val up 1 save areas (M<-S)
+.elseif (\LMODE\() == Smode || \LMODE\() == Umode)     // get trapsig_ptr & init val up 1 save areas (M<-S)
         LREG    T1, code_bgn_off + 1*sv_area_sz(sp)
 .else                            // get trapsig ptr & init val for this Mmode, (M)
         LREG    T1, code_bgn_off + 0*sv_area_sz(sp)
@@ -1305,9 +1305,9 @@ common_\__MODE__\()excpt_handler:
         srli    T3, T3, GVA_LSB-1       /* reposition RV32 mstatush into bit1   */
       #else
         srli    T3, T6, GVA_LSB-1+32    /* reposition RV32 mstatus  into bit1   */
+      #endif
         andi    T3, T3, 1<<1
         or      T4, T4, T3              /* extract GVA in bit1, insert into msk */
-    #endif
 // put H-extension implemented into bit 0       
         ori     T4, T4, 1               /* set LSB if H-ext present             */
         //****FIXME: this doesn't work if misa.H is RW but set to zero ****/

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -188,7 +188,7 @@
 #ifndef SET_ABS_TVAL_MSK
 #define SET_ABS_TVAL_MSK ((1<<CAUSE_ILLEGAL_INSTRUCTION) & 0xFFFFFFFF)
 #endif
-	
+
 #ifndef GOTO_M_OP
     #define GOTO_M_OP   ecall
 #endif
@@ -849,7 +849,7 @@ RVMODEL_DATA_END        /* model specific stuff */
         /**** set MEPC to mret+4; requires relocating the pc   ****/
 .if     (\LMODE\() == Vmode)     // get trapsig_ptr & init val up 2 save areas (M<-S<-V)
         LREG    T1, code_bgn_off + 2*sv_area_sz(sp)
-.elseif (\LMODE\() == Smode || \LMODE\() == Umode)     // get trapsig_ptr & init val up 1 save areas (M<-S)
+.elseif (\LMODE\() == Smode)     // get trapsig_ptr & init val up 1 save areas (M<-S)
         LREG    T1, code_bgn_off + 1*sv_area_sz(sp)
 .else                            // get trapsig ptr & init val for this Mmode, (M)
         LREG    T1, code_bgn_off + 0*sv_area_sz(sp)
@@ -1299,19 +1299,19 @@ common_\__MODE__\()excpt_handler:
         addi    T4, T4, 1
         andi    T4, T4, 4               
 // extract GVA into bit 1
-      #if (XLEN==32 && rvtest_vtrap_routine)
+    #if (rvtest_vtrap_routine)
+      #if (XLEN==32)
         csrr    T3, CSR_MSTATUSH        /* get CSR with GVA bit, but only H-ext */
         srli    T3, T3, GVA_LSB-1       /* reposition RV32 mstatush into bit1   */
-      #elseif(XLEN==64)
+      #else
         srli    T3, T6, GVA_LSB-1+32    /* reposition RV32 mstatus  into bit1   */
-      #endif
         andi    T3, T3, 1<<1
         or      T4, T4, T3              /* extract GVA in bit1, insert into msk */
+    #endif
 // put H-extension implemented into bit 0       
-      #if rvtest_vtrap_routine
         ori     T4, T4, 1               /* set LSB if H-ext present             */
         //****FIXME: this doesn't work if misa.H is RW but set to zero ****/
-      #endif
+    #endif
 // chk for illegal combination
         LI(     T6, 0x3B)                /*lgl msk(vMPP,GVA,H)= 011,00x,10x=0x3B */
         srl     T6, T6, T4
@@ -1659,12 +1659,14 @@ excpt_\__MODE__\()hndlr_tbl:            // handler code should only touch T2..T6
 rtn2mmode:
         addi    T4,T5, -CAUSE_MACHINE_ECALL
         beqz    T4, rtn_fm_mmode        /* shortcut if called from Mmode        */
-#if (XLEN==32 && rvtest_vtrap_routine)
+#if (rvtest_vtrap_routine)
+  #if (XLEN==32)
         csrr    T2, CSR_MSTATUSH        /* find out originating mode if  RV32   */
-#else
+  #else
         csrr    T2, CSR_MSTATUS         /* find out originating mode if RV64/128*/
-#endif
+  #endif
         slli    T2, T2, WDSZ-MPV_LSB-1  /* but V into MSB  ****FIXME if RV128   */ 
+#endif
         LREG    T6, code_bgn_off+1*sv_area_sz(sp)    /* get U/S mode code begin */
         bgez    T2, from_u_s            /* V==0, not virtualized, *1 offset     */
 from_v:

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -51,10 +51,7 @@
     .endif                                                        ;\
 	LREG t1, TYPE+0*sv_area_sz(sp)                            ;\
 	add t2, t1, t0                                            ;\
-	SREG t2, TYPE+1*sv_area_sz(sp)                            ;\
-	.if NARG(__VA_ARGS__) == 1                                ;\
-        SREG t2, TYPE+2*sv_area_sz(sp)                            ;\
-    .endif                                                        ;
+	SREG t2, TYPE+1*sv_area_sz(sp)                            ;
 
 //****NOTE: label `rvtest_Sroot_pg_tbl` must be declared after RVTEST_DATA_END
 //          in the test aligned at 4kiB (use .align 12)


### PR DESCRIPTION
## Description

Updated trap handler fixes two issues, one is to avoid using mstatush when using with Priv Arch 1.11 (as mstatush) is not defined in Priv 1.11. There are 2 places that reference mstatush, added the condition rvtest_vtrap_routine, which means H extension is present, and that isn't possible for priv 1.11. So, only 2 lines of code are changed. Second, there was a bug identified while looking at GOTO_Lower_mode macro, the save area was not being used properly when going from Mmode to Umode.

### Related Issues

Issue #403 , PR #405 