### PR TITLE
Fixed ISA fields for Zca, CMO, and rv32e rotate tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [3.8.6] -- 2013-12-24
+- Fixed check ISA fields to include 32/64 in Zca and CMO tests.  Note that the riscv-ctg CGFs have not been updated.
+- Fixed check ISA fields in rv32e_m/B/src/ror-01 and rori-01 that listed I instead of E. Again, CGF has not been updated.
+
 ## [3.8.5] -- 2013-12-23
 - Renamed rv32e_unratified to rv32e_m because the E extension has been ratified January 2023
 - Copied missing ebreak.S and ecall.S tests from rv32i_m/privilege to rv32e_m/privilege and update ISA for E

--- a/riscv-test-suite/rv32e_m/B/src/ror-01.S
+++ b/riscv-test-suite/rv32e_m/B/src/ror-01.S
@@ -32,13 +32,13 @@ RVTEST_CODE_BEGIN
 
 RVTEST_CASE(0,"//check ISA:=regex(.*E.*Zbb.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",ror)
 
-RVTEST_CASE(1,"//check ISA:=regex(.*I.*Zbkb.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",ror)
+RVTEST_CASE(1,"//check ISA:=regex(.*E.*Zbkb.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",ror)
 
-RVTEST_CASE(2,"//check ISA:=regex(.*I.*Zk.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",ror)
+RVTEST_CASE(2,"//check ISA:=regex(.*E.*Zk.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",ror)
 
-RVTEST_CASE(3,"//check ISA:=regex(.*I.*Zkn.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",ror)
+RVTEST_CASE(3,"//check ISA:=regex(.*E.*Zkn.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",ror)
 
-RVTEST_CASE(4,"//check ISA:=regex(.*I.*Zks.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",ror)
+RVTEST_CASE(4,"//check ISA:=regex(.*E.*Zks.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",ror)
 
 RVTEST_SIGBASE(x2,signature_x2_1)
 

--- a/riscv-test-suite/rv32e_m/B/src/rori-01.S
+++ b/riscv-test-suite/rv32e_m/B/src/rori-01.S
@@ -34,11 +34,11 @@ RVTEST_CASE(0,"//check ISA:=regex(.*E.*Zbb.*) ;def RVTEST_E = True;def TEST_CASE
 
 RVTEST_CASE(1,"//check ISA:=regex(.*E.*Zbkb.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",rori)
 
-RVTEST_CASE(2,"//check ISA:=regex(.*.*Zk.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",rori)
+RVTEST_CASE(2,"//check ISA:=regex(.*E.*Zk.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",rori)
 
-RVTEST_CASE(3,"//check ISA:=regex(.*I.*Zkn.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",rori)
+RVTEST_CASE(3,"//check ISA:=regex(.*E.*Zkn.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",rori)
 
-RVTEST_CASE(4,"//check ISA:=regex(.*I.*Zks.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",rori)
+RVTEST_CASE(4,"//check ISA:=regex(.*E.*Zks.*) ;def RVTEST_E = True;def TEST_CASE_1=True;",rori)
 
 RVTEST_SIGBASE(x5,signature_x5_1)
 

--- a/riscv-test-suite/rv32i_m/C/src/clbu-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/clbu-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clbu)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clbu)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/C/src/clhu-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/clhu-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clhu)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clhu)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/C/src/cmul-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/cmul-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*M.*Zca.*Zcb.*);def TEST_CASE_1=True;",cmul)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*M.*Zca.*Zcb.*);def TEST_CASE_1=True;",cmul)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/C/src/cnot-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/cnot-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",cnot)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",cnot)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/C/src/csb-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/csb-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",csb)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",csb)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/C/src/csext.b-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/csext.b-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",csext.b)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",csext.b)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/C/src/csext.h-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/csext.h-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",csext.h)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",csext.h)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/C/src/csh-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/csh-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",csh)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",csh)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/C/src/czext.b-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/czext.b-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",czext.b)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",czext.b)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/C/src/czext.h-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/czext.h-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",czext.h)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",czext.h)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/CMO/src/cbo.zero-01.S
+++ b/riscv-test-suite/rv32i_m/CMO/src/cbo.zero-01.S
@@ -16,11 +16,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // -----------
 //
-// This assembly file tests the cbo.zero instruction of the RISC-V RV32ZicbozZicsr extension for the cbozero covergroup.
+// This assembly file tests the cbo.zero instruction of the RISC-V RV32Zicboz extension for the cbozero covergroup.
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IZicbozZicsr")
+RVTEST_ISA("RV32IZicsr_Zicboz")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zicboz.*Zicsr.*);def TEST_CASE_1=True;",cbozero)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zicsr.*Zicboz.*);def TEST_CASE_1=True;",cbozero)
 
 RVTEST_SIGBASE(x2,signature_x2_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/clbu-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/clbu-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clbu)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clbu)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/clh-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/clh-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clh)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clh)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/clhu-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/clhu-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clhu)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clhu)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/cmul-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/cmul-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*M.*Zca.*Zcb.*);def TEST_CASE_1=True;",cmul)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*M.*Zca.*Zcb.*);def TEST_CASE_1=True;",cmul)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/cnot-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/cnot-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",cnot)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",cnot)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/csb-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/csb-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",csb)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",csb)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/csext.b-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/csext.b-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",csext.b)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",csext.b)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/csext.h-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/csext.h-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",csext.h)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",csext.h)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/csh-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/csh-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",csh)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",csh)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/czext.b-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/czext.b-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",czext.b)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",czext.b)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/czext.h-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/czext.h-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",czext.h)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*.Zbb.*);def TEST_CASE_1=True;",czext.h)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/C/src/czext.w-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/czext.w-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*.Zba.*);def TEST_CASE_1=True;",czext.w)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zca.*Zcb.*.Zba.*);def TEST_CASE_1=True;",czext.w)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/CMO/src/cbo.zero-01.S
+++ b/riscv-test-suite/rv64i_m/CMO/src/cbo.zero-01.S
@@ -16,11 +16,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // -----------
 //
-// This assembly file tests the cbo.zero instruction of the RISC-V RV64ZicbozZicsr extension for the cbozero covergroup.
+// This assembly file tests the cbo.zero instruction of the RISC-V RV64ZicsrZicboz extension for the cbozero covergroup.
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IZicbozZicsr")
+RVTEST_ISA("RV64IZicboz")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zicboz.*Zicsr.*);def TEST_CASE_1=True;",cbozero)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zicsr.*Zicboz.*);def TEST_CASE_1=True;",cbozero)
 
 RVTEST_SIGBASE(x3,signature_x3_1)
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Provide a detailed description of the changes performed by the PR.

Fixed ISA fields to include 32/64 in Zca and CMO tests.  
Also fixed ISA fields in rv32e_m/B/src/ror-01 and rori-01 that listed I instead of E.
Note that this fix does not change the bad riscv-ctg .CGF, so if the tests are regenerated, they will have this same bad ISA.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist
This is similar to the fixes in 410 and 411, but affects the new Zca and CMO tests as well as two EB tests.

### Ratified/Unratified Extensions

- [ x] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

Zca
CMO
EB

### Reference Model Used

- [ x] SAIL
- [ x] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ x] All tests are compliant with the test-format spec present in this repo ?
  - [ x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [n/a ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ n/a] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [n/a ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [ x] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : Added comment to open PR#22 regarding CMO.  The Zca and EB CGFs do not appear to be part of riscv-ctg yet.
  - [y ] Were the tests hand-written/modified ?
  - [ y  openhwgroup/cvw] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [n ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
