### PR TITLE
Fixed typo of regexp vs. regex in 6 rv32M test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [3.8.2.3] -- 2013-11-19
+-Fixed typo in regex in 3.8.2.2
+
 ## [3.8.2.2] -- 2013-11-17
 - Restored *RV32 Check ISA attributes to RV32IM test cases where they were dropped in 3.8.2. Missed these on 3.8.2.1.
 

--- a/riscv-test-suite/rv32i_m/M/src/divu-01.S
+++ b/riscv-test-suite/rv32i_m/M/src/divu-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 	
-RVTEST_CASE(0,"//check ISA:=regexp(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",divu) 
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",divu) 
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/M/src/mul-01.S
+++ b/riscv-test-suite/rv32i_m/M/src/mul-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regexp(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",mul)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",mul)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/M/src/mulh-01.S
+++ b/riscv-test-suite/rv32i_m/M/src/mulh-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regexp(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",mulh)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",mulh)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/M/src/mulhu-01.S
+++ b/riscv-test-suite/rv32i_m/M/src/mulhu-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regexp(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",mulhu)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",mulhu)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/M/src/rem-01.S
+++ b/riscv-test-suite/rv32i_m/M/src/rem-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regexp(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",rem)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",rem)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/M/src/remu-01.S
+++ b/riscv-test-suite/rv32i_m/M/src/remu-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regexp(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",remu)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*M.*);def TEST_CASE_1=True;",remu)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

Fixed regexp to regex in 6 rv32M test cases broken by PR411.
The original PR was tested in a different copy of the repository, and the fixes were incorrectly transcribed into the version being merged.

### Related Issues

> PR411 introduced a typo reported by Mario Hoffmann

### Ratified/Unratified Extensions

- [RV32M ] Ratified
- [ ] Unratified

### List Extensions

> RV32M

### Reference Model Used

- [ x] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [x ] All tests are compliant with the test-format spec present in this repo ?
  - [x ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [n/a ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [n/a ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [n/a ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [x ] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [y ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
