### PR TITLE
Fix building with LLVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [3.8.8] -- 2024-01-04
+- Fixed macros to allow assembling tests with LLVM.
+
 ## [3.8.7] -- 2024-01-02
 - Update satp initialization macro
 

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -574,13 +574,13 @@
 /******************************************************************************/
 
  .macro XCSR_RENAME __MODE__    // enable CSR names to be parameterized, V,S merged
-  .ifc   \__MODE__, M
+  .ifc   \__MODE__ , M
        _XCSR_RENAME_M
   .endif
-  .ifc   \__MODE__, S
+  .ifc   \__MODE__ , S
        _XCSR_RENAME_S
   .endif
-  .ifc  \__MODE__,  V
+  .ifc  \__MODE__ ,  V
        _XCSR_RENAME_S
   .endif
 .endm
@@ -593,13 +593,13 @@
 /******************************************************************************/
 
  .macro XCSR_VRENAME __MODE__   // enable CSR names to be parameterized, V,S separate 
-  .ifc   \__MODE__, M
+  .ifc   \__MODE__ , M
        _XCSR_RENAME_M
   .endif
-  .ifc   \__MODE__, S
+  .ifc   \__MODE__ , S
        _XCSR_RENAME_S
   .endif
-  .ifc  \__MODE__,  V
+  .ifc  \__MODE__ ,  V
        _XCSR_RENAME_V
   .endif
  .endm
@@ -979,10 +979,10 @@ init_\__MODE__\()scratch:
 //----------------------------------------------------------------------
 init_\__MODE__\()edeleg:
         li      T2, 0                   // save and clear edeleg so we can exit to Mmode
-.if (\__MODE__\() == V)
+.ifc \__MODE__ , V
         csrrw   T2, CSR_VEDELEG, T2     // special case: VS EDELEG available from Vmode
 .else
-  .if (\__MODE__\() == M)
+  .ifc \__MODE__ , M
     #ifdef rvtest_strap_routine
         csrrw   T2, CSR_XEDELEG, T2     // this handles M  mode save, but only if Smode exists
     #endif


### PR DESCRIPTION
## Description

Some of the string comparison modifications made by PR https://github.com/riscv-non-isa/riscv-arch-test/pull/391 to enable building the test-suite with LVM toolchains were reverted by commit https://github.com/riscv-non-isa/riscv-arch-test/commit/d885d66d4378c3d97c194d7920635026fed78bc6.  Reuse `.ifc` statements instead of `.if` ones and make spacing format consistent across the whole file. 

### Related Issues

NA

### Ratified/Unratified Extensions

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [ ] SAIL
- [X] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [X] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [X] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [X] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
