### PR TITLE
Added 32/64 to RVTEST_CASE for Zicond tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # CHANGELOG
 
-## [3.8.6] -- 2013-12-24
+## [3.8.7] -- 2024-01-12
+- Fixed Check ISA fields to include 32/64 in Zicond tests.  Note that the riscv-ctg CGFs have not been updated.
+
+## [3.8.6] -- 2023-12-24
 - Fixed check ISA fields to include 32/64 in Zca and CMO tests.  Note that the riscv-ctg CGFs have not been updated.
 - Fixed check ISA fields in rv32e_m/B/src/ror-01 and rori-01 that listed I instead of E. Again, CGF has not been updated.
 
-## [3.8.5] -- 2013-12-23
+## [3.8.5] -- 2023-12-23
 - Renamed rv32e_unratified to rv32e_m because the E extension has been ratified January 2023
 - Copied missing ebreak.S and ecall.S tests from rv32i_m/privilege to rv32e_m/privilege and update ISA for E
 

--- a/riscv-test-suite/rv32i_m/Zicond/src/czero.eqz-01.S
+++ b/riscv-test-suite/rv32i_m/Zicond/src/czero.eqz-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*Zicond.*);def TEST_CASE_1=True;",czero.eqz)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*Zicond.*);def TEST_CASE_1=True;",czero.eqz)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv32i_m/Zicond/src/czero.nez-01.S
+++ b/riscv-test-suite/rv32i_m/Zicond/src/czero.nez-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*Zicond.*);def TEST_CASE_1=True;",czero.nez)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*Zicond.*);def TEST_CASE_1=True;",czero.nez)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/Zicond/src/czero.eqz-01.S
+++ b/riscv-test-suite/rv64i_m/Zicond/src/czero.eqz-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*Zicond.*);def TEST_CASE_1=True;",czero.eqz)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*Zicond.*);def TEST_CASE_1=True;",czero.eqz)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 

--- a/riscv-test-suite/rv64i_m/Zicond/src/czero.nez-01.S
+++ b/riscv-test-suite/rv64i_m/Zicond/src/czero.nez-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*Zicond.*);def TEST_CASE_1=True;",czero.nez)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*Zicond.*);def TEST_CASE_1=True;",czero.nez)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

Added 32/64 to RVTEST_CASE for Zicond tests so riscof selects the appropriate tests for the appropriate architectures.

### Related Issues

N/A

### Ratified/Unratified Extensions

- [x ] Ratified
- [ ] Unratified

### List Extensions

Zicond

### Reference Model Used

- [x ] SAIL
- [ x] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ x] All tests are compliant with the test-format spec present in this repo ?
  - [ x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [ x] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
