### PR TITLE
ACTs for VM SV39 with Coverpoints 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## [3.8.1] - 2023-11-01
+- Added the comprehensive set of self-checking assembly tests for the architectural verification of SV39
+- Added the `vm_sv39.cfg` for coverpoint definations for SV39.
+
 ## [3.8.0] - 2023-10-26
 - Updated trap handler to handle delegated exceptions in S-mode for both bare and virtual modes.
 - Added Hypervisor mode support in Trap handler

--- a/coverage/vm_sv39.cgf
+++ b/coverage/vm_sv39.cgf
@@ -1,0 +1,3100 @@
+# For Licence details look at https://github.com/riscv-software-src/riscv-ctg/-/blob/master/LICENSE.incore
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C6)) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D6)) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE07:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C6)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE08:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                        # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C6)): 0                  # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE09: 
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                        # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C6)) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE10:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D6)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE11:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                        # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D6)): 0                  # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+invalid_PTE12: 
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                        # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D6)) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x087)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x087)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x087)) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x097)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x097)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x097)) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit07:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x089)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit08:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x089)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit09:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x089)) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit10:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x099)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit11:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x099)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+access_bit12:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x099)) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x047)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x047)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x047)) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x057)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x057)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+dirty_bit06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x057)) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0x0FF) == 0x0C7) and (((rs2_val &  0x7FC00) != 0x0))): 0 
+                                                                                                # checks the PTE permission,level1 and that ppn0!=0 (misaligned) at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x4C7) and (((rs2_val &  0xFFFFC00) != 0x0))) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0x0FF) == 0x0D7) and (((rs2_val &  0x7FC00) != 0x0))): 0 
+                                                                                                # checks the PTE permission,level1 and that ppn0!=0 (misaligned) at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x4D7) and (((rs2_val &  0xFFFFC00) != 0x0))) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0x0FF) == 0x0C9) and (((rs2_val &  0x7FC00) != 0x0))): 0 
+                                                                                                # checks the PTE permission,level1 and that ppn0!=0 (misaligned) at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x4C9) and (((rs2_val &  0xFFFFC00) != 0x0))) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission,level1 and that either ppn0!=0 or ppn1!=0 (misaligned) at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage07:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0x0FF) == 0x0D9) and (((rs2_val &  0x7FC00) != 0x0))): 0 
+                                                                                                # checks the PTE permission,level1 and that ppn0!=0 (misaligned) at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+misaligned_superpage08:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000007) and ((rs2_val & 0xFFF) == 0x4D9) and (((rs2_val &  0xFFFFC00) != 0x0))) if rs2_val is not None else None: 0               
+                                                                                                # checks the PTE permission,level1 and that either ppn0!=0 or ppn1!=0 (misaligned) at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1  
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 does not match the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 does not match the "load page fault
+    (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not match the " Instruction page fault" 
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1  
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 does not match the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 does not match the "load page fault
+    (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not match the " Instruction page fault" 
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1  
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 does not match the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 does not match the "load page fault
+    (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not match the " Instruction page fault"    
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C9)) if rs2_val is not None else None: 0 
+                                                                                                # checks the PTE permission and level2 at which PTE is stored               
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1  
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 does not match the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 does not match the "load page fault
+    (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not match the " Instruction page fault" 
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1  
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 does not match the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 does not match the "load page fault
+    (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not match the " Instruction page fault" 
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_set06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    (mstatus & 0x80000) == 0x80000: 0                                                           # checks the mstatus.MXR == 1  
+  
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 does not match the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 does not match the "load page fault
+    (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not match the " Instruction page fault"    
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D9)) if rs2_val is not None else None: 0 
+                                                                                                # checks the PTE permission and level2 at which PTE is stored               
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x80000) == 0x0    : 0                                                           # checks the mstatus.MXR == 0  
+
+  val_comb:
+
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.   
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x80000) == 0x0    : 0                                                           # checks the mstatus.MXR == 0  
+
+  val_comb:
+
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x80000) == 0x0    : 0                                                           # checks the mstatus.MXR == 0  
+  
+  val_comb:
+
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C9)) if rs2_val is not None else None: 0 
+                                                                                                # checks the PTE permission and level2 at which PTE is stored               
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    (mstatus & 0x80000) == 0x0    : 0                                                           # checks the mstatus.MXR == 0  
+
+  val_comb:
+
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.   
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    (mstatus & 0x80000) == 0x0    : 0                                                           # checks the mstatus.MXR == 0  
+
+  val_comb:
+
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D9)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+mxr_unset06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+    (mstatus & 0x80000) == 0x0    : 0                                                           # checks the mstatus.MXR == 0  
+  
+  val_comb:
+
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D9)) if rs2_val is not None else None: 0 
+                                                                                                # checks the PTE permission and level2 at which PTE is stored               
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_set01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x40000: 0                                                           # Checks that mstatus.SUM == 1
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 does not match the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 does not match the "load page fault
+    (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not match the " Instruction page fault"     (rs2_val != 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_set02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x40000: 0                                                           # Checks that mstatus.SUM == 1
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 does not match the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 does not match the "load page fault
+    (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not match the " Instruction page fault"     (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_set03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x40000: 0                                                           # Checks that mstatus.SUM == 1
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 does not match the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 does not match the "load page fault
+    (rs2_val != 0xC): 0                                                                         # checks if the rs2 does not match the " Instruction page fault" 
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_set04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x40000: 0                                                           # Checks that mstatus.SUM == 1
+    
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"                                                                        # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_set05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x40000: 0                                                           # Checks that mstatus.SUM == 1
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault" 
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_set06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x40000: 0                                                           # Checks that mstatus.SUM == 1
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault" 
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_unset01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x0    : 0                                                           # Checks that mstatus.SUM == 0
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_unset02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x0    : 0                                                           # Checks that mstatus.SUM == 0
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_unset03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x0    : 0                                                           # Checks that mstatus.SUM == 0
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_unset04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x0    : 0                                                           # Checks that mstatus.SUM == 0
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault" 
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_unset05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x0    : 0                                                           # Checks that mstatus.SUM == 0
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault" 
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+sum_unset06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+    (mstatus & 0x40000) == 0x0    : 0                                                           # Checks that mstatus.SUM == 0
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault" 
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_set01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_set02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 does not match the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 does not match the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_set03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_set04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_set05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D1)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_set06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_unset01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_unset02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_unset03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_unset04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_unset05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+ubit_unset06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+Smode_page_in_Smode01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+Smode_page_in_Smode02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+Smode_page_in_Smode03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val != 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val != 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+Smode_page_in_Smode04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+Smode_page_in_Smode05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+Smode_page_in_Smode06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C1)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+Smode_page_in_Smode07:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+Smode_page_in_Smode08:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+Smode_page_in_Smode09:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+reserved_rwx01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C5)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+reserved_rwx02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C5)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+reserved_rwx03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C5)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+reserved_rwx04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+  
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D5)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+reserved_rwx05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D5)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+reserved_rwx06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D5)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+reserved_rwx07:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+  
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D5)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+reserved_rwx08:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D5)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+reserved_rwx09:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D5)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+nonleaf_pte01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C1)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+nonleaf_pte02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xF): 0                                                                         # check if the rs2 matches the "store/AMO page fault
+    (rs2_val == 0xD): 0                                                                         # check if the rs2 matches the "load page fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+nonleaf_pte03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0xC): 0                                                                         # checks if the rs2 matches the " Instruction page fault"
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D1)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+    (rs1_val >= (pmpaddr3 << 2)) and (rs1_val <= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+    (rs1_val >= (pmpaddr2 << 2)) and (rs1_val <= (pmpaddr2 << 2)) and ((pmpcfg0 & 0xFF0000) >> 16 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)    
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+    (rs1_val >= (pmpaddr4 << 2)) and (rs1_val <= (pmpaddr4 << 2)) and ((pmpcfg0 & 0xFF00000000) >> 32 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)    
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+    (rs1_val >= (pmpaddr3 << 2)) and (rs1_val <= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+    (rs1_val >= (pmpaddr2 << 2)) and (rs1_val <= (pmpaddr2 << 2)) and ((pmpcfg0 & 0xFF0000) >> 16 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)    
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+    (rs1_val >= (pmpaddr4 << 2)) and (rs1_val <= (pmpaddr4 << 2)) and ((pmpcfg0 & 0xFF00000000) >> 32 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)    
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte07:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+    (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte08:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+    (rs1_val >= (pmpaddr2 << 2)) and ((pmpcfg0 & 0xFF0000) >> 16 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)    
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte09:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+    (rs1_val >= (pmpaddr4 << 2)) and ((pmpcfg0 & 0xFF00000000) >> 32 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)    
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte10:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+    (rs1_val >= (pmpaddr3 << 2)) and ((pmpcfg0 & 0xFF000000) >> 24 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr3, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte11:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+    (rs1_val >= (pmpaddr2 << 2)) and ((pmpcfg0 & 0xFF0000) >> 16 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)    
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pte12:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+    (rs1_val >= (pmpaddr4 << 2)) and ((pmpcfg0 & 0xFF00000000) >> 32 == 0x18): 0
+                                                                                                # Check if rs1_val falls within the range specified by pmpaddr2, and if the
+                                                                                                # corresponding 8 bits of pmpcfg0 are equal to 0x18( No Read and write permissions)    
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa01:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    ld          : 0 
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+   
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+    (rs1_val == 0x0900001688 ) and ((pmpcfg0 & 0xFF00) >> 8 == 0x08): 0                        
+    # checks that the value in rs1 equals to 0x0900001688 (va_data) which is a virtual address for the rvtest_data where there is no read and write 
+    # PTE permissions, which is confirmed by checking the bits fo pmpcfg0, this cover point should hit two times one for the LREG and one for SREG
+    # instr in the "vm_en" label during virtualization 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa02:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.    
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    ld          : 0 
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+   
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0C7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+    (rs1_val == 0x0901000688 ) and ((pmpcfg0 & 0xFF00) >> 8 == 0x08): 0                        
+    # checks that the value in rs1 equals to 0x0901000688 (va_data) which is a virtual address for the rvtest_data where there is no read and write 
+    # PTE permissions, which is confirmed by checking the bits fo pmpcfg0, this cover point should hit two times one for the LREG and one for SREG
+    # instr in the "vm_en" label during virtualization 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa03:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    ld          : 0 
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0800 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "S" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+   
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0C7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+    (rs1_val == 0x0980000688 ) and ((pmpcfg0 & 0xFF00) >> 8 == 0x08): 0                        
+    # checks that the value in rs1 equals to 0x0980000688 (va_data) which is a virtual address for the rvtest_data where there is no read and write 
+    # PTE permissions, which is confirmed by checking the bits fo pmpcfg0, this cover point should hit two times one for the LREG and one for SREG
+    # instr in the "vm_en" label during virtualization 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa04:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    ld          : 0 
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+   
+    (((rs1_val >> 12 ) == 0x80000000005) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level0 at which PTE is stored 
+    (rs1_val == 0x0900001688 ) and ((pmpcfg0 & 0xFF00) >> 8 == 0x08): 0                        
+    # checks that the value in rs1 equals to 0x0900001688 (va_data) which is a virtual address for the rvtest_data where there is no read and write 
+    # PTE permissions, which is confirmed by checking the bits fo pmpcfg0, this cover point should hit two times one for the LREG and one for SREG
+    # instr in the "vm_en" label during virtualization 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa05:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    ld          : 0 
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+   
+    (((rs1_val >> 12 ) == 0x80000000004) and ((rs2_val & 0xFFF) == 0x0D7)): 0                   # checks the PTE permission and level1 at which PTE is stored 
+
+    (rs1_val == 0x0901000688 ) and ((pmpcfg0 & 0xFF00) >> 8 == 0x08): 0                        
+    # checks that the value in rs1 equals to 0x0901000688 (va_data) which is a virtual address for the rvtest_data where there is no read and write 
+    # PTE permissions, which is confirmed by checking the bits fo pmpcfg0, this cover point should hit two times one for the LREG and one for SREG
+    # instr in the "vm_en" label during virtualization 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+pmp_pa06:
+
+  config:
+
+  - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+
+  mnemonics:
+
+    csrrw       : 0                                                                             # Sets the expected encoding value for the "csrrw" mnemonic.
+    csrrs       : 0                                                                             # Sets the expected encoding value for the "csrrs" mnemonic.
+    csrrc       : 0                                                                             # Sets the expected encoding value for the "csrrc" mnemonic.  
+    sd          : 0                                                                             # Sets the expected encoding value for the "sd" mnemonic.
+    ld          : 0 
+
+  csr_comb:
+
+    (satp >> 60 == 0x8) and (rs1 == 'x31') and (rd == 'x0'): 0                                  # Check if the top 4 bits of the "satp" register indicate sv39 mode.
+    (mstatus & 0x1800)  == 0x0000 and ( rs1 == 'x9' ) and (rd == 'x0') : 0                      # Ensure the "MPP" bits in "mstatus" are set to "U" mode.
+
+  val_comb:
+
+    (rs2_val == 0x7): 0                                                                         # check if the rs2 matches the "store/AMO access fault
+    (rs2_val == 0x5): 0                                                                         # check if the rs2 matches the "load access fault
+    (rs2_val == 0x1): 0                                                                         # check if the rs2 matches the instruction access fault
+   
+    (((rs1_val >> 12 ) == 0x80000000006) and ((rs2_val & 0xFFF) == 0x0D7)) if rs2_val is not None else None: 0 
+                                                                                                 # checks the PTE permission and level2 at which PTE is stored 
+    (rs1_val == 0x0980000688 ) and ((pmpcfg0 & 0xFF00) >> 8 == 0x08): 0                        
+    # checks that the value in rs1 equals to 0x0980000688 (va_data) which is a virtual address for the rvtest_data where there is no read and write 
+    # PTE permissions, which is confirmed by checking the bits fo pmpcfg0, this cover point should hit two times one for the LREG and one for SREG
+    # instr in the "vm_en" label during virtualization 
+
+# *----------------------------------------------------------------------------------------------------------------------
+# *----------------------------------------------------------------------------------------------------------------------
+
+

--- a/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode01.S
@@ -1,0 +1,166 @@
+# ############################################################################################ #
+# Verification Goal: Test the the RWX Access in Supervisor mode for PTE setuped for LEVEL 0    #
+#		     RWX should be successful (PTE.r = 1 & PTE.w = 1).                         #
+#                                                                                              #
+# Discription: 	     If PTE belongs to supervisor mode i.e. its U permission bit is clear      #
+#                    (pte.u = 0),then accessing that PTE in supervisor mode should be          #
+#                    successful if the corresponding (r,w,x) permission of PTE is granted.     #
+#                    Otherwise raise a page fault exception of the corresponding access type   #
+# ############################################################################################ #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",Smode_page_in_Smode01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits (PTE_U == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should be successful)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should be successful)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode02.S
@@ -1,0 +1,164 @@
+# ############################################################################################ #
+# Verification Goal: Test the the RWX Access in Supervisor mode for PTE setuped for LEVEL 1    #
+#		     RWX should be successful (PTE.r = 1 & PTE.w = 1).                         #
+#                                                                                              #
+# Discription: 	     If PTE belongs to supervisor mode i.e. its U permission bit is clear      #
+#                    (pte.u = 0),then accessing that PTE in supervisor mode should be          #
+#                    successful if the corresponding (r,w,x) permission of PTE is granted.     #
+#                    Otherwise raise a page fault exception of the corresponding access type   #
+# ############################################################################################ #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",Smode_page_in_Smode02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0901000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits (PTE_U == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should be successful)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should be successful)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode03.S
@@ -1,0 +1,166 @@
+# ############################################################################################ #
+# Verification Goal: Test the the RWX Access in Supervisor mode for PTE setuped for LEVEL 2    #
+#		     RWX should be successful (PTE.r = 1 & PTE.w = 1).                         #
+#                                                                                              #
+# Discription: 	     If PTE belongs to supervisor mode i.e. its U permission bit is clear      #
+#                    (pte.u = 0),then accessing that PTE in supervisor mode should be          #
+#                    successful if the corresponding (r,w,x) permission of PTE is granted.     #
+#                    Otherwise raise a page fault exception of the corresponding access type   #
+# ############################################################################################ #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",Smode_page_in_Smode03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits (PTE_U == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should be successful)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should be successful)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode04.S
@@ -1,0 +1,168 @@
+# ############################################################################################ #
+# Verification Goal: Test the the RW  Access in Supervisor mode for PTE setuped for LEVEL 0    #
+#		     RWX should raise a page fault exception of the corresponding access type  #
+# 		     (PTE.r = 0 & PTE.w = 0).			                               #
+#                                                                                              #
+# Discription: 	     If PTE belongs to supervisor mode i.e. its U permission bit is clear      #
+#                    (pte.u = 0),then accessing that PTE in supervisor mode should be          #
+#                    successful if the corresponding (r,w,x) permission of PTE is granted.     #
+#                    Otherwise raise a page fault exception of the corresponding access type   #
+# ############################################################################################ #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",Smode_page_in_Smode04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_V ) 					// sets the permission bits (PTE_U & PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode05.S
@@ -1,0 +1,166 @@
+# ############################################################################################ #
+# Verification Goal: Test the the RW  Access in Supervisor mode for PTE setuped for LEVEL 1    #
+#		     RWX should raise a page fault exception of the corresponding access type  #
+# 		     (PTE.r = 0 & PTE.w = 0).			                               #
+#                                                                                              #
+# Discription: 	     If PTE belongs to supervisor mode i.e. its U permission bit is clear      #
+#                    (pte.u = 0),then accessing that PTE in supervisor mode should be          #
+#                    successful if the corresponding (r,w,x) permission of PTE is granted.     #
+#                    Otherwise raise a page fault exception of the corresponding access type   #
+# ############################################################################################ #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",Smode_page_in_Smode05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0901000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_V ) 					// sets the permission bits (PTE_U & PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode06.S
@@ -1,0 +1,168 @@
+# ############################################################################################ #
+# Verification Goal: Test the the RW  Access in Supervisor mode for PTE setuped for LEVEL 2    #
+#		     RWX should raise a page fault exception of the corresponding access type  #
+# 		     (PTE.r = 0 & PTE.w = 0).			                               #
+#                                                                                              #
+# Discription: 	     If PTE belongs to supervisor mode i.e. its U permission bit is clear      #
+#                    (pte.u = 0),then accessing that PTE in supervisor mode should be          #
+#                    successful if the corresponding (r,w,x) permission of PTE is granted.     #
+#                    Otherwise raise a page fault exception of the corresponding access type   #
+# ############################################################################################ #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",Smode_page_in_Smode06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_V ) 					// sets the permission bits (PTE_U & PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode07.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode07.S
@@ -1,0 +1,166 @@
+# ##############################################################################################
+# Verification Goal: Test the the Execut Access in Supervisor mode for PTE setuped for LEVEL 0 #
+#		     Execute access should raise an exception (PTE.X = 0). 	               #
+#                                                                                              #
+# Discription: 	     If PTE belongs to supervisor mode i.e. its U permission bit is clear      #
+#                    (pte.u = 0),then accessing that PTE in supervisor mode should be          #
+#                    successful if the corresponding (r,w,x) permission of PTE is granted.     #
+#                    Otherwise raise a page fault exception of the corresponding access type   #
+# ############################################################################################ #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",Smode_page_in_Smode07)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_V )	               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits (PTE_U == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode08.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode08.S
@@ -1,0 +1,165 @@
+# ##############################################################################################
+# Verification Goal: Test the the Execut Access in Supervisor mode for PTE setuped for LEVEL 1 #
+#		     Execute access should raise an exception (PTE.X = 0). 	               #
+#                                                                                              #
+# Discription: 	     If PTE belongs to supervisor mode i.e. its U permission bit is clear      #
+#                    (pte.u = 0),then accessing that PTE in supervisor mode should be          #
+#                    successful if the corresponding (r,w,x) permission of PTE is granted.     #
+#                    Otherwise raise a page fault exception of the corresponding access type   #
+# ############################################################################################ #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",Smode_page_in_Smode08)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0901000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_X | PTE_V ) 		               		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits (PTE_U == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode09.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/Smode_pages_in_Smode/Smode_pages_in_Smode09.S
@@ -1,0 +1,166 @@
+# ##############################################################################################
+# Verification Goal: Test the the Execut Access in Supervisor mode for PTE setuped for LEVEL 2 #
+#		     Execute access should raise an exception (PTE.X = 0). 	               #
+#                                                                                              #
+# Discription: 	     If PTE belongs to supervisor mode i.e. its U permission bit is clear      #
+#                    (pte.u = 0),then accessing that PTE in supervisor mode should be          #
+#                    successful if the corresponding (r,w,x) permission of PTE is granted.     #
+#                    Otherwise raise a page fault exception of the corresponding access type   #
+# ############################################################################################ #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",Smode_page_in_Smode09)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_X | PTE_V )	               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits (PTE_U == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit01.S
@@ -1,0 +1,165 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Read Acces and Write Access in Supervisor mode for    #
+#                     Level 0 Should raise a load page fault for read access and Store AMO fault       #
+#                     for write access                                                                 #
+#                                                                                                      #
+# Description:       If PTE does not have Access (pte.A=0) permission, then accessing it would	       #
+#                    raise page fault exception of the corresponding access type.           	       #
+# #################################################################################################### #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_W | PTE_R | PTE_V ) 		        	// sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit02.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Read Acces and Write Access in Supervisor mode for    #
+#                     Level 1 Should raise a load page fault for read access and Store AMO fault       #
+#                     for write access                                                                 #
+#                                                                                                      #
+# Description:       If PTE does not have Access (pte.A=0) permission, then accessing it would	       #
+#                    raise page fault exception of the corresponding access type.           	       #
+# #################################################################################################### #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0901000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_W | PTE_R | PTE_V) 			        // sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit03.S
@@ -1,0 +1,165 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Read Acces and Write Access in Supervisor mode for    #
+#                     Level 2 Should raise a load page fault for read access and Store AMO fault       #
+#                     for write access                                                                 #
+#                                                                                                      #
+# Description:       If PTE does not have Access (pte.A=0) permission, then accessing it would	       #
+#                    raise page fault exception of the corresponding access type.           	       #
+# #################################################################################################### #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_W | PTE_R | PTE_V) 				// sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit04.S
@@ -1,0 +1,165 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Read and write Access in User mode for Level0         # 
+# 		      should raise a load page fault for read access and store amo fault for store     #	
+# 		      access. 									       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )    			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_U | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit05.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Read and write Access in user mode for Level1         # 
+# 		      should raise a load page fault for read access and store amo fault for store     #	
+# 		      access. 									       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )  		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_U | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit06.S
@@ -1,0 +1,165 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Read and write Access in user mode for Level2         # 
+# 		      should raise a load page fault for read access and store amo fault for store     #	
+# 		      access. 									       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_U | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+	
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit07.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit07.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Execute Access in Supervisor mode for Level0          # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.A=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit07)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_X | PTE_V ) 		                        // sets the permission bits(PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit08.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit08.S
@@ -1,0 +1,162 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Execute Access in Supervisor mode for Level1          # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.A=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit08)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_X | PTE_V )		                        // sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit09.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit09.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Execute Access in Supervisor mode for Level2          # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.A=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit09)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_X | PTE_V)		                        	// sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit10.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit10.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Execute Access in User mode for Level0                # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.A=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit10)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_U | PTE_X | PTE_V ) 		                // sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+	
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit11.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit11.S
@@ -1,0 +1,162 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.A = 0 and test the Execute Access in User mode for Level1                # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.A=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit11)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_U | PTE_X | PTE_V )		                // sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit12.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/access_bit/access_bit12.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Execute Access in User mode for Level2                # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",access_bit12)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_U | PTE_X | PTE_V ) 		                // sets the permission bits (PTE_A == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit01.S
@@ -1,0 +1,162 @@
+#################################################################################################           
+# Verification Goal:    Set PTE.D = 0 and test the Write access at Supervisor mode for          #
+#                       PTE at Level 0                                                          #
+# Description: 		If implementation does not sets the pte.D when PTE is written,          #
+#                       and PTE has pte.D=0, then attempting to store on that PTE would         #
+#                       raise Store/AMO page fault exception.                                   #                                                                                             
+################################################################################################# 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",dirty_bit01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900001688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                                // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_A | PTE_W | PTE_R | PTE_V ) 	  	                // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V ) 	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+
+	LI (t0, va_data)                                                        
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit02.S
@@ -1,0 +1,162 @@
+#################################################################################################           
+# Verification Goal:    Set PTE.D = 0 and test the Write access at Supervisor mode for          #
+#                       PTE at Level 1                                                          #
+# Description: 		If implementation does not sets the pte.D when PTE is written,          #
+#                       and PTE has pte.D=0, then attempting to store on that PTE would         #
+#                       raise Store/AMO page fault exception.                                   #                                                                                             
+################################################################################################# 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",dirty_bit02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+        
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                                // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_A | PTE_W | PTE_R | PTE_V ) 		                // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	
+        LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+
+	LI (t0, va_data)                                                        
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit03.S
@@ -1,0 +1,162 @@
+#################################################################################################           
+# Verification Goal:    Set PTE.D = 0 and test the Write access at Supervisor mode for          #
+#                       PTE at Level 2                                                          #
+# Description: 		If implementation does not sets the pte.D when PTE is written,          #
+#                       and PTE has pte.D=0, then attempting to store on that PTE would         #
+#                       raise Store/AMO page fault exception.                                   #                                                                                             
+################################################################################################# 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",dirty_bit03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_A | PTE_W | PTE_R | PTE_V ) 				// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V ) 	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+
+	LI (t0, va_data)                                                        
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit04.S
@@ -1,0 +1,162 @@
+#################################################################################################           
+# Verification Goal:    Set PTE.D = 0 and test the Write access at User mode for                #
+#                       PTE at Level 0                                                          #
+# Description: 		If implementation does not sets the pte.D when PTE is written,          #
+#                       and PTE has pte.D=0, then attempting to store on that PTE would         #
+#                       raise Store/AMO page fault exception.                                   #                                                                                             
+################################################################################################# 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",dirty_bit04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900001688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 	        	// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V ) 	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+
+	LI (t0, va_data)                                                        
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit05.S
@@ -1,0 +1,162 @@
+#################################################################################################           
+# Verification Goal:    Set PTE.D = 0 and test the Write access at User mode for                #
+#                       PTE at Level 1                                                          #
+# Description: 		If implementation does not sets the pte.D when PTE is written,          #
+#                       and PTE has pte.D=0, then attempting to store on that PTE would         #
+#                       raise Store/AMO page fault exception.                                   #                                                                                             
+################################################################################################# 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",dirty_bit05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+        
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 	        	// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	
+        LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V ) 	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+
+	LI (t0, va_data)                                                        
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/dirty_bit/dirty_bit06.S
@@ -1,0 +1,162 @@
+#################################################################################################           
+# Verification Goal:    Set PTE.D = 0 and test the Write access at Supervisor mode for          #
+#                       PTE at Level 2                                                          #
+# Description: 		If implementation does not sets the pte.D when PTE is written,          #
+#                       and PTE has pte.D=0, then attempting to store on that PTE would         #
+#                       raise Store/AMO page fault exception.                                   #                                                                                             
+################################################################################################# 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",dirty_bit06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )               		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )   		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+
+	LI (t0, va_data)                                                        
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte01.S
@@ -1,0 +1,165 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Read and write Access in Supervisor mode for Level0   # 
+# 		      should raise a load page fault for read access and store amo fault for store     #	
+# 		      access. 									       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R ) 				// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte02.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Read and write Access in Supervisor mode for Level1   # 
+# 		      should raise a load page fault for read access and store amo fault for store     #	
+# 		      access. 									       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0901000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R ) 				// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte03.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Read and write Acces in Supervisor mode for Level2    # 
+# 		      should raise a load page fault for read access and store amo fault for store     #	
+# 		      access. 									       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE03)
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R) 				// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte04.S
@@ -1,0 +1,165 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Read and write Access in User mode for Level0         # 
+# 		      should raise a load page fault for read access and store amo fault for store     #	
+# 		      access. 									       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )    			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R ) 			// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte05.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Read and write Access in user mode for Level1         # 
+# 		      should raise a load page fault for read access and store amo fault for store     #	
+# 		      access. 									       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )  		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R ) 			// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte06.S
@@ -1,0 +1,165 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Read and write Access in user mode for Level2         # 
+# 		      should raise a load page fault for read access and store amo fault for store     #	
+# 		      access. 									       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )       		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R ) 			// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte07.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte07.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Execute Access in Supervisor mode for Level0          # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE07)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X ) 		                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R ) 				// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte08.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte08.S
@@ -1,0 +1,162 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Execute Access in Supervisor mode for Level1          # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE08)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X )		                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R ) 				// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte09.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte09.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Execute Access in Supervisor mode for Level2          # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE09)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X )		                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R )	 			// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte10.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte10.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Execute Access in User mode for Level0                # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE10)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X ) 		                // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R ) 			// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte11.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte11.S
@@ -1,0 +1,162 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Execute Access in User mode for Level1                # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE11)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X )		                // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R ) 			// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte12.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/invalid_pte/invalid_pte12.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.V = 0 and test the Execute Access in User mode for Level2                # 
+# 		      should raise a fetch access exception     				       #                        
+#                                                                                                      #
+# Description:        If PTE does not have Valid (pte.V=0) permission, then accessing it would	       #
+#                     raise page fault exception of the corresponding access type.           	       #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",invalid_PTE12)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X ) 		                // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R ) 			// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage01.S
@@ -1,0 +1,165 @@
+# #################################################################################################          
+# Verification Goal: Test the Read and write access in Supervisor mode for Level1 PTE  for        #
+#                    Misaligned Superpage should raise load page fault for read access and store  #
+#                    amo fault for store access.	                        	          #			
+# Discription:       If PTE at level1 PTE (superpage) and its pte.ppn[0]!=0, then it is a         #
+#                    misaligned superpage and accessing that PTE would raise page fault exception #
+#                    of the corresponding access type.                              		  # 	  
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",misaligned_superpage01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000000						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	li s10,0x134
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   		        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+j _start
+.align 12									// makes the ppn[0]!=0 (Misaligned Superpage)
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.word 0xdeadbeef
+_start:
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage02.S
@@ -1,0 +1,166 @@
+# #################################################################################################          
+# Verification Goal: Test the Read and write access in Supervisor mode for Level2 PTE  for        #
+#                    Misaligned Superpage should raise load page fault for read access and store  #
+#                    amo fault for store access.	                        	          #			
+# Discription:       If PTE at level2 PTE (superpage) and its pte.ppn[0]!=0 or ppn[1]!=0, then it #
+#                    is a misaligned superpage and accessing that PTE would raise page fault	  #
+# 		     exception of the corresponding access type.                     		  # 	  
+# #################################################################################################
+
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",misaligned_superpage02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000000						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )   		                // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )              		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+j _start
+.align 12									// makes the ppn[0]!=0 (Misaligned Superpage)
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.word 0xdeadbeef
+_start:
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage03.S
@@ -1,0 +1,163 @@
+# #################################################################################################          
+# Verification Goal: Test the Read and write access in User mode for Level1 PTE  for  Misaligned  #
+#                    Superpage should raise load page fault for read access and store amo fault   #
+#                    for store access.	                        	                          #			
+# Discription:       If PTE at level1 PTE (superpage) and its pte.ppn[0]!=0, then it is a         #
+#                    misaligned superpage and accessing that PTE would raise page fault exception #
+#                    of the corresponding access type.                              		  # 	  
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",misaligned_superpage03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000000						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V ) 		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V )        	// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )        	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+j _start
+.align 12									// makes the ppn[0]!=0 (Misaligned Superpage)
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.word 0xdeadbeef
+_start:
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage04.S
@@ -1,0 +1,163 @@
+# #################################################################################################          
+# Verification Goal: Test the Read and write access in User mode for Level2 PTE  for  Misaligned  #
+#                    Superpage should raise load page fault for read access and store amo fault   #
+#                    for store access.	                        	                          #			
+# Discription:       If PTE at level1 PTE (superpage) and its pte.ppn[0]!=0, then it is a         #
+#                    misaligned superpage and accessing that PTE would raise page fault exception #
+#                    of the corresponding access type.                              		  # 	  
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",misaligned_superpage04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000000						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )  		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )          	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+#endif
+
+j _start
+.align 12									// makes the ppn[0]!=0 (Misaligned Superpage)
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.word 0xdeadbeef
+_start:
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage05.S
@@ -1,0 +1,163 @@
+# #################################################################################################          
+# Verification Goal: Test the execute access in Supervisor mode for Level1 PTE  for Misaligned    #
+#                    Superpage should raise a fetch page fault for execute access	          #			
+# Discription:       If PTE at level1 PTE (superpage) and its pte.ppn[0]!=0, then it is a         #
+#                    misaligned superpage and accessing that PTE would raise page fault exception #
+#                    of the corresponding access type.                              		  # 	  
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",misaligned_superpage05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+j _start
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.word 0xdeadbeef
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000000						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LA (a0, vm_en)                                                          // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )       			        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )     		        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+j vm_en
+.align 12									// makes the ppn[0]!=0 (Misaligned Superpage)
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage06.S
@@ -1,0 +1,163 @@
+# #################################################################################################          
+# Verification Goal: Test the execute access in Supervisor mode for Level2 PTE  for Misaligned    #
+#                    Superpage should raise a fetch page fault for execute access	          #			
+# Discription:       If PTE at level1 PTE (superpage) and its pte.ppn[0]!=0, then it is a         #
+#                    misaligned superpage and accessing that PTE would raise page fault exception #
+#                    of the corresponding access type.                              		  # 	  
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",misaligned_superpage06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.word 0xdeadbeef
+_start:
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000000						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LA (a0, vm_en)                                                          // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )  	                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )             	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+j vm_en
+.align 12									// makes the ppn[0]!=0 (Misaligned Superpage)
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage07.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage07.S
@@ -1,0 +1,163 @@
+# #################################################################################################          
+# Verification Goal: Test the execute access in User mode for Level1 PTE  for Misaligned          #
+#                    Superpage should raise a fetch page fault for execute access	          #			
+# Discription:       If PTE at level1 PTE (superpage) and its pte.ppn[0]!=0, then it is a         #
+#                    misaligned superpage and accessing that PTE would raise page fault exception #
+#                    of the corresponding access type.                              		  # 	  
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",misaligned_superpage07)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.word 0xdeadbeef
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000000						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LA (a0, vm_en)                                                          // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )   		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V )       	        // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )     		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+j vm_en
+.align 12									// makes the ppn[0]!=0 (Misaligned Superpage)
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage08.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/misaligned_superpage/misaligned_superpage08.S
@@ -1,0 +1,162 @@
+# #################################################################################################          
+# Verification Goal: Test the execute access in User mode for Level2 PTE  for Misaligned          #
+#                    Superpage should raise a fetch page fault for execute access	          #			
+# Discription:       If PTE at level1 PTE (superpage) and its pte.ppn[0]!=0, then it is a         #
+#                    misaligned superpage and accessing that PTE would raise page fault exception #
+#                    of the corresponding access type.                              		  # 	  
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",misaligned_superpage08)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.word 0xdeadbeef
+_start:
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000000						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LA (a0, vm_en)                                                          // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )     		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V ) 	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+j vm_en
+.align 12									// makes the ppn[0]!=0 (Misaligned Superpage)
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set01.S
@@ -1,0 +1,165 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=1 and test the read acces	#
+#		     for level 0 PTE in Supervisor mode,there should be no fault		#
+#												#
+# Description:       If PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=1, then 	#
+#		     read access on that PTE should be successful without having explicit 	#
+#		     read permission (pte.r = 0).						#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_set01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V ) 		                // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrs mstatus,s7	                                                        // clear the mstatus.MXR = 1 
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should be successful)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set02.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=1 and test the read acces	#
+#		     for level 1 PTE in Supervisor mode,there should be no fault		#
+#												#
+# Description:       If PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=1, then 	#
+#		     read access on that PTE should be successful without having explicit 	#
+#		     read permission (pte.r = 0).						#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_set02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0901000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V ) 		                // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrs mstatus,s7	                                                        // clear the mstatus.MXR = 1 
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should be successful)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set03.S
@@ -1,0 +1,165 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=1 and test the read acces	#
+#		     for level 2 PTE in Supervisor mode,there should be no fault		#
+#												#
+# Description:       If PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=1, then 	#
+#		     read access on that PTE should be successful without having explicit 	#
+#		     read permission (pte.r = 0).						#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_set03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V ) 		                // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrs mstatus,s7	                                                        // clear the mstatus.MXR = 1 
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should be successful)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set04.S
@@ -1,0 +1,165 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=1 and test the read acces	#
+#		     for level 0 PTE in User mode,there should be no fault			#
+#												#
+# Description:       f PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=1, then 	#
+#		     read access on that PTE should be successful without having explicit 	#
+#		     read permission (pte.r = 0).						#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_set04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )    			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V ) 		        // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrs mstatus,s7	                                                        // clear the mstatus.MXR = 1 
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should be successful)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set05.S
@@ -1,0 +1,165 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=1 and test the read acces	#
+#		     for level 1 PTE in User mode,there should be no fault			#
+#												#
+# Description:       f PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=1, then 	#
+#		     read access on that PTE should be successful without having explicit 	#
+#		     read permission (pte.r = 0).						#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_set05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )  		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V ) 		        // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrs mstatus,s7	                                                        // clear the mstatus.MXR = 1 
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should be successful)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_set/mxr_set06.S
@@ -1,0 +1,165 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=1 and test the read acces	#
+#		     for level 2 PTE in User mode,there should be no fault			#
+#												#
+# Description:       f PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=1, then 	#
+#		     read access on that PTE should be successful without having explicit 	#
+#		     read permission (pte.r = 0).						#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_set06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V ) 		        // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrs mstatus,s7	                                                        // clear the mstatus.MXR = 1 
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should be successful)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset01.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=0 and test the read acces	#
+#		     for level 0 PTE in Supervisor mode,Should raise load page fault.		#
+#												#
+# Description:       If PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=0, then 	#
+#		     read access on that PTE should raise load page fault exception.		#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_unset01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V ) 		                // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrc mstatus,s7	                                                        // clear the mstatus.MXR = 0 
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise exception)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset02.S
@@ -1,0 +1,163 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=0 and test the read acces	#
+#		     for level 1 PTE in Supervisor mode,Should raise load page fault.		#
+#												#
+# Description:       If PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=0, then 	#
+#		     read access on that PTE should raise load page fault exception.		#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_unset02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0901000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V ) 		                // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrc mstatus,s7	                                                        // clear the mstatus.MXR = 0 
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise exception)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset03.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=0 and test the read acces	#
+#		     for level 2 PTE in Supervisor mode,Should raise load page fault.		#
+#												#
+# Description:       If PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=0, then 	#
+#		     read access on that PTE should raise load page fault exception.		#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_unset03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V ) 		                // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrc mstatus,s7	                                                        // clear the mstatus.MXR = 0 
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise exception)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset04.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=0 and test the read acces	#
+#		     for level 0 PTE in User mode,Should raise load page fault.			#
+#												#
+# Description:       If PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=0, then 	#
+#		     read access on that PTE should raise load page fault exception.		#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_unset04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )    			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V ) 		        // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrc mstatus,s7	                                                        // clear the mstatus.MXR = 0 
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise exception)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset05.S
@@ -1,0 +1,163 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=0 and test the read acces	#
+#		     for level 1 PTE in User mode,Should raise load page fault.			#
+#												#
+# Description:       If PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=0, then 	#
+#		     read access on that PTE should raise load page fault exception.		#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_unset05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )  		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V ) 		        // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrc mstatus,s7	                                                        // clear the mstatus.MXR = 0 
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise exception)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/mxr_unset/mxr_unset06.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Set pte.r=0 & pte.w=0 & pte.x=1 & s/mstatus.MXR=0 and test the read acces	#
+#		     for level 2 PTE in User mode,Should raise load page fault.			#
+#												#
+# Description:       If PTE has only execute permission (pte.x = 1) and s/mstatus.MXR=0, then 	#
+#		     read access on that PTE should raise load page fault exception.		#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",mxr_unset06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V ) 		        // sets the permission bits (PTE_R & PTE_W == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	li s7, MSTATUS_MXR                                                      // loads the value of MSTATUS_MXR
+        csrc mstatus,s7	                                                        // clear the mstatus.MXR = 0 
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise exception)
+        nop                                             
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/non_leaf_pte/non_leaf_pte01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/non_leaf_pte/non_leaf_pte01.S
@@ -1,0 +1,166 @@
+# ###############################################################################################
+#  Verification Goal: Set pte.r=0 & pte.w=0 and test the Read Acces and Write Access  		#
+#                     in Supervisor mode for Level 0 Should raise a load page fault for read    #
+#                     access and Store AMO fault for write access                               #
+#                                                                                               #
+# Description:        If PTE has non-leaf RWX permissions (pte.x=0 & pte.r=0 & pte.w=0), then   #
+#                     accessing it would raise page fault exception of the corresponding access #
+#                     type.	                                                                #
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",nonleaf_pte01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_V )         				// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/non_leaf_pte/non_leaf_pte02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/non_leaf_pte/non_leaf_pte02.S
@@ -1,0 +1,166 @@
+# ###############################################################################################
+#  Verification Goal: Set pte.r=0 & pte.w=0 and test the Read Acces and Write Access  		#
+#                     in User mode for Level 0 Should raise a load page fault for read          #
+#                     access and Store AMO fault for write access                               #
+#                                                                                               #
+# Description:        If PTE has non-leaf RWX permissions (pte.x=0 & pte.r=0 & pte.w=0), then   #
+#                     accessing it would raise page fault exception of the corresponding access #
+#                     type.	                                                                #
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",nonleaf_pte02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )    			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V ) 			        // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/non_leaf_pte/non_leaf_pte03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/non_leaf_pte/non_leaf_pte03.S
@@ -1,0 +1,165 @@
+# ###############################################################################################
+#  Verification Goal: Set pte.r=0 & pte.w=0 and test the Execute Access in User mode for Level0 #
+#                     Should raise an exception.                                                #
+#                                                                                               #
+# Description:        If PTE has non-leaf RWX permissions (pte.x=0 & pte.r=0 & pte.w=0), then   #
+#                     accessing it would raise page fault exception of the corresponding access #
+#                     type.	                                                                #
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",nonleaf_pte03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V )           			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V ) 			        // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa01.S
@@ -1,0 +1,189 @@
+# ###############################################################################################
+# Verification Goal: Remove execute PMP permission of translated Physical Address in pmpcfg     #
+#                    and test the Read Acces and Write Access in Supervisor mode for            #
+#                    Level 0 Should raise a load page fault for read access and Store AMO fault #
+#                    for write access                                                           #
+#                                                                                               #
+# Description:       If PTE has valid and non-reserved RWX permissions, but the translated      #
+#                    Physical address (pte.ppn of leaf PTE + offset) does not have (r,w,x) PMP  #
+#                    permissions, then accessing the translated Physical address would raise    #
+#                    access fault exception of the corresponding access type.                   #
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pa01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the PMP Permissions-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+
+        LA (t1,rvtest_data)							// loads the address of the label rvtest_data
+        LA (t2, _start)								// loads the address of the label _start
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr0,t1							// write t1 to the pmpaddr0
+	csrw pmpaddr1,t2							// write t1 to the pmpaddr1
+
+        LA ( t1,vm_en)								// loads the address of the label vm_en
+        LA ( t2, sig_end_canary)						// loads the address of the sig_end_canary
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr2,t1							// write t1 to the pmpaddr2
+	csrw pmpaddr3,t2							// write t1 to the pmpaddr3
+
+	LI ( t4,( (PMP_TOR | PMP_X | PMP_W | PMP_R) << 24) | (PMP_TOR <<8) )	// sets the permission bits
+	csrw pmpcfg0,t4								// write to the pmpcfg0
+
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled---------------------------
+check_execute:
+
+	add t1, t1, 0x123 							// dummy instr (should raise an exception)
+	nop	
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG t0, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa02.S
@@ -1,0 +1,188 @@
+# ###############################################################################################
+# Verification Goal: Remove execute PMP permission of translated Physical Address in pmpcfg     #
+#                    and test the Read Acces and Write Access in Supervisor mode for            #
+#                    Level 1 Should raise a load page fault for read access and Store AMO fault #
+#                    for write access                                                           #
+#                                                                                               #
+# Description:       If PTE has valid and non-reserved RWX permissions, but the translated      #
+#                    Physical address (pte.ppn of leaf PTE + offset) does not have (r,w,x) PMP  #
+#                    permissions, then accessing the translated Physical address would raise    #
+#                    access fault exception of the corresponding access type.                   #
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pa02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the PMP Permissions-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+
+        LA (t1,rvtest_data)							// loads the address of the label rvtest_data
+        LA (t2, _start)								// loads the address of the label _start
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr0,t1							// write t1 to the pmpaddr0
+	csrw pmpaddr1,t2							// write t1 to the pmpaddr1
+
+        LA ( t1,vm_en)								// loads the address of the label vm_en
+        LA ( t2, sig_end_canary)						// loads the address of the sig_end_canary
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr2,t1							// write t1 to the pmpaddr2
+	csrw pmpaddr3,t2							// write t1 to the pmpaddr3
+
+	LI ( t4,( (PMP_TOR | PMP_X | PMP_W | PMP_R) << 24) | (PMP_TOR <<8) )	// sets the permission bits
+	csrw pmpcfg0,t4								// write to the pmpcfg0
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0901000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled---------------------------
+check_execute:
+
+	add t1, t1, 0x123 							// dummy instr (should raise an exception)
+	nop	
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG t0, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa03.S
@@ -1,0 +1,189 @@
+# ###############################################################################################
+# Verification Goal: Remove execute PMP permission of translated Physical Address in pmpcfg     #
+#                    and test the Read Acces and Write Access in Supervisor mode for            #
+#                    Level 2 Should raise a load page fault for read access and Store AMO fault #
+#                    for write access                                                           #
+#                                                                                               #
+# Description:       If PTE has valid and non-reserved RWX permissions, but the translated      #
+#                    Physical address (pte.ppn of leaf PTE + offset) does not have (r,w,x) PMP  #
+#                    permissions, then accessing the translated Physical address would raise    #
+#                    access fault exception of the corresponding access type.                   #
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pa03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the PMP Permissions-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+
+        LA (t1,rvtest_data)							// loads the address of the label rvtest_data
+        LA (t2, _start)								// loads the address of the label _start
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr0,t1							// write t1 to the pmpaddr0
+	csrw pmpaddr1,t2							// write t1 to the pmpaddr1
+
+        LA ( t1,vm_en)								// loads the address of the label vm_en
+        LA ( t2, sig_end_canary)						// loads the address of the sig_end_canary
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr2,t1							// write t1 to the pmpaddr2
+	csrw pmpaddr3,t2							// write t1 to the pmpaddr3
+
+	LI ( t4,( (PMP_TOR | PMP_X | PMP_W | PMP_R) << 24) | (PMP_TOR <<8) )	// sets the permission bits
+	csrw pmpcfg0,t4								// write to the pmpcfg0
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled---------------------------
+check_execute:
+
+	add t1, t1, 0x123 							// dummy instr (should raise an exception)
+	nop	
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG t0, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa04.S
@@ -1,0 +1,188 @@
+# ###############################################################################################
+# Verification Goal: Remove execute PMP permission of translated Physical Address in pmpcfg     #
+#                    and test the Read Acces and Write Access in User mode for Level 0 Should	#
+# 		     raise a load page fault for read access and Store AMO fault for write	# 
+# 		     access       	                                                        #
+#                                                                                               #
+# Description:       If PTE has valid and non-reserved RWX permissions, but the translated      #
+#                    Physical address (pte.ppn of leaf PTE + offset) does not have (r,w,x) PMP  #
+#                    permissions, then accessing the translated Physical address would raise    #
+#                    access fault exception of the corresponding access type.                   #
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pa04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the PMP Permissions-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+
+        LA (t1,rvtest_data)							// loads the address of the label rvtest_data
+        LA (t2, _start)								// loads the address of the label _start
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr0,t1							// write t1 to the pmpaddr0
+	csrw pmpaddr1,t2							// write t1 to the pmpaddr1
+
+        LA ( t1,vm_en)								// loads the address of the label vm_en
+        LA ( t2, sig_end_canary)						// loads the address of the sig_end_canary
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr2,t1							// write t1 to the pmpaddr2
+	csrw pmpaddr3,t2							// write t1 to the pmpaddr3
+
+	LI ( t4,( (PMP_TOR | PMP_X | PMP_W | PMP_R) << 24) | (PMP_TOR <<8) )	// sets the permission bits
+	csrw pmpcfg0,t4								// write to the pmpcfg0
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )    			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 		// sets the permission bits (PTE_V == 0)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------
+check_execute:
+
+	add t1, t1, 0x123 							// dummy instr (should raise an exception)
+	nop	
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG t0, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled---------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa05.S
@@ -1,0 +1,189 @@
+# ###############################################################################################
+# Verification Goal: Remove execute PMP permission of translated Physical Address in pmpcfg     #
+#                    and test the Read Acces and Write Access in User mode for Level 1 Should	#
+# 		     raise a load page fault for read access and Store AMO fault for write	# 
+# 		     access       	                                                        #
+#                                                                                               #
+# Description:       If PTE has valid and non-reserved RWX permissions, but the translated      #
+#                    Physical address (pte.ppn of leaf PTE + offset) does not have (r,w,x) PMP  #
+#                    permissions, then accessing the translated Physical address would raise    #
+#                    access fault exception of the corresponding access type.                   #
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pa05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the PMP Permissions-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+
+        LA (t1,rvtest_data)							// loads the address of the label rvtest_data
+        LA (t2, _start)								// loads the address of the label _start
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr0,t1							// write t1 to the pmpaddr0
+	csrw pmpaddr1,t2							// write t1 to the pmpaddr1
+
+        LA ( t1,vm_en)								// loads the address of the label vm_en
+        LA ( t2, sig_end_canary)						// loads the address of the sig_end_canary
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr2,t1							// write t1 to the pmpaddr2
+	csrw pmpaddr3,t2							// write t1 to the pmpaddr3
+
+	LI ( t4,( (PMP_TOR | PMP_X | PMP_W | PMP_R) << 24) | (PMP_TOR <<8) )	// sets the permission bits
+	csrw pmpcfg0,t4								// write to the pmpcfg0
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )  		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------
+check_execute:
+
+	add t1, t1, 0x123 							// dummy instr (should raise an exception)
+	nop	
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG t0, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled---------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_physical_address/pmp_pa06.S
@@ -1,0 +1,189 @@
+# ###############################################################################################
+# Verification Goal: Remove execute PMP permission of translated Physical Address in pmpcfg     #
+#                    and test the Read Acces and Write Access in User mode for Level 2 Should	#
+# 		     raise a load page fault for read access and Store AMO fault for write	# 
+# 		     access       	                                                        #
+#                                                                                               #
+# Description:       If PTE has valid and non-reserved RWX permissions, but the translated      #
+#                    Physical address (pte.ppn of leaf PTE + offset) does not have (r,w,x) PMP  #
+#                    permissions, then accessing the translated Physical address would raise    #
+#                    access fault exception of the corresponding access type.                   #
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pa06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the PMP Permissions-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+
+        LA (t1,rvtest_data)							// loads the address of the label rvtest_data
+        LA (t2, _start)								// loads the address of the label _start
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr0,t1							// write t1 to the pmpaddr0
+	csrw pmpaddr1,t2							// write t1 to the pmpaddr1
+
+        LA ( t1,vm_en)								// loads the address of the label vm_en
+        LA ( t2, sig_end_canary)						// loads the address of the sig_end_canary
+	srli t1,t1,PMP_SHIFT							// shift the address by PMP_SHIFT (2)
+	srli t2,t2,PMP_SHIFT							// shift the address by PMP_SHIFT (2)	
+
+	csrw pmpaddr2,t1							// write t1 to the pmpaddr2
+	csrw pmpaddr3,t2							// write t1 to the pmpaddr3
+
+	LI ( t4,( (PMP_TOR | PMP_X | PMP_W | PMP_R) << 24) | (PMP_TOR <<8) )	// sets the permission bits
+	csrw pmpcfg0,t4								// write to the pmpcfg0
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )        		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------
+check_execute:
+
+	add t1, t1, 0x123 							// dummy instr (should raise an exception)
+	nop	
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG t0, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled---------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte01.S
@@ -1,0 +1,214 @@
+# #################################################################################################
+# Verification Goal: Remove read and write PMP permission of PTE address in pmpcfg and test the   #
+# 		     Read Acces and Write Access in Supervisor mode for Level 0 PTE Should	  #	
+# 		     raise a load page fault for read access and Store AMO fault for write access #
+#                    		                                                                  #
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R ) << 16 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0                                                      	// 8-byte of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT  ) << 24 ))	                		// sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 32 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+
+      	LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        addi t1,t1,8								// adding 8 byte to the base address of rvtest_slvl2_pg_tbl
+	srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr6, t1                                                       // write t1 to the pmpaddr6
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R ) << 48 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+	csrw satp, zero								// write zero to the satp (bare mode)
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x090000A000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900000688						// 39 bits of VA address	
+	.set sig_data,   0x090000B118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x090000A000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level0 PTE setup for pa (0x0900000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level0 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x090000B118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte02.S
@@ -1,0 +1,215 @@
+# #################################################################################################
+# Verification Goal: Remove read and write PMP permission of PTE address in pmpcfg and test the   #
+# 		     Read Acces and Write Access in Supervisor mode for Level 1 PTE Should	  #	
+# 		     raise a load page fault for read access and Store AMO fault for write access #
+#                    		                                                                  #
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0                                                       	// 8-byte of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT ) << 16 ))				                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                      	// 4KB of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 24 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 32 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+
+      	LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        addi t1,t1,8								// adding 8 byte to the base address of rvtest_slvl1_pg_tbl
+	srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr6, t1                                                       // write t1 to the pmpaddr6
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R ) << 48 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x090A000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900000688						// 39 bits of VA address	
+	.set sig_data,   0x090B000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level2 PTE setup for pa (0x090A000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1 for sv39
+ 										// level2 PTE setup for pa (0x0900000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x090B000118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte03.S
@@ -1,0 +1,216 @@
+# #################################################################################################
+# Verification Goal: Remove read and write PMP permission of PTE address in pmpcfg and test the   #
+# 		     Read Acces and Write Access in Supervisor mode for Level 2 PTE Should	  #	
+# 		     raise a load page fault for read access and Store AMO fault for write access #
+#                    		                                                                  #
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 16 ))			// sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                      	// 4-KB of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 24 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT) << 32 ))	                                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+
+      	LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        addi t1,t1,8								// adding 8 byte to the base address of rvtest_Sroot_pg_tbl
+	srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr6, t1                                                       // write t1 to the pmpaddr6
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R ) << 48 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x09C0000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0000000688						// 39 bits of VA address	
+	.set sig_data,   0x0980000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level2 PTE setup for pa (0x09C0000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2 for sv39
+ 										// level2 PTE setup for pa (0x0000000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0980000118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte04.S
@@ -1,0 +1,214 @@
+# #################################################################################################
+# Verification Goal: Remove read and write PMP permission of PTE address in pmpcfg and test the   #
+# 		     Read Acces and Write Access in User mode for Level 0 PTE Should	          #	
+# 		     raise a load page fault for read access and Store AMO fault for write access #
+#                    		                                                                  #
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R ) << 16 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0                                                      	// 8-byte of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT  ) << 24 ))	                		// sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 32 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+
+      	LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        addi t1,t1,8								// adding 8 byte to the base address of rvtest_slvl2_pg_tbl
+	srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr6, t1                                                       // write t1 to the pmpaddr6
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R ) << 48 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+	csrw satp, zero								// write zero to the satp (bare mode)
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x090000A000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900000688						// 39 bits of VA address	
+	.set sig_data,   0x090000B118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x090000A000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )               		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x090000B118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte05.S
@@ -1,0 +1,215 @@
+# #################################################################################################
+# Verification Goal: Remove read and write PMP permission of PTE address in pmpcfg and test the   #
+# 		     Read Acces and Write Access in User mode for Level 1 PTE Should	          #	
+# 		     raise a load page fault for read access and Store AMO fault for write access #
+#                    		                                                                  #
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0                                                       	// 8-byte of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT ) << 16 ))				                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                      	// 4KB of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 24 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 32 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+
+      	LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        addi t1,t1,8								// adding 8 byte to the base address of rvtest_slvl1_pg_tbl
+	srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr6, t1                                                       // write t1 to the pmpaddr6
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R ) << 48 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x090A000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900000688						// 39 bits of VA address	
+	.set sig_data,   0x090B000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x090A000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                	// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x090B000118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte06.S
@@ -1,0 +1,216 @@
+# #################################################################################################
+# Verification Goal: Remove read and write PMP permission of PTE address in pmpcfg and test the   #
+# 		     Read Acces and Write Access in User mode for Level 2 PTE Should	          #	
+# 		     raise a load page fault for read access and Store AMO fault for write access #
+#                    		                                                                  #
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 16 ))			// sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                      	// 4-KB of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 24 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT) << 32 ))	                                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+
+      	LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        addi t1,t1,8								// adding 8 byte to the base address of rvtest_Sroot_pg_tbl
+	srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr6, t1                                                       // write t1 to the pmpaddr6
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R ) << 48 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x09C0000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0000000688						// 39 bits of VA address	
+	.set sig_data,   0x0980000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x09C0000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )              		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0000000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0980000118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte07.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte07.S
@@ -1,0 +1,205 @@
+# #################################################################################################
+# Verification Goal: Remove execute PMP permission of PTE address in pmpcfg and test the execute  #
+# 		     Access in Supervisor mode for Level 0 PTE Should raise an exception.	  #
+# 												  #	
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte07)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R ) << 16 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                      	// 4KB of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT  ) << 24 ))	                		// sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 32 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x090000A000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900000688						// 39 bits of VA address	
+	.set sig_data,   0x090000B118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x090000A000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x090000B118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte08.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte08.S
@@ -1,0 +1,207 @@
+# #################################################################################################
+# Verification Goal: Remove execute PMP permission of PTE address in pmpcfg and test the execute  #
+# 		     Access in Supervisor mode for Level 1 PTE Should raise an exception.	  #
+# 												  #	
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte08)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( ( PMP_NAPOT ) << 16 ))				        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                      	// 4KB of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 24 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 32 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x090A000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900000688						// 39 bits of VA address	
+	.set sig_data,   0x090B000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x090A000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x090B000118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte09.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte09.S
@@ -1,0 +1,208 @@
+# #################################################################################################
+# Verification Goal: Remove execute PMP permission of PTE address in pmpcfg and test the execute  #
+# 		     Access in Supervisor mode for Level 2 PTE Should raise an exception.	  #
+# 												  #	
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte09)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 16 ))			// sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                      	// 4-KB of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 24 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT) << 32 ))	                                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+	
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x09C0000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0000000688						// 39 bits of VA address	
+	.set sig_data,   0x0980000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x09C0000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0000000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 			// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0980000118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte10.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte10.S
@@ -1,0 +1,206 @@
+# #################################################################################################
+# Verification Goal: Remove execute PMP permission of PTE address in pmpcfg and test the execute  #
+# 		     Access in User mode for Level 0 PTE Should raise an exception.	 	  #
+# 												  #	
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte10)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R ) << 16 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT  ) << 24 ))	                		// sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 32 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+
+	csrw satp, zero								// write zero to the satp (bare mode)
+
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x090000A000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900000688						// 39 bits of VA address	
+	.set sig_data,   0x090000B118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x090000A000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )               		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x090000B118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte11.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte11.S
@@ -1,0 +1,206 @@
+# #################################################################################################
+# Verification Goal: Remove execute PMP permission of PTE address in pmpcfg and test the execute  #
+# 		     Access in User mode for Level 1 PTE Should raise an exception.	 	  #
+# 												  #	
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte11)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT ) << 16 ))				                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                      	// 4KB of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 24 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 32 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+
+	csrw satp, zero								// write zero to the satp (bare mode)
+
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x090A000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900000688						// 39 bits of VA address	
+	.set sig_data,   0x090B000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x090A000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                	// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x090B000118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte12.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/pmp_pte/pmp_pte12.S
@@ -1,0 +1,207 @@
+# #################################################################################################
+# Verification Goal: Remove execute PMP permission of PTE address in pmpcfg and test the execute  #
+# 		     Access in User mode for Level 2 PTE Should raise an exception.	 	  #
+# 												  #	
+# Description:       If PTE does not have (r,w,x) PMP permissions, then accessing it would        #
+# 		     raise access fault exception of the corresponding access type.               #
+# #################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",pmp_pte12)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	csrw pmpcfg0, zero							// clear the pmpcfg0 register
+        
+        LA( t1, rvtest_data )                                                   // loads the base address of rvtest_data label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_data label by PMP_Shift(2)
+        ori t1, t1, 0                                                           // 8-byte of NAPOT range
+        csrw pmpaddr0, t1                                                       // write t1 to the pmpaddr0
+       	LI ( t2,( PMP_NAPOT | PMP_X | PMP_W | PMP_R))	                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, vm_en )                                                         // loads the base address of vm_en label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of vm_en label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr1, t1                                                       // write t1 to the pmpaddr1
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 8 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl1_pg_tbl )                                           // loads the base address of rvtest_slvl1_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl1_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr2, t1                                                       // write t1 to the pmpaddr2
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 16 ))			// sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_slvl2_pg_tbl )                                           // loads the base address of rvtest_slvl2_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_slvl2_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                      	// 4-KB of NAPOT range
+        csrw pmpaddr3, t1                                                       // write t1 to the pmpaddr3
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 24 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_Sroot_pg_tbl )                                           // loads the base address of rvtest_Sroot_pg_tbl label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_Sroot_pg_tbl label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr4, t1                                                       // write t1 to the pmpaddr4
+       	LI ( t2,( (PMP_NAPOT) << 32 ))	                                        // sets the permission bits
+	csrs pmpcfg0,t2								// write to the pmpcfg0
+
+        LA( t1, rvtest_sig_begin )                                              // loads the base address of rvtest_sig_begin label        
+        srli t1, t1, PMP_SHIFT                                                  // Right shift the address of rvtest_sig_begin label by PMP_Shift(2)
+        ori t1, t1, 0x1FF                                                       // 4KB of NAPOT range
+        csrw pmpaddr5, t1                                                       // write t1 to the pmpaddr5
+       	LI ( t2,( (PMP_NAPOT | PMP_X | PMP_W | PMP_R) << 40 ))	                // sets the permission bits
+	csrs pmpcfg0,t2								// set the permissions of all memory 
+
+	csrw satp, zero								// write zero to the satp (bare mode)
+
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x09C0000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0000000688						// 39 bits of VA address	
+	.set sig_data,   0x0980000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x09C0000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )              		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0000000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0980000118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx01.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Read and Write Access for the reserved RWX permission of level 0 PTE in    #
+#                    Supervisor mode should raise a load page fault for read access and         #
+#                    Store AMO fault for write access                                           #
+# Description:       If PTE has reserved RWX encodings (pte.w=1 & pte.r=0), then accessing   	#
+#                    it would raise page fault exception of the corresponding access type.   	#
+# ############################################################################################### 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",reserved_rwx01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_V )        			// sets the permission bits (PTE_R == 0 & PTE_W == 1)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx02.S
@@ -1,0 +1,163 @@
+# ###############################################################################################
+# Verification Goal: Read and Write Access for the reserved RWX permission of level 1 PTE in    #
+#                    Supervisor mode should raise a load page fault for read access and         #
+#                    Store AMO fault for write access                                           #
+# Description:       If PTE has reserved RWX encodings (pte.w=1 & pte.r=0), then accessing   	#
+#                    it would raise page fault exception of the corresponding access type.   	#
+# ############################################################################################### 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",reserved_rwx02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0901000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_V )        			// sets the permission bits (PTE_R == 0 & PTE_W == 1)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )                	// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx03.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Read and Write Access for the reserved RWX permission of level 2 PTE in    #
+#                    Supervisor mode should raise a load page fault for read access and         #
+#                    Store AMO fault for write access                                           #
+# Description:       If PTE has reserved RWX encodings (pte.w=1 & pte.r=0), then accessing   	#
+#                    it would raise page fault exception of the corresponding access type.   	#
+# ############################################################################################### 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",reserved_rwx03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )               			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_V )        			// sets the permission bits (PTE_R == 0 & PTE_W == 1)
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )   	                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx04.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Read and Write Access for the reserved RWX permission of level 0 PTE in    #
+#                    User mode should raise a load page fault for read access and        	#
+#                    Store AMO fault for write access                                           #
+# Description:       If PTE has reserved RWX encodings (pte.w=1 & pte.r=0), then accessing   	#
+#                    it would raise page fault exception of the corresponding access type.   	#
+# ############################################################################################### 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",reserved_rwx04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )    			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_V )        		// sets the permission bits (PTE_R == 0 & PTE_W == 1)	
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx05.S
@@ -1,0 +1,163 @@
+# ###############################################################################################
+# Verification Goal: Read and Write Access for the reserved RWX permission of level 1 PTE in    #
+#                    User mode should raise a load page fault for read access and        	#
+#                    Store AMO fault for write access                                           #
+# Description:       If PTE has reserved RWX encodings (pte.w=1 & pte.r=0), then accessing   	#
+#                    it would raise page fault exception of the corresponding access type.   	#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",reserved_rwx05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )  		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_V )        		// sets the permission bits (PTE_R == 0 & PTE_W == 1)	
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx06.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Read and Write Access for the reserved RWX permission of level 2 PTE in    #
+#                    User mode should raise a load page fault for read access and        	#
+#                    Store AMO fault for write access                                           #
+# Description:       If PTE has reserved RWX encodings (pte.w=1 & pte.r=0), then accessing   	#
+#                    it would raise page fault exception of the corresponding access type.   	#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",reserved_rwx06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )        		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_V )        		// sets the permission bits (PTE_R == 0 & PTE_W == 1)	
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+	
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx07.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx07.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Execute Access for the reserved RWX permission of level 0 PTE in           #
+#                    User mode should raise a load page fault for read access and        	#
+#                    Store AMO fault for write access                                           #
+# Description:       If PTE has reserved RWX encodings (pte.w=1 & pte.r=0), then accessing   	#
+#                    it would raise page fault exception of the corresponding access type.   	#
+# ############################################################################################### 
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",reserved_rwx07)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V )            			// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_V )        		// sets the permission bits (PTE_R == 0 & PTE_W == 1)	
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx08.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx08.S
@@ -1,0 +1,163 @@
+# ###############################################################################################
+# Verification Goal: Execute Access for the reserved RWX permission of level 1 PTE in           #
+#                    User mode should raise a load page fault for read access and        	#
+#                    Store AMO fault for write access                                           #
+# Description:       If PTE has reserved RWX encodings (pte.w=1 & pte.r=0), then accessing   	#
+#                    it would raise page fault exception of the corresponding access type.   	#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",reserved_rwx08)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V )  		                // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0901000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_V )        		// sets the permission bits (PTE_R == 0 & PTE_W == 1)	
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )                // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx09.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/reserved_rwx/reserved_rwx09.S
@@ -1,0 +1,164 @@
+# ###############################################################################################
+# Verification Goal: Execute Access for the reserved RWX permission of level 2 PTE in    	#
+#                    User mode should raise a load page fault for read access and        	#
+#                    Store AMO fault for write access                                           #
+# Description:       If PTE has reserved RWX encodings (pte.w=1 & pte.r=0), then accessing   	#
+#                    it would raise page fault exception of the corresponding access type.   	#
+# ###############################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",reserved_rwx09)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V )                		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0980000688 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_V )        		// sets the permission bits (PTE_R == 0 & PTE_W == 1)	
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set01.S
@@ -1,0 +1,169 @@
+# ###############################################################################################           
+# Verification Goal: Test the Read and write acces in Supervisor mode for Level0 PTE such that   #
+#                    (PTE.u=1 and mstatus.SUM=1), Read access and write access to the PTE should #
+#                     be successful.                                                             #
+#												 #													
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)    #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode        #
+#                    would be successful but eXecute access would raise instruction page         #
+#                    fault exception in s-mode.                                                  #   
+# ###############################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_set01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900001688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                 		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )    		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrs mstatus,s7                                                         // set the mstatus.SUM = 1         
+
+        RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set02.S
@@ -1,0 +1,169 @@
+# ###############################################################################################           
+# Verification Goal: Test the Read and write acces in Supervisor mode for Level1 PTE such that   #
+#                    (PTE.u=1 and mstatus.SUM=1), Read access and write access to the PTE should #
+#                     be successful.                                                             #
+#												 #													
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)    #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode        #
+#                    would be successful but eXecute access would raise instruction page         #
+#                    fault exception in s-mode.                                                  #   
+# ###############################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_set02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                 		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )    		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrs mstatus,s7                                                         // set the mstatus.SUM = 1         
+
+        RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set03.S
@@ -1,0 +1,170 @@
+# ###############################################################################################           
+# Verification Goal: Test the Read and write acces in Supervisor mode for Level1 PTE such that   #
+#                    (PTE.u=1 and mstatus.SUM=1), Read access and write access to the PTE should #
+#                     be successful.                                                             #
+#												 #														
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)    #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode        #
+#                    would be successful but eXecute access would raise instruction page         #
+#                    fault exception in s-mode.                                                  #   
+# ###############################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_set03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                 		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )    		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrs mstatus,s7                                                         // set the mstatus.SUM = 1         
+
+        RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set04.S
@@ -1,0 +1,168 @@
+# #######################################################################################################           
+# Verification Goal: Test the Execute acces in Supervisor mode for Level0 PTE such that (PTE.u=1        #
+#                    and mstatus.SUM=1), execute access to the PTE should raise page fault exception    #
+#												        #														
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)           #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode               #
+#                    would be successful but eXecute access would raise instruction page                #
+#                    fault exception in s-mode.                                                         #   
+# #######################################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_set04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900001688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )    		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )    		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrs mstatus,s7                                                         // set the mstatus.SUM = 1         
+
+        RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set05.S
@@ -1,0 +1,168 @@
+# #######################################################################################################           
+# Verification Goal: Test the Execute acces in Supervisor mode for Level1 PTE such that (PTE.u=1        #
+#                    and mstatus.SUM=1), execute access to the PTE should raise page fault exception    #
+#												        #														
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)           #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode               #
+#                    would be successful but eXecute access would raise instruction page                #
+#                    fault exception in s-mode.                                                         #   
+# #######################################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_set05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )    		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )    		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrs mstatus,s7                                                         // set the mstatus.SUM = 1         
+
+        RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_set/sum_set06.S
@@ -1,0 +1,169 @@
+# #######################################################################################################           
+# Verification Goal: Test the Execute acces in Supervisor mode for Level2 PTE such that (PTE.u=1        #
+#                    and mstatus.SUM=1), execute access to the PTE should raise page fault exception    #
+#												        #														
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)           #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode               #
+#                    would be successful but eXecute access would raise instruction page                #
+#                    fault exception in s-mode.                                                         #   
+# #######################################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_set06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )    		        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )    		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrs mstatus,s7                                                         // set the mstatus.SUM = 1         
+
+        RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset01.S
@@ -1,0 +1,170 @@
+# ###############################################################################################           
+# Verification Goal: Test the Read and write acces in Supervisor mode for Level0 PTE such that   #
+#                    (PTE.u=1 and mstatus.SUM=0), Read access and write access to the PTE should #
+#                     raise an exception.                                                        #
+#												 #													
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)    #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode        #
+#                    would be successful but eXecute access would raise instruction page         #
+#                    fault exception in s-mode.                                                  #   
+# ###############################################################################################  
+
+   
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_unset01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900001688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                 		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )        		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrc mstatus,s7                                                         // set the mstatus.SUM = 0         
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset02.S
@@ -1,0 +1,168 @@
+# ###############################################################################################           
+# Verification Goal: Test the Read and write acces in Supervisor mode for Level1 PTE such that   #
+#                    (PTE.u=1 and mstatus.SUM=0), Read access and write access to the PTE should #
+#                     raise an exception.                                                        #
+#												 #													
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)    #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode        #
+#                    would be successful but eXecute access would raise instruction page         #
+#                    fault exception in s-mode.                                                  #   
+# ###############################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_unset02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                 		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )        		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrc mstatus,s7                                                         // set the mstatus.SUM = 0         
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset03.S
@@ -1,0 +1,169 @@
+# ###############################################################################################           
+# Verification Goal: Test the Read and write acces in Supervisor mode for Level2 PTE such that   #
+#                    (PTE.u=1 and mstatus.SUM=0), Read access and write access to the PTE should #
+#                     raise an exception.                                                        #
+#												 #														
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)    #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode        #
+#                    would be successful but eXecute access would raise instruction page         #
+#                    fault exception in s-mode.                                                  #   
+# ###############################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_unset03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_X | PTE_V )                 		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )        		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrc mstatus,s7                                                         // set the mstatus.SUM = 0         
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset04.S
@@ -1,0 +1,166 @@
+# #######################################################################################################           
+# Verification Goal: Test the Execute acces in Supervisor mode for Level0 PTE such that (PTE.u=1        #
+#                    and mstatus.SUM=1), execute access to the PTE should raise page fault exception    #
+#												        #												#
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode               #
+#                    would be successful but eXecute access would raise instruction page                #
+#                    fault exception in s-mode.                                                         #   
+# #######################################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_unset04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900001688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )        		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )        		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrc mstatus,s7                                                         // set the mstatus.SUM = 0         
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset05.S
@@ -1,0 +1,167 @@
+# #######################################################################################################           
+# Verification Goal: Test the Execute acces in Supervisor mode for Level1 PTE such that (PTE.u=1        #
+#                    and mstatus.SUM=1), execute access to the PTE should raise page fault exception    #
+#												        #												
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)           #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode               #
+#                    would be successful but eXecute access would raise instruction page                #
+#                    fault exception in s-mode.                                                         #   
+# #######################################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_unset05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )        		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )        		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrc mstatus,s7                                                         // set the mstatus.SUM = 0         
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+	
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/sum_unset/sum_unset06.S
@@ -1,0 +1,168 @@
+# #######################################################################################################           
+# Verification Goal: Test the Execute acces in Supervisor mode for Level2 PTE such that (PTE.u=1        #
+#                    and mstatus.SUM=1), execute access to the PTE should raise page fault exception    #
+#												        #													
+# Discription:       If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1)           #
+#                    and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode               #
+#                    would be successful but eXecute access would raise instruction page                #
+#                    fault exception in s-mode.                                                         #   
+# #######################################################################################################  
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",sum_unset06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )        		// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )        		// sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa)						// signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data)				// signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1)				// signature area for signature 
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data)				// signature area for vmem
+
+	sfence.vma                                                              // flush the TLB
+        LI (s7, MSTATUS_SUM)                                                    // loads the value of MSTATUS_SUM
+        csrc mstatus,s7                                                         // set the mstatus.SUM = 0         
+	RVTEST_GOTO_LOWER_MODE	Smode		                                // Switching to S mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set01.S
@@ -1,0 +1,165 @@
+# ########################################################################################################
+#  Verification Goal: Set PTE.U = 1 and PTE.WR=0 and test the Read Acces and Write Access in User mode   #
+#                     for Level 0 PTE Should raise a load page fault for read access and Store AMO fault #
+#                     for write access                                                                   #
+#                                                                                                        #   
+# Description:        If PTE have U bit and does not Read Write (pte.WR=0) permission,                   #
+#                     then accessing it in User mode would raise page fault exception of the             #
+#                     corresponding access type.                                                         #
+# ########################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_set01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900001688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V ) 		                // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )       	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set02.S
@@ -1,0 +1,164 @@
+# ########################################################################################################
+#  Verification Goal: Set PTE.U = 1 and PTE.WR=1 and test the Read Acces and Write Access in User mode   #
+#                     for Level 0 PTE Should be successful                                               #
+#                                                                                                        #   
+# Description:        If PTE have U bit and does not Read Write (pte.WR=0) permission,                   #
+#                     then accessing it in User mode would raise page fault exception of the             #
+#                     corresponding access type.                                                         #
+# ########################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_set02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900001688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V ) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )       	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set03.S
@@ -1,0 +1,165 @@
+# ########################################################################################################
+#  Verification Goal: Set PTE.U = 1 and PTE.WR=0 and test the Read Acces and Write Access in User mode   #
+#                     for Level 1 PTE Should raise a load page fault for read access and Store AMO fault #
+#                     for write access                                                                   #
+#                                                                                                        #   
+# Description:        If PTE have U bit and does not Read Write (pte.WR=0) permission,                   #
+#                     then accessing it in User mode would raise page fault exception of the             #
+#                     corresponding access type.                                                         #
+# ########################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_set03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000000 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V) 	                	// sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )       	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set04.S
@@ -1,0 +1,164 @@
+# ########################################################################################################
+#  Verification Goal: Set PTE.U = 1 and PTE.WR=1 and test the Read Acces and Write Access in User mode   #
+#                     for Level 1 PTE Should be successful                                               #
+#                                                                                                        #   
+# Description:        If PTE have U bit and does not Read Write (pte.WR=0) permission,                   #
+#                     then accessing it in User mode would raise page fault exception of the             #
+#                     corresponding access type.                                                         #
+# ########################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_set04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) 		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )       	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set05.S
@@ -1,0 +1,168 @@
+# ########################################################################################################
+#  Verification Goal: Set PTE.U = 1 and PTE.WR=0 and test the Read Acces and Write Access in User mode   #
+#                     for Level 2 PTE Should raise a load page fault for read access and Store AMO fault #
+#                     for write access                                                                   #
+#                                                                                                        #   
+# Description:        If PTE have U bit and does not Read Write (pte.WR=0) permission,                   #
+#                     then accessing it in User mode would raise page fault exception of the             #
+#                     corresponding access type.                                                         #
+# ########################################################################################################
+
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_set05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V)  		       		// sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )       	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_set/ubit_set06.S
@@ -1,0 +1,167 @@
+# ########################################################################################################
+#  Verification Goal: Set PTE.U = 1 and PTE.WR=1 and test the Read Acces and Write Access in User mode   #
+#                     for Level 2 PTE Should be successful                                               #
+#                                                                                                        #   
+# Description:        If PTE have U bit and does not Read Write (pte.WR=0) permission,                   #
+#                     then accessing it in User mode would raise page fault exception of the             #
+#                     corresponding access type.                                                         #
+# ########################################################################################################
+
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_set06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V)      	        // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )       	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset01.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset01.S
@@ -1,0 +1,164 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.U = 0 and test the Read Acces and Write Access in User mode for          #
+#                     Level 0 Should raise a load page fault for read access and Store AMO fault       #
+#                     for write access                                                                 #
+#                                                                                                      #
+# Description:       If PTE does not have U bit (pte.U=0) permission, then accessing it in User mode   #
+#                    would raise page fault exception of the corresponding access type.                #
+# #################################################################################################### #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_unset01)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900001688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 	  	        // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset02.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset02.S
@@ -1,0 +1,165 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.U = 0 and test the Read Acces and Write Access in User mode for          #
+#                     Level 1 Should raise a load page fault for read access and Store AMO fault       #
+#                     for write access                                                                 #
+#                                                                                                      #
+# Description:       If PTE does not have U bit (pte.U=0) permission, then accessing it in User mode   #
+#                    would raise page fault exception of the corresponding access type.                #
+# #################################################################################################### #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_unset02)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V) 	       	        // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset03.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset03.S
@@ -1,0 +1,166 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.U = 0 and test the Read Acces and Write Access in User mode for          #
+#                     Level 2 Should raise a load page fault for read access and Store AMO fault       #
+#                     for write access                                                                 #
+#                                                                                                      #
+# Description:       If PTE does not have U bit (pte.U=0) permission, then accessing it in User mode   #
+#                    would raise page fault exception of the corresponding access type.                #
+# #################################################################################################### #
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_unset03)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 	  	        // sets the permission bits 
+        PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset04.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset04.S
@@ -1,0 +1,163 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.U = 0 and test the Execute Access in User mode for Level 0 Should raise  #
+#                     a fetch page fault for execute access                                            #
+#                                                                                                      #
+# Description:       If PTE does not have U bit (pte.U=0) permission, then accessing it in User mode   #
+#                    would raise page fault exception of the corresponding access type.                #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_unset04)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0900001688						// 39 bits of VA address	
+	.set sig_data,   0x0900020118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+	
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level1
+								                // level0 PTE setup for pa (0x0900001688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U| PTE_V )                                 // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL0,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 	  	        // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL0,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset05.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset05.S
@@ -1,0 +1,163 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.U = 0 and test the Execute Access in User mode for Level 1 Should raise  #
+#                     a fetch page fault for execute access                                            #
+#                                                                                                      #
+# Description:       If PTE does not have U bit (pte.U=0) permission, then accessing it in User mode   #
+#                    would raise page fault exception of the corresponding access type.                #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_unset05)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0901000688						// 39 bits of VA address	
+	.set sig_data,   0x0902000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level2
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V )                                // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL1,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 	  	        // sets the permission bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL1,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset06.S
+++ b/riscv-test-suite/rv64i_m/vm_sv39/ubit_unset/ubit_unset06.S
@@ -1,0 +1,165 @@
+# ######################################################################################################
+#  Verification Goal: Set PTE.U = 0 and test the Execute Access in User mode for Level 2 Should raise  #
+#                     a fetch page fault for execute access                                            #
+#                                                                                                      #
+# Description:       If PTE does not have U bit (pte.U=0) permission, then accessing it in User mode   #
+#                    would raise page fault exception of the corresponding access type.                #
+# ######################################################################################################
+
+#include "model_test.h"
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+#ifdef TEST_CASE_1
+
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",ubit_unset06)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+
+
+main:
+
+j _start
+.align 3									// to align for 64 bit 
+rvtest_data:									// rvtest_data region for RWX access(ppn1==0 and ppn0==0)
+	.dword 0xFACECAFEBEEDCAFE
+_start:
+
+
+# -------------------------------------------------------------------------
+
+#ifdef rvtest_mtrap_routine							// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					         	// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+
+# -------------------------Set the all mem PMP-----------------------------	
+
+	ALL_MEM_PMP							        // set the permissions of all memory 
+	csrw satp, zero								// write zero to the satp (bare mode)
+	
+# -------------------------------------------------------------------------
+
+	.set va,       	 0x0900000000						// 39 bits of VA address
+	.set pa,       	 0x80000000000000 					// 56 bits of PA address 
+	.set va_data,  	 0x0980000688						// 39 bits of VA address	
+	.set sig_data,   0x0A00000118						// 39 bits of VA address (offset bits should be same as that of rvtest_sig_begin)
+
+# -------------------------Set the PTE for level2 for sv39-----------------
+								                // level0 PTE setup for pa (0x0900000688 -> 0x80000000000000)	
+	LI (a0, pa)                                                             // loads the PA address in a0
+	LI a1, ( PTE_D | PTE_A | PTE_U | PTE_V )                                // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, va, LEVEL2,sv39)                         // setup the PTE for level0 for sv39
+ 										// level2 PTE setup for pa (0x0900001000 -> rvtest_data)
+	LA( a0,rvtest_data)							// loads the PA address in a0 
+	LI a1, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V ) 	  	        // sets the permission bits 
+        PTE_SETUP_RV64(a0, a1, t0, t1, va_data, LEVEL2,sv39)                    // setup the PTE for level2 for sv39
+	
+# -------------------------Set the PTE for signature update-----------------
+
+	LA (a0, rvtest_slvl1_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL2,sv39)                   // setup the PTE for level2
+
+	LA (a0, rvtest_slvl2_pg_tbl)                                            // loads the address in a0
+	LI a1, ( PTE_V )           					        // sets the permission bits
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL1,sv39)                   // setup the PTE for level1 
+                                                                                // PTE setup for 0x0900020118 -> rvtest_sig_begin
+	la a0, rvtest_sig_begin   						// Physical address of signature area
+	li a1, ( PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V )  	        // sets the permissions bits 
+	PTE_SETUP_RV64(a0, a1, t0, t1, sig_data, LEVEL0,sv39) 			// PTE Setup for signature area address at pgtbl0
+	
+	LI (t0, sig_data)                                                       // loads the value of the sig_data
+	LA (t1, rvtest_sig_begin)                                               // loads the address of the rvtest_sig_begin       
+	sub t0, t0, t1 					        		// (VA-PA) Note: VA > PA 
+	add s11, x13, t0				        		// Translation of Signature reg
+
+# -------------------------Set the SATP for virtulization------------------
+
+	SATP_SETUP_RV64 (sv39)                                                  // set the SATP for virtualization
+
+# -------------------------Save area logic----------------------------------
+
+	SIGNATURE_AREA (CODE, va, pa,user)                                      // signature area for code 
+	SIGNATURE_AREA (DATA, va_data,rvtest_data,user)                         // signature area for data 
+	SIGNATURE_AREA (SIG, sig_data, signature_x13_1,user)                    // signature area for signature
+	SIGNATURE_AREA (VMEM, va_data, rvtest_data,user)                        // signature area for vmem 
+
+	sfence.vma                                                              // flush the TLB
+	RVTEST_GOTO_LOWER_MODE	Umode		                                // Switching to U mode
+
+# -------------------------virtulization enabled----------------------------------
+
+vm_en:
+	LI (a4, 0xdead)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+	nop
+	LI (t0, va_data)                                                        
+	LREG x2, 0(t0)                                                          // test the load access  (should raise an exception)
+        nop                                             
+	SREG x2, 0(t0)                                                          // test the store access (should raise an exception)
+	nop
+	LI (a4, 0xbeef)
+	RVTEST_SIGUPD(s11,a4)                                                   // Verification of virtualization enabeled
+        nop
+
+# -------------------------virtulization disabled----------------------------------
+
+	RVTEST_GOTO_MMODE		                                        // Switching back to M mode
+	addi x13,x13,REGWIDTH
+
+	LI (a4, 0x123)
+	RVTEST_SIGUPD(x13,a4)                                                   // Verification of virtualization disabled
+
+#endif
+
+ # -----------------------------------------------------------------------------
+
+RVTEST_CODE_END
+
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+        RVTEST_PTE_IDENT_MAP
+rvtest_slvl2_pg_tbl:
+        RVTEST_PTE_IDENT_MAP        
+#endif
+
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/64),4,0xdeadbeef
+
+// trap signatures initialization
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/64),4,0xcafebeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

Hello everyone,

This PR is adding a comprehensive set of self-checking assembly tests for the architectural verification of **SV39** with coverpoint defination. These tests are hand-written and follows the test plan provided in the following [testplan](https://docs.google.com/spreadsheets/d/1W6aVG9LDQXiJk5MqLOgG8Y2P_J2fqoWL7dve2IT8RV0/edit#gid=1303473646). All the tests are RISCOF compliant. I have executed these tests using `SAIL` as our reference model and `SPIKE` as the Device Under Test (DUT).
For detailed information on the code coverage and verification outcomes, please refer to the rendered report, accessible via the provided [coverage report](https://htmlpreview.github.io/?https://github.com/Ammarkhan561/riscv-ctg/blob/branch1/riscof_work/coverage.html)


I've added clear test descriptions at the beginning of each test, detailing their behavior and expected outcomes. I've also created separate commits for each test as per the test plan for better organization.

Here's an overview of the different categories covered by these tests

| Test Features                         | Test Description                                                                                                      |
|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| PMP Permissions                       | Assesses PMP permissions on both physical addresses and PTEs.                                                        |
| PTE Validity and Permissions          | Evaluates the Read/Write/Execute (RWX) permissions of PTEs with the valid bit set to 0, including reserved encodings at **`level2, level1 and level0`** PTEs, and non-leaf PTEs for **`level 0`** in both user and supervisor modes.         |
| Access on Supervisor and User Pages   | Tests access permissions for Supervisor and User mode pages in both supervisor and user privilege **`level2, level1 and level0`** PTEs.                                    |
| Executable Page Readability           | Checks the behavior of readable executable pages with different **s/mstatus.MXR** set and unset.                               |
| RWX access on U mode pages in S mode  | Examines RWX access of User mode pages in Supervisor mode with different **s/mstatus.SUM** set and unset.                      |
| Access and Dirty Bit Implementation   | Evaluates the implementation and effects of the access and dirty bits **(A and D)** on page fault exceptions.            |
| Misaligned Superpage                  | Investigates page faults for misaligned superpages at **`level 2 and level 1`** PTEs in both user and supervisor modes.                                                  |

### Important Note

These tests have been specifically designed for the RV64 architecture. However, it's important to note that by default, both `SPIKE` and `SAIL` do not support addresses greater than 32 bits. The physical address space for sv39 architecture extends up to **56 bits**. To enable support for this 56-bit address space:

- For `SPIKE`, use the `-m<size in MB>` flag in the execute command within the `riscof_spike.py` script. In the context of a 56-bit address space, set the size to **8796093022208 MB**, equivalent to **0x80000000000**, effectively encompassing the entire 56-bit memory.

- For `SAIL`, utilize the `--ram-size=<size in MB>` flag in the execute command within the `riscof_sail_cSim.py` script, again setting the size to **8796093022208 MB**.

> Ensure that this size is configured as the **starting address** in our linker file to correctly map memory for these tests.

### Related Issues

> This PR is related to SV39 Vm ACTs, as discussed in [Virtual Memory ACT](https://github.com/riscv-admin/dev-partners/issues/11) 

### Ratified/Unratified Extensions

- [x] Ratified
- [ ] Unratified

### Reference Model Used

- [x] SAIL
- [x] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [x] All tests are compliant with the test-format spec present in this repo ?
  - [x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [x] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [x] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): [Folder Link](https://drive.google.com/drive/folders/16WvWKH8oQjY45dL4NayClebl6354eP3x)
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated 
  - [x] Changelog entry created with a minor patch

### Optional Checklist:

  - [x] RISCV-V CTG PR link  : [PR#89](https://github.com/riscv-software-src/riscv-ctg/pull/89)
  - [x] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.


