### PR TITLE
Restored *64 attributes to RV_TESTCASE for 7 RV64M tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## [3.8.2.1] -- 2013-11-15
+- Restored *RV64 Check ISA attributes to RV64IM test \
+cases where they were dropped in 3.8.2.  Similar to 3.7.5
+  
 ## [3.8.2] - 2023-11-14
 - Added "most negative number divided by -1" case for RV64IM and RV32IM in remw, divw, div and rem tests
 

--- a/riscv-test-suite/rv64i_m/M/src/divu-01.S
+++ b/riscv-test-suite/rv64i_m/M/src/divu-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",divu)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*M.*);def TEST_CASE_1=True;",divu)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/M/src/mul-01.S
+++ b/riscv-test-suite/rv64i_m/M/src/mul-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",mul)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*M.*);def TEST_CASE_1=True;",mul)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/M/src/mulh-01.S
+++ b/riscv-test-suite/rv64i_m/M/src/mulh-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",mulh)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*M.*);def TEST_CASE_1=True;",mulh)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/M/src/mulhsu-01.S
+++ b/riscv-test-suite/rv64i_m/M/src/mulhsu-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",mulhsu)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*M.*);def TEST_CASE_1=True;",mulhsu)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/M/src/mulhu-01.S
+++ b/riscv-test-suite/rv64i_m/M/src/mulhu-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",mulhu)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*M.*);def TEST_CASE_1=True;",mulhu)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/M/src/rem-01.S
+++ b/riscv-test-suite/rv64i_m/M/src/rem-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",rem)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*M.*);def TEST_CASE_1=True;",rem)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/M/src/remu-01.S
+++ b/riscv-test-suite/rv64i_m/M/src/remu-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",remu)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*M.*);def TEST_CASE_1=True;",remu)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> This PR restores the *64 attribute to RV_TESTCASE for 7 RV64M tests that lost the attributed in commit 9b503d7 that was pulled yesterday.  When the *64 attributes are missing, I got the following errors while running riscof.

  ERROR | Error in test: /home/harris/cvwtest/cvw/addins/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/divu-01.S
Test Selected without the relevant extensions being available on DUT.
   ERROR | Error in test: /home/harris/cvwtest/cvw/addins/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/mul-01.S
Test Selected without the relevant extensions being available on DUT.
   ERROR | Error in test: /home/harris/cvwtest/cvw/addins/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/mulh-01.S
Test Selected without the relevant extensions being available on DUT.
   ERROR | Error in test: /home/harris/cvwtest/cvw/addins/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/mulhsu-01.S
Test Selected without the relevant extensions being available on DUT.
   ERROR | Error in test: /home/harris/cvwtest/cvw/addins/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/mulhu-01.S
Test Selected without the relevant extensions being available on DUT.
   ERROR | Error in test: /home/harris/cvwtest/cvw/addins/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/rem-01.S
Test Selected without the relevant extensions being available on DUT.
   ERROR | Error in test: /home/harris/cvwtest/cvw/addins/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/remu-01.S
Test Selected without the relevant extensions being available on DUT.

### Related Issues

> N/A

### Ratified/Unratified Extensions

- [ x] Ratified
- [ ] Unratified

### List Extensions

M extension test case

### Reference Model Used

- [ x] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [x ] All tests are compliant with the test-format spec present in this repo ?
  - [ x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ n/a] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [n/a ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [n/a ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [x ] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
