### PR TITLE
Draft: Add m-mode, s-mode CLIC interrupt testcases

### DIFF
--- a/coverage/rvi_smclic.cgf
+++ b/coverage/rvi_smclic.cgf
@@ -1,0 +1,54 @@
+clicdirect-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+cliclevel-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+cliclevel-02:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+cliclevel-03:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+cliclevel-04:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+clicnomint-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 0: 0
+
+clicnomint-02:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 0: 0
+
+clicnomint-03:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 0: 0
+
+clicwfi-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+

--- a/coverage/rvi_ssclic.cgf
+++ b/coverage/rvi_ssclic.cgf
@@ -1,0 +1,96 @@
+sclicdeleg-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+sclicmdisable-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 0: 0
+
+sclicmdisable-02:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 0: 0
+
+sclicmdisable-03:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 0: 0
+
+sclicnodeleg-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+sclicorder-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+sclicorder-02:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+sclicorder-03:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+sclicorder-04:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+sclicprivorder-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+sclicprivorder-02:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+sclicprivorder-03:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+
+sclicsdisable-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 0: 0
+
+sclicsdisable-02:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 0: 0
+
+sclicsdisable-03:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 0: 0
+
+sclicwfi-01:
+  config:
+    - check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True
+  csr_comb:
+    mcause >> (xlen-1) == 1: 0
+

--- a/riscv-test-suite/rv32i_m/Smclic/src/clicdirect-01.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/clicdirect-01.S
@@ -81,7 +81,7 @@
         #define RVMODEL_INT1_EXCCODE 0x3
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -223,6 +223,9 @@ RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in t
 
     fence; // ensure memory mapped registers are setup
 
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
 location_1:
@@ -267,6 +270,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -289,6 +296,10 @@ direct_mtvec_handler:
     csrw    CSR_MINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -308,6 +319,10 @@ location_2:
     LA(     t0,finish)
     csrw  CSR_MEPC, t0
     csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -358,6 +373,10 @@ second_direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x87654321)
     csrrw  t0, CSR_MSCRATCHCSW, t0

--- a/riscv-test-suite/rv32i_m/Smclic/src/clicdirect-01.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/clicdirect-01.S
@@ -1,0 +1,577 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: trigger, clear, no retrigger of same interrupt.  Will hang if no interrupt occurs
+// - enable clicintie (default)
+
+// - generate interrupt1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - clear 1st interrupt
+
+// - generate interrupt1 again (ignored)
+
+// - set mepc to finish
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicdirect-01 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MSW_INT 
+#endif
+#ifndef RVMODEL_MINTTHRESH
+        #define RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN
+#endif
+#ifndef RVMODEL_WFI
+        #define RVMODEL_WFI inf_loop: j inf_loop;  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicdirect-01)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicdirect-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-01.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-01.S
@@ -85,7 +85,7 @@
         #define RVMODEL_INT1_EXCCODE 0x3
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -227,6 +227,9 @@ RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in t
 
     fence; // ensure memory mapped registers are setup
 
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
 location_1:
@@ -271,6 +274,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -293,6 +300,10 @@ direct_mtvec_handler:
     csrw    CSR_MINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -312,6 +323,10 @@ location_2:
     LA(     t0,finish)
     csrw  CSR_MEPC, t0
     csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -362,6 +377,10 @@ second_direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x87654321)
     csrrw  t0, CSR_MSCRATCHCSW, t0

--- a/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-01.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-01.S
@@ -1,0 +1,581 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int
+// - enable clicintie (default)
+
+// - generate interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, mnxti csrrsi updates mcause.id for 2nd interrupt
+
+// - if clicintctrl represents priority, no 2nd interrupt occurs.
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// cliclevel-01 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",cliclevel-01)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test cliclevel-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-02.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-02.S
@@ -88,7 +88,7 @@
         #define RVMODEL_INT1_EXCCODE 0x3
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -230,6 +230,9 @@ RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in t
 
     fence; // ensure memory mapped registers are setup
 
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
 location_1:
@@ -274,6 +277,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -296,6 +303,10 @@ direct_mtvec_handler:
     csrw    CSR_MINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -315,6 +326,10 @@ location_2:
     LA(     t0,finish)
     csrw  CSR_MEPC, t0
     csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -365,6 +380,10 @@ second_direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x87654321)
     csrrw  t0, CSR_MSCRATCHCSW, t0

--- a/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-02.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-02.S
@@ -1,0 +1,584 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int
+// - enable clicintie (default)
+
+// - generate interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, trigger 2nd m-mode handler
+
+// - if clicintctrl represents priority, no 2nd interrupt occurs.
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// cliclevel-02 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED
+        #define RVMODEL_MNXTI_SIMMED 0  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",cliclevel-02)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test cliclevel-02\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-03.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-03.S
@@ -1,0 +1,581 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, max level int followed by min level int
+// - enable clicintie (default)
+
+// - generate interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, 2nd interrupt is lower than current interupt level, no 2nd interrupt occurs.
+
+// - if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs. 
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// cliclevel-03 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MIN  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",cliclevel-03)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test cliclevel-03\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-03.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-03.S
@@ -85,7 +85,7 @@
         #define RVMODEL_INT1_EXCCODE 0x3
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -227,6 +227,9 @@ RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in t
 
     fence; // ensure memory mapped registers are setup
 
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
 location_1:
@@ -271,6 +274,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -293,6 +300,10 @@ direct_mtvec_handler:
     csrw    CSR_MINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -312,6 +323,10 @@ location_2:
     LA(     t0,finish)
     csrw  CSR_MEPC, t0
     csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -362,6 +377,10 @@ second_direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x87654321)
     csrrw  t0, CSR_MSCRATCHCSW, t0

--- a/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-04.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-04.S
@@ -88,7 +88,7 @@
         #define RVMODEL_INT1_EXCCODE 0x3
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -230,6 +230,9 @@ RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in t
 
     fence; // ensure memory mapped registers are setup
 
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
 location_1:
@@ -274,6 +277,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -296,6 +303,10 @@ direct_mtvec_handler:
     csrw    CSR_MINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -315,6 +326,10 @@ location_2:
     LA(     t0,finish)
     csrw  CSR_MEPC, t0
     csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -365,6 +380,10 @@ second_direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x87654321)
     csrrw  t0, CSR_MSCRATCHCSW, t0

--- a/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-04.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/cliclevel-04.S
@@ -1,0 +1,584 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int with max mintthresh setting.
+// - enable clicintie (default)
+
+// - generate interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, 2nd interrupt is higher than current interupt level but equal to mintthresh, no 2nd interrupt occurs.
+
+// - if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs.
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// cliclevel-04 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1
+        #define RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MAX  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",cliclevel-04)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test cliclevel-04\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-01.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-01.S
@@ -1,0 +1,569 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: expect interrupts will not trigger in m-mode unless mstatus.mie is set
+// - enable clicintie (default)
+
+// - generate interrupt1
+
+// - nop
+
+// - jump to finish
+
+//////////////////
+
+//////////////////
+// clicnomint-01 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE 0
+#endif
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT 
+#endif
+#ifndef RVMODEL_WFI
+        #define RVMODEL_WFI nop  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicnomint-01)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicnomint-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-01.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-01.S
@@ -73,7 +73,7 @@
         #define RVMODEL_INT1_EXCCODE 0x3
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -215,6 +215,9 @@ RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in t
 
     fence; // ensure memory mapped registers are setup
 
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
 location_1:
@@ -259,6 +262,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -281,6 +288,10 @@ direct_mtvec_handler:
     csrw    CSR_MINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -300,6 +311,10 @@ location_2:
     LA(     t0,finish)
     csrw  CSR_MEPC, t0
     csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -350,6 +365,10 @@ second_direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x87654321)
     csrrw  t0, CSR_MSCRATCHCSW, t0

--- a/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-02.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-02.S
@@ -78,7 +78,7 @@
         #define RVMODEL_INT1_EXCCODE 0x3
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -220,6 +220,9 @@ RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in t
 
     fence; // ensure memory mapped registers are setup
 
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
 location_1:
@@ -264,6 +267,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -286,6 +293,10 @@ direct_mtvec_handler:
     csrw    CSR_MINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -305,6 +316,10 @@ location_2:
     LA(     t0,finish)
     csrw  CSR_MEPC, t0
     csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -355,6 +370,10 @@ second_direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x87654321)
     csrrw  t0, CSR_MSCRATCHCSW, t0

--- a/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-02.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-02.S
@@ -1,0 +1,574 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: expect interrupts will not trigger in m-mode unless clicintie.x is set
+// - disable clicintie
+
+// - generate interrupt1
+
+// - enable mstatus.mie
+
+// - nop
+
+// - jump to finish
+
+//////////////////
+
+//////////////////
+// clicnomint-02 settings
+#ifndef RVMODEL_INT1_CLICINTIE
+        #define RVMODEL_INT1_CLICINTIE 0 
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE
+        #define RVMODEL_INT2_CLICINTIE 0 
+#endif
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT 
+#endif
+#ifndef RVMODEL_WFI
+        #define RVMODEL_WFI nop  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicnomint-02)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicnomint-02\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-03.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-03.S
@@ -75,7 +75,7 @@
         #define RVMODEL_INT1_EXCCODE 0x3
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -217,6 +217,9 @@ RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in t
 
     fence; // ensure memory mapped registers are setup
 
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
 location_1:
@@ -261,6 +264,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -283,6 +290,10 @@ direct_mtvec_handler:
     csrw    CSR_MINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -302,6 +313,10 @@ location_2:
     LA(     t0,finish)
     csrw  CSR_MEPC, t0
     csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -352,6 +367,10 @@ second_direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x87654321)
     csrrw  t0, CSR_MSCRATCHCSW, t0

--- a/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-03.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/clicnomint-03.S
@@ -1,0 +1,571 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: expect interrupts will not trigger in m-mode unless clicintctrl.x > mintthresh 
+// - enable clicintie (default)
+
+// - generate interrupt1
+
+// - enable mstatus.mie
+
+// - nop
+
+// - jump to finish
+
+//////////////////
+
+//////////////////
+// clicnomint-03 settings
+#ifndef RVMODEL_MINTTHRESH
+        #define RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MAX
+#endif
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT 
+#endif
+#ifndef RVMODEL_WFI
+        #define RVMODEL_WFI nop  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicnomint-03)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicnomint-03\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclic/src/clicwfi-01.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/clicwfi-01.S
@@ -72,7 +72,7 @@
         #define RVMODEL_INT1_EXCCODE 0x3
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -214,6 +214,9 @@ RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in t
 
     fence; // ensure memory mapped registers are setup
 
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
 location_1:
@@ -258,6 +261,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -280,6 +287,10 @@ direct_mtvec_handler:
     csrw    CSR_MINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -299,6 +310,10 @@ location_2:
     LA(     t0,finish)
     csrw  CSR_MEPC, t0
     csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -349,6 +364,10 @@ second_direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x87654321)
     csrrw  t0, CSR_MSCRATCHCSW, t0

--- a/riscv-test-suite/rv32i_m/Smclic/src/clicwfi-01.S
+++ b/riscv-test-suite/rv32i_m/Smclic/src/clicwfi-01.S
@@ -1,0 +1,568 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: expect wfi to behave like a nop when a single interrupt is pending when mstatus.mie is disabled
+// - enable clicintie (default)
+
+// - generate interrupt1
+
+// - wfi
+
+// - wakeup
+
+// - jump to finish
+
+//////////////////
+
+//////////////////
+// clicwfi-01 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE 0
+#endif
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MSW_INT
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicwfi-01)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicwfi-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclic/src/smclic.adoc
+++ b/riscv-test-suite/rv32i_m/Smclic/src/smclic.adoc
@@ -1,0 +1,218 @@
+==== clicnomint-01.S
+.Description: expect interrupts will not trigger in m-mode unless mstatus.mie is set
+- enable clicintie (default)
+- generate interrupt1
+- nop
+- jump to finish
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE = 0
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT 
+ RVMODEL_WFI = nop  
+----
+Coverage
+----
+mstatus.mie | verify no interrupt occurs in m-mode if mstatus.mie is 0
+----
+==== clicnomint-02.S
+.Description: expect interrupts will not trigger in m-mode unless clicintie.x is set
+- disable clicintie
+- generate interrupt1
+- enable mstatus.mie
+- nop
+- jump to finish
+[%autofit]
+----
+ RVMODEL_INT1_CLICINTIE = 0 
+ RVMODEL_INT2_CLICINTIE = 0 
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT 
+ RVMODEL_WFI = nop  
+----
+Coverage
+----
+clicintie[msw]    | verify no msw interrupt occurs if clicintie[msw] is 0
+clicintie[mtimer] | verify no mtimer interrupt occurs if clicintie[mtimer] is 0
+----
+==== clicnomint-03.S
+.Description: expect interrupts will not trigger in m-mode unless clicintctrl.x > mintthresh 
+- enable clicintie (default)
+- generate interrupt1
+- enable mstatus.mie
+- nop
+- jump to finish
+[%autofit]
+----
+ RVMODEL_MINTTHRESH = RVMODEL_MINTTHRESH_MAX
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT 
+ RVMODEL_WFI = nop  
+----
+Coverage
+----
+mintthresh    | verify no msw interrupt occurs if mintthresh is max
+----
+==== clicwfi-01.S
+.Description: expect wfi to behave like a nop when a single interrupt is pending when mstatus.mie is disabled
+- enable clicintie (default)
+- generate interrupt1
+- wfi
+- wakeup
+- jump to finish
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE = 0
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_INT1 = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MSW_INT
+----
+Coverage
+----
+mstatus.mie | verify no interrupt occurs in m-mode if mstatus.mie is 0
+wfi | verify wakeup/nop occurs with mstatus.mie = 0
+wfi | verify wakeup/nop occurs with pending interrupt
+----
+==== clicdirect-01.S 
+.Description: trigger, clear, no retrigger of same interrupt.  Will hang if no interrupt occurs
+- enable clicintie (default)
+- generate interrupt1
+- enable mstatus.mie
+- trigger m-mode handler
+- clear 1st interrupt
+- generate interrupt1 again (ignored)
+- set mepc to finish
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_INT1 = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MSW_INT 
+ RVMODEL_MINTTHRESH = RVMODEL_MINTTHRESH_MIN
+ RVMODEL_WFI = jump_to_self  
+----
+Coverage
+----
+mtvec.mode     | verify direct mode is used to handle interrupt
+no msip retrigger | verify after mstatus.mie is enabled in interrupt handler, msip will not retrigger because msip intlevel is not > mintstatus
+msip trigger | verify RVMODEL_SET_MSW_INT trigger
+msip clear   | verify RVMODEL_CLEAR_MSW_INT clear
+mcause       | verify machine software interrupt signature
+mstatus      | verify mstatus.mie/mpie/mpp signature in interrupt handler and after mret
+mtvec        | verify interrupt uses mtvec to calculate pc of interrupt handler (direct)
+mepc         | verify mepc location is jump_to_self location
+----
+
+==== cliclevel-01.S
+.Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int
+- enable clicintie (default)
+- generate interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, mnxti csrrsi updates mcause.id for 2nd interrupt
+- if clicintctrl represents priority, no 2nd interrupt occurs.
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MAX  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+
+==== cliclevel-02.S
+.Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int
+- enable clicintie (default)
+- generate interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, trigger 2nd m-mode handler
+- if clicintctrl represents priority, no 2nd interrupt occurs.
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_MNXTI_SIMMED = 0  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+
+==== cliclevel-03.S
+.Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, max level int followed by min level int
+- enable clicintie (default)
+- generate interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, 2nd interrupt is lower than current interupt level, no 2nd interrupt occurs.
+- if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs. 
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MIN  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+
+==== cliclevel-04.S
+.Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int with max mintthresh setting.
+- enable clicintie (default)
+- generate interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, 2nd interrupt is higher than current interupt level but equal to mintthresh, no 2nd interrupt occurs.
+- if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs.
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_MINTTHRESH_HNDLR1 = RVMODEL_MINTTHRESH_MAX  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvdirect-01.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvdirect-01.S
@@ -1,0 +1,613 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: trigger, clear, no retrigger of same interrupt.  Will hang if no interrupt occurs
+// - enable clicintie (default)
+
+// - generate shv interrupt1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - clear 1st interrupt
+
+// - generate interrupt1 again (ignored)
+
+// - set mepc to finish
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvdirect-01 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MSW_INT 
+#endif
+#ifndef RVMODEL_MINTTHRESH
+        #define RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN
+#endif
+#ifndef RVMODEL_WFI
+        #define RVMODEL_WFI inf_loop: j inf_loop;  
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC1
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC0  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvdirect-01)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvdirect-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvinhv-01.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvinhv-01.S
@@ -1,0 +1,619 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: set mepc to shv table entry, set inhv, mret
+// - enable clicintie (default)
+
+// - generate shv interrupt1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - clear 1st interrupt
+
+// - generate interrupt1 again (ignored)
+
+// - set mepc to finish
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvinhv-01 settings
+#ifndef RVMODEL_TEST_INHV
+        #define RVMODEL_TEST_INHV 0x1  
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE
+        #define RVMODEL_INT1_CLICINTIE 0x0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE
+        #define RVMODEL_INT2_CLICINTIE 0x0
+#endif
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MSW_INT 
+#endif
+#ifndef RVMODEL_MINTTHRESH
+        #define RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC1
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvinhv-01)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvinhv-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-01.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-01.S
@@ -1,0 +1,617 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int
+// - enable clicintie (default)
+
+// - generate shv interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate non-shv interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, mnxti csrrsi updates mcause.id for 2nd interrupt if non-shv
+
+// - if clicintctrl represents priority, no 2nd interrupt occurs.
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvlevel-01 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX  
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC1
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC0  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvlevel-01)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvlevel-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-02.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-02.S
@@ -1,0 +1,620 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int
+// - enable clicintie (default)
+
+// - generate shv interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate non-shv interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, trigger 2nd m-mode handler
+
+// - if clicintctrl represents priority, no 2nd interrupt occurs.
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvlevel-02 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED
+        #define RVMODEL_MNXTI_SIMMED 0  
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC1
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC0  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvlevel-02)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvlevel-02\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-03.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-03.S
@@ -1,0 +1,617 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, max level int followed by min level int
+// - enable clicintie (default)
+
+// - generate shv interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate non-shv interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, 2nd interrupt is lower than current interupt level, no 2nd interrupt occurs.
+
+// - if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs. 
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvlevel-03 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MIN  
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC1
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC0  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvlevel-03)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvlevel-03\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-04.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-04.S
@@ -1,0 +1,620 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int with max mintthresh setting.
+// - enable clicintie (default)
+
+// - generate shv interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate non-shv interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, 2nd interrupt is higher than current interupt level but equal to mintthresh, no 2nd interrupt occurs.
+
+// - if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs.
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvlevel-04 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1
+        #define RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MAX  
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC1
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC0  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvlevel-04)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvlevel-04\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-05.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-05.S
@@ -1,0 +1,617 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: same as clicshvlevel-01 but int1 is non-shv and int2 is shv
+// - enable clicintie (default)
+
+// - generate non-shv interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate shv interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, mnxti csrrsi updates mcause.id for 2nd interrupt if non-shv
+
+// - if clicintctrl represents priority, no 2nd interrupt occurs.
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvlevel-05 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX  
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC1  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvlevel-05)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvlevel-05\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-06.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-06.S
@@ -1,0 +1,620 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: same as clicshvlevel-02 but int1 is non-shv and int2 is shv
+// - enable clicintie (default)
+
+// - generate non-shv interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate shv interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, trigger 2nd m-mode handler
+
+// - if clicintctrl represents priority, no 2nd interrupt occurs.
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvlevel-06 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED
+        #define RVMODEL_MNXTI_SIMMED 0  
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC1  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvlevel-06)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvlevel-06\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-07.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-07.S
@@ -1,0 +1,617 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: same as clicshvlevel-03 but int1 is non-shv and int2 is shv
+// - enable clicintie (default)
+
+// - generate non-shv interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate shv interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, 2nd interrupt is lower than current interupt level, no 2nd interrupt occurs.
+
+// - if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs. 
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvlevel-07 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MIN  
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC1  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvlevel-07)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvlevel-07\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-08.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-08.S
@@ -1,0 +1,620 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: same as clicshvlevel-04 but int1 is non-shv and int2 is shv
+// - enable clicintie (default)
+
+// - generate non-shv interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate shv interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, 2nd interrupt is higher than current interupt level but equal to mintthresh, no 2nd interrupt occurs.
+
+// - if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs.
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvlevel-08 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1
+        #define RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MAX  
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC1  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvlevel-08)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvlevel-08\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-09.S
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/clicshvlevel-09.S
@@ -1,0 +1,617 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: same as clicshvlevel-01 but both interrupts are shv
+// - enable clicintie (default)
+
+// - generate shv interrupt 1
+
+// - enable mstatus.mie
+
+// - trigger m-mode handler
+
+// - generate shv interrupt 2 (both interrupts now pending)
+
+// - if clicintctrl represents levels, mnxti csrrsi updates mcause.id for 2nd interrupt if non-shv
+
+// - if clicintctrl represents priority, no 2nd interrupt occurs.
+
+// - set mepc to finish
+
+// - clear mstatus.mpie
+
+// - mret to finish
+
+//////////////////
+
+//////////////////
+// clicshvlevel-09 settings
+#ifndef RVMODEL_SET_INT1
+        #define RVMODEL_SET_INT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SET_INT2
+        #define RVMODEL_SET_INT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 
+#endif
+#ifndef RVMODEL_CLEAR_INT2
+        #define RVMODEL_CLEAR_INT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX  
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR
+        #define RVMODEL_INT1_CLICINTATTR 0xC1
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR
+        #define RVMODEL_INT2_CLICINTATTR 0xC1  
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_INT1_CLICINTIE    
+        #define RVMODEL_INT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT1_EXCCODE    
+        #define RVMODEL_INT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_INT1_CLICINTCTL    
+        #define RVMODEL_INT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT1_CLICINTATTR    
+        #define RVMODEL_INT1_CLICINTATTR 0xC0
+#endif
+#ifndef RVMODEL_INT2_CLICINTIE    
+        #define RVMODEL_INT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_INT2_EXCCODE    
+        #define RVMODEL_INT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_INT2_CLICINTCTL    
+        #define RVMODEL_INT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_INT2_CLICINTATTR    
+        #define RVMODEL_INT2_CLICINTATTR 0xC0
+#endif
+
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_TEST_INHV    
+        #define RVMODEL_TEST_INHV 0
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+// implementations without s-mode will not have mideleg CSR.
+// most implementations and SAIL model probably currently reset midelg to 0        
+// implementations with s-mode and mideleg.msi/mti uninitializsed or set to 1 will need to
+// initialize mideleg.msi/mti to 0        
+// e.g. #define RVMODEL_INITIALIZE_MIDELEG LI(t0,RVMODEL_SET_MIE);csrrc x0,CSR_MIDELEG,t0;
+#ifndef RVMODEL_INITIALIZE_MIDELEG  
+        #define RVMODEL_INITIALIZE_MIDELEG
+#endif
+#ifndef RVMODEL_ECALL  
+        #define RVMODEL_ECALL
+#endif
+
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1_m) // a1 will point to signature_a1_m label in the signature region - m-mode
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Smclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",clicshvlevel-09)
+    # ---------------------------------------------------------------------------------------------
+    // hook to allow implementations to setup their specific CLIC implementation
+    // e.g. (num priv modes, num interrupt levels)
+    RVMODEL_CONFIG_CLIC
+
+    LA(     t0,first_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0x55555555)
+    csrrw s2,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT1_CLICINTCTL<<24 + RVMODEL_INT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_INT2_CLICINTCTL<<24 + RVMODEL_INT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_INT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_INT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    ; // only for CLINT, for CSR_MIE, CSR_MIP, CSR_MIDELEG is inactive in CLIC mode
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_INITIALIZE_MIDELEG
+
+    RVMODEL_SET_INT1
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+location_1:
+
+    RVMODEL_WFI
+
+    LI(     t0, RVMODEL_TEST_INHV)
+    beqz t0, finish
+    LA(     t0,mtvtval)
+    csrw    CSR_MEPC, t0
+    LI(     t0,0x40000000)
+    csrrs   x0, CSR_MCAUSE, t0
+    mret
+
+    j     finish
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,first_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,second_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    LA(     t0,second_mtvtval)
+    csrw  CSR_MTVT, t0
+
+    RVMODEL_CLEAR_INT1
+    RVMODEL_SET_INT2    
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    RVMODEL_ECALL
+        
+    LI(     t0,MSTATUS_MIE )
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts in m-mode
+    ; // CLINT would nest, CLIC nests based on intstatus and intthresh
+location_2:
+        
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+    csrrci t0, CSR_MNXTI, RVMODEL_MNXTI_CIMMED
+    beqz t0, skip_normalization3
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE)
+    csrrc x0, CSR_MSTATUS, t0; // by default, clear previous global interrupts
+    LI(     t0,MSTATUS_MPP )
+    csrrs x0, CSR_MSTATUS, t0; // force return to m-mode
+    mret
+
+    .align 2
+    .global second_direct_mtvec_handler
+second_direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(     t1,location_2)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(     t1,RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(     t1,second_mtvec_handler)
+    ori t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization4
+    LA(     t1,second_mtvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x87654321)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x23456789)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_CLEAR_INT2
+    fence; // ensure memory mapped registers are setup
+
+    LA(     t0,finish)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+    .align 6
+    .global first_mtvec_handler
+first_mtvec_handler:
+    csrr  t0, CSR_MCAUSE
+    bgez  t0, finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)    
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_handler0
+mtvtval1:       .word vectored_handler1
+mtvtval2:       .word vectored_handler2
+mtvtval3:       .word vectored_handler3
+mtvtval4:       .word vectored_handler4
+mtvtval5:       .word vectored_handler5
+mtvtval6:       .word vectored_handler6
+mtvtval7:       .word vectored_handler7
+mtvtval8:       .word vectored_handler8
+mtvtval9:       .word vectored_handler9
+mtvtval10:      .word vectored_handler10
+mtvtval11:      .word vectored_handler11
+mtvtval12:      .word vectored_handler12
+mtvtval13:      .word vectored_handler13
+mtvtval14:      .word vectored_handler14
+mtvtval15:      .word vectored_handler15
+
+
+    .align 2
+vectored_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global second_mtvec_handler
+second_mtvec_handler:
+    j  second_direct_mtvec_handler   
+
+    .align 8
+    .global second_mtvtval
+second_mtvtval:        .word second_direct_mtvec_handler
+second_mtvtval1:       .word second_direct_mtvec_handler
+second_mtvtval2:       .word second_direct_mtvec_handler
+second_mtvtval3:       .word second_direct_mtvec_handler
+second_mtvtval4:       .word second_direct_mtvec_handler
+second_mtvtval5:       .word second_direct_mtvec_handler
+second_mtvtval6:       .word second_direct_mtvec_handler
+second_mtvtval7:       .word second_direct_mtvec_handler
+second_mtvtval8:       .word second_direct_mtvec_handler
+second_mtvtval9:       .word second_direct_mtvec_handler
+second_mtvtval10:      .word second_direct_mtvec_handler
+second_mtvtval11:      .word second_direct_mtvec_handler
+second_mtvtval12:      .word second_direct_mtvec_handler
+second_mtvtval13:      .word second_direct_mtvec_handler
+second_mtvtval14:      .word second_direct_mtvec_handler
+second_mtvtval15:      .word second_direct_mtvec_handler
+
+finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_MSCRATCH, s2; // restore CSR_MSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test clicshvlevel-09\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+        
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1_m:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Smclicshv/src/test_summary.adoc
+++ b/riscv-test-suite/rv32i_m/Smclicshv/src/test_summary.adoc
@@ -1,0 +1,321 @@
+==== clicshvinhv-01.S 
+.Description: set mepc to shv table entry, set inhv, mret
+- enable clicintie (default)
+- generate shv interrupt1
+- enable mstatus.mie
+- trigger m-mode handler
+- clear 1st interrupt
+- generate interrupt1 again (ignored)
+- set mepc to finish
+- mret to finish
+[%autofit]
+----
+ RVMODEL_TEST_INHV = 0x1  
+ RVMODEL_INT1_CLICINTIE = 0x0
+ RVMODEL_INT2_CLICINTIE = 0x0
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_INT1 = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MSW_INT 
+ RVMODEL_MINTTHRESH = RVMODEL_MINTTHRESH_MIN
+ RVMODEL_INT1_CLICINTATTR = 0xC1
+ RVMODEL_INT2_CLICINTATTR = 0xC0
+----
+Coverage
+----
+mtvec.mode     | verify direct mode is used to handle interrupt
+no msip retrigger | verify after mstatus.mie is enabled in interrupt handler, msip will not retrigger because msip intlevel is not > mintstatus
+msip trigger | verify RVMODEL_SET_MSW_INT trigger
+msip clear   | verify RVMODEL_CLEAR_MSW_INT clear
+mcause       | verify machine software interrupt signature
+mstatus      | verify mstatus.mie/mpie/mpp signature in interrupt handler and after mret
+mtvec        | verify interrupt uses mtvec to calculate pc of interrupt handler (direct)
+mepc         | verify mepc location is jump_to_self location
+----
+
+==== clicshvdirect-01.S 
+.Description: trigger, clear, no retrigger of same interrupt.  Will hang if no interrupt occurs
+- enable clicintie (default)
+- generate shv interrupt1
+- enable mstatus.mie
+- trigger m-mode handler
+- clear 1st interrupt
+- generate interrupt1 again (ignored)
+- set mepc to finish
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_INT1 = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MSW_INT 
+ RVMODEL_MINTTHRESH = RVMODEL_MINTTHRESH_MIN
+ RVMODEL_WFI = jump_to_self  
+ RVMODEL_INT1_CLICINTATTR = 0xC1
+ RVMODEL_INT2_CLICINTATTR = 0xC0  
+----
+Coverage
+----
+mtvec.mode     | verify direct mode is used to handle interrupt
+no msip retrigger | verify after mstatus.mie is enabled in interrupt handler, msip will not retrigger because msip intlevel is not > mintstatus
+msip trigger | verify RVMODEL_SET_MSW_INT trigger
+msip clear   | verify RVMODEL_CLEAR_MSW_INT clear
+mcause       | verify machine software interrupt signature
+mstatus      | verify mstatus.mie/mpie/mpp signature in interrupt handler and after mret
+mtvec        | verify interrupt uses mtvec to calculate pc of interrupt handler (direct)
+mepc         | verify mepc location is jump_to_self location
+----
+
+==== clicshvlevel-01.S
+.Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int
+- enable clicintie (default)
+- generate shv interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate non-shv interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, mnxti csrrsi updates mcause.id for 2nd interrupt if non-shv
+- if clicintctrl represents priority, no 2nd interrupt occurs.
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MAX  
+ RVMODEL_INT1_CLICINTATTR = 0xC1
+ RVMODEL_INT2_CLICINTATTR = 0xC0  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+
+==== clicshvlevel-02.S
+.Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int
+- enable clicintie (default)
+- generate shv interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate non-shv interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, trigger 2nd m-mode handler
+- if clicintctrl represents priority, no 2nd interrupt occurs.
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_MNXTI_SIMMED = 0  
+ RVMODEL_INT1_CLICINTATTR = 0xC1
+ RVMODEL_INT2_CLICINTATTR = 0xC0  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+
+==== clicshvlevel-03.S
+.Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, max level int followed by min level int
+- enable clicintie (default)
+- generate shv interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate non-shv interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, 2nd interrupt is lower than current interupt level, no 2nd interrupt occurs.
+- if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs. 
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MIN  
+ RVMODEL_INT1_CLICINTATTR = 0xC1
+ RVMODEL_INT2_CLICINTATTR = 0xC0  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+
+==== clicshvlevel-04.S
+.Description: verify interrupt level order, 2 interrupts asserted in 1st interrupt handler, min level int followed by max level int with max mintthresh setting.
+- enable clicintie (default)
+- generate shv interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate non-shv interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, 2nd interrupt is higher than current interupt level but equal to mintthresh, no 2nd interrupt occurs.
+- if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs.
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_MINTTHRESH_HNDLR1 = RVMODEL_MINTTHRESH_MAX  
+ RVMODEL_INT1_CLICINTATTR = 0xC1
+ RVMODEL_INT2_CLICINTATTR = 0xC0  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+==== clicshvlevel-05.S
+.Description: same as clicshvlevel-01 but int1 is non-shv and int2 is shv
+- enable clicintie (default)
+- generate non-shv interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate shv interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, mnxti csrrsi updates mcause.id for 2nd interrupt if non-shv
+- if clicintctrl represents priority, no 2nd interrupt occurs.
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MAX  
+ RVMODEL_INT1_CLICINTATTR = 0xC0
+ RVMODEL_INT2_CLICINTATTR = 0xC1  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+
+==== clicshvlevel-06.S
+.Description: same as clicshvlevel-02 but int1 is non-shv and int2 is shv
+- enable clicintie (default)
+- generate non-shv interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate shv interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, trigger 2nd m-mode handler
+- if clicintctrl represents priority, no 2nd interrupt occurs.
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_MNXTI_SIMMED = 0  
+ RVMODEL_INT1_CLICINTATTR = 0xC0
+ RVMODEL_INT2_CLICINTATTR = 0xC1  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+
+==== clicshvlevel-07.S
+.Description: same as clicshvlevel-03 but int1 is non-shv and int2 is shv
+- enable clicintie (default)
+- generate non-shv interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate shv interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, 2nd interrupt is lower than current interupt level, no 2nd interrupt occurs.
+- if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs. 
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MIN  
+ RVMODEL_INT1_CLICINTATTR = 0xC0
+ RVMODEL_INT2_CLICINTATTR = 0xC1  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+
+==== clicshvlevel-08.S
+.Description: same as clicshvlevel-04 but int1 is non-shv and int2 is shv
+- enable clicintie (default)
+- generate non-shv interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate shv interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, 2nd interrupt is higher than current interupt level but equal to mintthresh, no 2nd interrupt occurs.
+- if clicintctrl represents priority, 2nd interrupt is same level, no 2nd interrupt occurs.
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_MINTTHRESH_HNDLR1 = RVMODEL_MINTTHRESH_MAX  
+ RVMODEL_INT1_CLICINTATTR = 0xC0
+ RVMODEL_INT2_CLICINTATTR = 0xC1  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----
+==== clicshvlevel-09.S
+.Description: same as clicshvlevel-01 but both interrupts are shv
+- enable clicintie (default)
+- generate shv interrupt 1
+- enable mstatus.mie
+- trigger m-mode handler
+- generate shv interrupt 2 (both interrupts now pending)
+- if clicintctrl represents levels, mnxti csrrsi updates mcause.id for 2nd interrupt if non-shv
+- if clicintctrl represents priority, no 2nd interrupt occurs.
+- set mepc to finish
+- clear mstatus.mpie
+- mret to finish
+[%autofit]
+----
+ RVMODEL_SET_INT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_SET_INT2 = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_INT1 = <EMPTY>
+ RVMODEL_CLEAR_INT2 = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_INT1_CLICINTCTL = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_INT2_CLICINTCTL = RVMODEL_CLICINTCTL_MAX  
+ RVMODEL_INT1_CLICINTATTR = 0xC1
+ RVMODEL_INT2_CLICINTATTR = 0xC1  
+----
+Coverage
+----
+Interrupt ordering - both interrupts asserted in first interrupt handler
+----

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicdeleg-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicdeleg-01.S
@@ -84,7 +84,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -354,6 +354,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -366,6 +368,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -385,7 +388,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -417,6 +420,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -441,7 +448,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -451,6 +458,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -488,10 +499,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -499,6 +510,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -528,6 +543,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -812,7 +831,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicdeleg-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicdeleg-01.S
@@ -1,0 +1,836 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify when executing in s-mode, an s-mode interrupt will be handled when mstatus.sie is 1:
+// - generate s-mode interrupt (sint1),
+
+// - switch to s-mode,
+
+// - trigger (s-mode handler),
+
+// - clear interrupt,
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicdeleg-01 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicdeleg-01)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicdeleg-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-01.S
@@ -89,7 +89,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -359,6 +359,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -371,6 +373,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -390,7 +393,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -422,6 +425,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -446,7 +453,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -456,6 +463,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -493,10 +504,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -504,6 +515,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -533,6 +548,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -817,7 +836,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-01.S
@@ -1,0 +1,841 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify m-mode interrupt not taken in m-mode when mstatus.mie is 0
+// - generate m-mode interrupt (msw)
+
+// - stay in m-mode
+
+// - wfi
+
+// - wakeup
+
+// - jump to done
+
+// - ecall
+
+//////////////////
+
+//////////////////
+// sclicmdisable-01 settings
+#ifndef RVMODEL_SWITCH_TO_S_MODE
+        #define RVMODEL_SWITCH_TO_S_MODE 
+#endif
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE 0
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicmdisable-01)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicmdisable-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-02.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-02.S
@@ -1,0 +1,847 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify m-mode interrupt not taken in m-mode when clicintie is 0
+// - generate m-mode interrupt (msw)
+
+// - stay in m-mode
+
+// - nop
+
+// - wakeup
+
+// - jump to done
+
+// - ecall
+
+//////////////////
+
+//////////////////
+// sclicmdisable-02 settings
+#ifndef RVMODEL_WFI
+        #define RVMODEL_WFI nop
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE
+        #define RVMODEL_SWITCH_TO_S_MODE 
+#endif
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MINT1_CLICINTIE
+        #define RVMODEL_MINT1_CLICINTIE 0x0
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicmdisable-02)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicmdisable-02\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-02.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-02.S
@@ -95,7 +95,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -365,6 +365,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -377,6 +379,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -396,7 +399,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -428,6 +431,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -452,7 +459,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -462,6 +469,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -499,10 +510,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -510,6 +521,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -539,6 +554,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -823,7 +842,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-03.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-03.S
@@ -86,7 +86,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -356,6 +356,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -368,6 +370,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -387,7 +390,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -419,6 +422,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -443,7 +450,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -453,6 +460,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -490,10 +501,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -501,6 +512,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -530,6 +545,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -814,7 +833,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-03.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicmdisable-03.S
@@ -1,0 +1,838 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify s-mode interrupt not taken in m-mode
+// - generate s-mode interrupt (msw)
+
+// - stay in m-mode
+
+// - wfi
+
+// - wakeup
+
+// - jump to done
+
+// - ecall
+
+//////////////////
+
+//////////////////
+// sclicmdisable-03 settings
+#ifndef RVMODEL_SWITCH_TO_S_MODE
+        #define RVMODEL_SWITCH_TO_S_MODE 
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicmdisable-03)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicmdisable-03\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicnodeleg-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicnodeleg-01.S
@@ -1,0 +1,835 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify when executing in s-mode, the m-mode interrupt will be handled even though mstatus.mie is 0:
+// - generate m-mode interrupt (msw)
+
+// - switch to s-mode (mstatus.mie disabled),
+
+// - trigger (m-mode handler),
+
+// - clear interrupt,
+
+// - return to s-mode,
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicnodeleg-01 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE 0
+#endif
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 RVMODEL_SET_MSW_INT;
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 RVMODEL_CLEAR_MSW_INT;
+#endif
+#ifndef RVMODEL_MINTTHRESH
+        #define RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MAX
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicnodeleg-01)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicnodeleg-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicnodeleg-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicnodeleg-01.S
@@ -83,7 +83,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -353,6 +353,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -365,6 +367,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -384,7 +387,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -416,6 +419,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -440,7 +447,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -450,6 +457,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -487,10 +498,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -498,6 +509,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -527,6 +542,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -811,7 +830,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-01.S
@@ -1,0 +1,854 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify order of 2 s-mode interrupts
+// - generate 2 s-mode interrupts (msw, mtimer),
+
+// - switch to s-mode,
+
+// - trigger (s-mode handler),
+
+// - clear interrupts,
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicorder-01 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MIN  
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE
+        #define RVMODEL_SINT2_EXCCODE 0x7
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicorder-01)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicorder-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-01.S
@@ -102,7 +102,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -372,6 +372,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -384,6 +386,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -403,7 +406,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -435,6 +438,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -459,7 +466,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -469,6 +476,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -506,10 +517,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -517,6 +528,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -546,6 +561,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -830,7 +849,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-02.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-02.S
@@ -106,7 +106,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -376,6 +376,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -388,6 +390,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -407,7 +410,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -439,6 +442,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -463,7 +470,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -473,6 +480,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -510,10 +521,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -521,6 +532,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -550,6 +565,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -834,7 +853,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-02.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-02.S
@@ -1,0 +1,858 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description:
+// - generate 2 s-mode interrupts (msw, mtimer),
+
+// - switch to s-mode,
+
+// - trigger (s-mode handler),
+
+// - only sint1 is cleared,
+
+// - re-enable mstatus.sie
+
+// - trigger (go to stvec_finish, capture cause signature)
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicorder-02 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MIN  
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE
+        #define RVMODEL_SINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE
+        #define RVMODEL_CLEAR_SSTATUS_SPIE 0
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicorder-02)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicorder-02\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-03.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-03.S
@@ -109,7 +109,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -379,6 +379,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -391,6 +393,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -410,7 +413,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -442,6 +445,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -466,7 +473,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -476,6 +483,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -513,10 +524,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -524,6 +535,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -553,6 +568,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -837,7 +856,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-03.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-03.S
@@ -1,0 +1,861 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description:
+// - generate 2 s-mode interrupts (msw, mtimer),
+
+// - switch to s-mode,
+
+// - trigger (s-mode handler),
+
+// - only sint1 is cleared,
+
+// - set sintthresh
+
+// - re-enable mstatus.sie
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicorder-03 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1
+        #define RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MAX
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE
+        #define RVMODEL_SINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE
+        #define RVMODEL_CLEAR_SSTATUS_SPIE 0
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicorder-03)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicorder-03\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-04.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-04.S
@@ -106,7 +106,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -376,6 +376,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -388,6 +390,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -407,7 +410,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -439,6 +442,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -463,7 +470,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -473,6 +480,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -510,10 +521,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -521,6 +532,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -550,6 +565,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -834,7 +853,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-04.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicorder-04.S
@@ -1,0 +1,858 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description:
+// - generate 2 s-mode interrupts (msw, mtimer),
+
+// - switch to s-mode,
+
+// - trigger (s-mode handler),
+
+// - only sint2 is cleared,
+
+// - re-enable mstatus.sie
+
+// - trigger (go to stvec_finish, capture cause signature)
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicorder-04 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MIN  
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE
+        #define RVMODEL_SINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE
+        #define RVMODEL_CLEAR_SSTATUS_SPIE 0
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicorder-04)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicorder-04\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-01.S
@@ -110,7 +110,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -380,6 +380,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -392,6 +394,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -411,7 +414,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -443,6 +446,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -467,7 +474,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -477,6 +484,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -514,10 +525,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -525,6 +536,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -554,6 +569,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -838,7 +857,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-01.S
@@ -1,0 +1,862 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify m-mode interrupt is handled before s-mode interrupt
+// - generate 1 m-mode interrupt (mtimer) and 1 s-mode interrupt (msw),
+
+// - switch to s-mode,
+
+// - trigger (m-mode handler),
+
+// - clear m-mode interrupt
+
+// - return to s-mode
+
+// - trigger (s-mode handler)
+
+// - clear s-mode interrupt
+
+// - return to s-mode
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicprivorder-01 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MIN  
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicprivorder-01)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicprivorder-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-02.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-02.S
@@ -113,7 +113,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -383,6 +383,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -395,6 +397,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -414,7 +417,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -446,6 +449,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -470,7 +477,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -480,6 +487,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -517,10 +528,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -528,6 +539,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -557,6 +572,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -841,7 +860,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-02.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-02.S
@@ -1,0 +1,865 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify m-mode interrupt is handled before s-mode interrupt setting sintthresh to max
+// - generate 1 m-mode interrupt (mtimer) and 1 s-mode interrupt (msw),
+
+// - switch to s-mode,
+
+// - trigger (m-mode handler),
+
+// - clear m-mode interrupt
+
+// - return to s-mode
+
+// - trigger (s-mode handler)
+
+// - clear s-mode interrupt
+
+// - return to s-mode
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicprivorder-02 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1
+        #define RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MAX
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicprivorder-02)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicprivorder-02\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-03.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-03.S
@@ -113,7 +113,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -383,6 +383,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -395,6 +397,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -414,7 +417,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -446,6 +449,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -470,7 +477,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -480,6 +487,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -517,10 +528,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -528,6 +539,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -557,6 +572,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -841,7 +860,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-03.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicprivorder-03.S
@@ -1,0 +1,865 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify m-mode interrupt is handled before s-mode interrupt setting mintthresh to max
+// - generate 1 m-mode interrupt (mtimer) and 1 s-mode interrupt (msw),
+
+// - switch to s-mode,
+
+// - trigger (m-mode handler),
+
+// - clear m-mode interrupt
+
+// - return to s-mode
+
+// - trigger (s-mode handler)
+
+// - clear s-mode interrupt
+
+// - return to s-mode
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicprivorder-03 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 RVMODEL_SET_MTIMER_INT
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2 RVMODEL_CLEAR_MTIMER_INT
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MIN
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1
+        #define RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MAX
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicprivorder-03)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicprivorder-03\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-01.S
@@ -86,7 +86,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -356,6 +356,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -368,6 +370,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -387,7 +390,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -419,6 +422,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -443,7 +450,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -453,6 +460,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -490,10 +501,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -501,6 +512,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -530,6 +545,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -814,7 +833,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-01.S
@@ -1,0 +1,838 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify s-mode interrupt not taken in s-mode when mstatus.sie is 0
+// - generate s-mode interrupt (msw)
+
+// - switch to s-mode,
+
+// - wfi
+
+// - wakeup
+
+// - jump to done
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicsdisable-01 settings
+#ifndef RVMODEL_MSTATUS_SIE
+        #define RVMODEL_MSTATUS_SIE 0
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicsdisable-01)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicsdisable-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-02.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-02.S
@@ -90,7 +90,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -360,6 +360,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -372,6 +374,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -391,7 +394,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -423,6 +426,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -447,7 +454,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -457,6 +464,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -494,10 +505,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -505,6 +516,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -534,6 +549,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -818,7 +837,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-02.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-02.S
@@ -1,0 +1,842 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify s-mode interrupt not taken in s-mode when clcintie is 0
+// - generate s-mode interrupt (msw)
+
+// - switch to s-mode,
+
+// - nop
+
+// - jump to done
+
+// - ecall back to m-mode
+
+//////////////////
+
+//////////////////
+// sclicsdisable-02 settings
+#ifndef RVMODEL_WFI
+        #define RVMODEL_WFI nop
+#endif
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SINT1_CLICINTIE
+        #define RVMODEL_SINT1_CLICINTIE 0x0
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicsdisable-02)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicsdisable-02\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-03.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-03.S
@@ -85,7 +85,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -355,6 +355,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -367,6 +369,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -386,7 +389,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -418,6 +421,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -442,7 +449,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -452,6 +459,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -489,10 +500,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -500,6 +511,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -529,6 +544,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -813,7 +832,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-03.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicsdisable-03.S
@@ -1,0 +1,837 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: Verify s-mode interrupt not taken in m-mode when mstatus.sie is 1 (but wfi acts as nop)
+// - generate s-mode interrupt (msw)
+
+// - wfi
+
+// - wakeup
+
+// - jump to done
+
+//////////////////
+
+//////////////////
+// sclicsdisable-03 settings
+#ifndef RVMODEL_SWITCH_TO_S_MODE
+        #define RVMODEL_SWITCH_TO_S_MODE 
+#endif
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicsdisable-03)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicsdisable-03\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicwfi-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicwfi-01.S
@@ -84,7 +84,7 @@
         #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
 #endif
 #ifndef RVMODEL_CLICINTCTL_MIN    
-        #define  RVMODEL_CLICINTCTL_MIN     0x1
+        #define  RVMODEL_CLICINTCTL_MIN     0xF
 #endif
 #ifndef RVMODEL_CLICINTCTL_MAX    
         #define  RVMODEL_CLICINTCTL_MAX     0xFF
@@ -354,6 +354,8 @@ RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the s
     RVMODEL_SET_SINT2
 
     fence; // ensure memory mapped registers are setup
+    LI(     t0,MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_SPIE)
+    csrrc x0, CSR_MSTATUS, t0; // initialize mpp, mpie for deterministic signatures in tests that don't take traps
 
     LI(     t0,RVMODEL_MSTATUS_MIE)
     csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
@@ -366,6 +368,7 @@ location_1s:
 
     RVMODEL_WFI
 
+location_after_wfi:
     j     s_done
 
 
@@ -385,7 +388,7 @@ direct_mtvec_handler:
     and   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MEPC
-    LA(   t1, location_1)
+    LA(   t1, location_1s)
     sub   t0, t0, t1    
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MTVAL
@@ -417,6 +420,10 @@ direct_mtvec_handler:
     csrr  t0, CSR_MINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_MNXTI
+    beqz t0, skip_normalization1
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization1:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_MSCRATCHCSW, t0
@@ -441,7 +448,7 @@ direct_mtvec_handler:
     RVMODEL_CLEAR_MINT2
     fence; // ensure memory mapped registers are setup
         
-    LA(     t0,s_done)
+    LA(     t0,location_after_wfi)
     csrw  CSR_MEPC, t0
 
     LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
@@ -451,6 +458,10 @@ direct_mtvec_handler:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    beqz t0, skip_normalization2
+    LA(     t1,mtvtval)
+    sub   t0, t0, t1    
+skip_normalization2:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_MCAUSE
@@ -488,10 +499,10 @@ direct_stvec_handler:
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SIE
     RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVEC
     LA(   t1, direct_stvec_handler)
     ori   t1, t1, RVMODEL_STVEC_MODE
     sub   t0, t0, t1    
-    csrr  t0, CSR_STVEC
     RVTEST_SIGUPD( a1,t0)
 
     csrr  t0, CSR_SINTSTATUS
@@ -499,6 +510,10 @@ direct_stvec_handler:
     csrr  t0, CSR_SINTTHRESH
     RVTEST_SIGUPD( a1,t0)
     csrr  t0, CSR_SNXTI
+    beqz t0, skip_normalization3
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization3:
     RVTEST_SIGUPD( a1,t0)  
     LI(     t0,0x12345678)
     csrrw  t0, CSR_SSCRATCHCSW, t0
@@ -528,6 +543,10 @@ location_2s:
     csrw    CSR_SINTTHRESH, t0
         
     csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    beqz t0, skip_normalization4
+    LA(     t1,stvtval)
+    sub   t0, t0, t1    
+skip_normalization4:
     RVTEST_SIGUPD( a1,t0)
         
     csrr  t0, CSR_SCAUSE
@@ -812,7 +831,7 @@ RVTEST_DATA_END
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 signature_a1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 96*(XLEN/32),4,0xdeadbeef
 
 sig_begin_canary:
 CANARY;

--- a/riscv-test-suite/rv32i_m/Ssclic/src/sclicwfi-01.S
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/sclicwfi-01.S
@@ -1,0 +1,836 @@
+// -----------                                                   
+// Copyright (c) 2023. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause                         
+// -----------                                                   
+//                                                               
+//                                                               
+//////////////////
+// Description: expect wfi to behave like a nop when a single interrupt is pending when mstatus.mie is disabled
+// - enable clicintie (default)
+
+// - generate s-mode interrupt (msw)
+
+// - wfi
+
+// - wakeup
+
+// - jump to finish
+
+//////////////////
+
+//////////////////
+// sclicwfi-01 settings
+#ifndef RVMODEL_MSTATUS_MIE
+        #define RVMODEL_MSTATUS_MIE 0
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 RVMODEL_SET_MSW_INT
+#endif
+#ifndef RVMODEL_CLEAR_INT1
+        #define RVMODEL_CLEAR_INT1 RVMODEL_CLEAR_MSW_INT
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE
+        #define RVMODEL_SINT1_EXCCODE 0x3
+#endif
+ 
+#include "model_test.h"
+#include "arch_test.h"
+
+//////////////////
+// general defaults
+#ifndef RVMODEL_CONFIG_CLIC  
+        #define  RVMODEL_CONFIG_CLIC   
+#endif
+#ifndef RVMODEL_MCLICBASE    
+        #define  RVMODEL_MCLICBASE     0x4000000
+#endif
+#ifndef RVMODEL_MNXTI_SIMMED    
+        #define  RVMODEL_MNXTI_SIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_MNXTI_CIMMED    
+        #define  RVMODEL_MNXTI_CIMMED  MSTATUS_MIE
+#endif
+#ifndef RVMODEL_SNXTI_SIMMED    
+        #define  RVMODEL_SNXTI_SIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_SNXTI_CIMMED    
+        #define  RVMODEL_SNXTI_CIMMED  MSTATUS_SIE
+#endif
+#ifndef RVMODEL_MINTTHRESH_MIN    
+        #define  RVMODEL_MINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_MINTTHRESH_MAX    
+        #define  RVMODEL_MINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_MINTTHRESH    
+        #define  RVMODEL_MINTTHRESH RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_MINTTHRESH_HNDLR1    
+        #define  RVMODEL_MINTTHRESH_HNDLR1 RVMODEL_MINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_MIN    
+        #define  RVMODEL_SINTTHRESH_MIN     0x0
+#endif
+#ifndef RVMODEL_SINTTHRESH_MAX    
+        #define  RVMODEL_SINTTHRESH_MAX     0xFF
+#endif
+#ifndef RVMODEL_SINTTHRESH    
+        #define  RVMODEL_SINTTHRESH RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_SINTTHRESH_HNDLR1    
+        #define  RVMODEL_SINTTHRESH_HNDLR1 RVMODEL_SINTTHRESH_MIN    
+#endif
+#ifndef RVMODEL_CLICINTCTL_MIN    
+        #define  RVMODEL_CLICINTCTL_MIN     0x1
+#endif
+#ifndef RVMODEL_CLICINTCTL_MAX    
+        #define  RVMODEL_CLICINTCTL_MAX     0xFF
+#endif
+#ifndef RVMODEL_CLICINTATTR_MMODE  
+        #define  RVMODEL_CLICINTATTR_MMODE  0xC0
+#endif
+#ifndef RVMODEL_CLICINTATTR_SMODE  
+        #define  RVMODEL_CLICINTATTR_SMODE  0x40
+#endif
+
+
+#ifndef RVMODEL_MINT1_CLICINTIE    
+        #define RVMODEL_MINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT1_EXCCODE    
+        #define RVMODEL_MINT1_EXCCODE 0x3
+#endif
+#ifndef RVMODEL_MINT1_CLICINTCTL    
+        #define RVMODEL_MINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT1_CLICINTATTR    
+        #define RVMODEL_MINT1_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+#ifndef RVMODEL_MINT2_CLICINTIE    
+        #define RVMODEL_MINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_MINT2_EXCCODE    
+        #define RVMODEL_MINT2_EXCCODE 0x7
+#endif
+#ifndef RVMODEL_MINT2_CLICINTCTL    
+        #define RVMODEL_MINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_MINT2_CLICINTATTR    
+        #define RVMODEL_MINT2_CLICINTATTR RVMODEL_CLICINTATTR_MMODE
+#endif
+        
+#ifndef RVMODEL_SINT1_CLICINTIE    
+        #define RVMODEL_SINT1_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT1_EXCCODE    
+        #define RVMODEL_SINT1_EXCCODE 0x1
+#endif
+#ifndef RVMODEL_SINT1_CLICINTCTL    
+        #define RVMODEL_SINT1_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT1_CLICINTATTR    
+        #define RVMODEL_SINT1_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+#ifndef RVMODEL_SINT2_CLICINTIE    
+        #define RVMODEL_SINT2_CLICINTIE 0x1
+#endif
+#ifndef RVMODEL_SINT2_EXCCODE    
+        #define RVMODEL_SINT2_EXCCODE 0x5
+#endif
+#ifndef RVMODEL_SINT2_CLICINTCTL    
+        #define RVMODEL_SINT2_CLICINTCTL RVMODEL_CLICINTCTL_MAX
+#endif
+#ifndef RVMODEL_SINT2_CLICINTATTR    
+        #define RVMODEL_SINT2_CLICINTATTR RVMODEL_CLICINTATTR_SMODE
+#endif
+        
+#ifndef RVMODEL_WFI    
+        #define RVMODEL_WFI wfi
+#endif
+#ifndef RVMODEL_CLEAR_ALL_INTS  
+        #define RVMODEL_CLEAR_ALL_INTS \
+        RVMODEL_CLEAR_MSW_INT \
+        RVMODEL_CLEAR_MTIMER_INT  
+#endif
+
+#ifndef RVMODEL_MSTATUS_MIE    
+        #define RVMODEL_MSTATUS_MIE MSTATUS_MIE
+#endif
+// MIE_MSIE, MIE_MTIE
+#ifndef MIE_MSIE    
+        #define MIE_MSIE 0x8
+#endif
+#ifndef MIE_MTIE    
+        #define MIE_MTIE 0x80
+#endif
+#ifndef RVMODEL_SET_MIE    
+        #define RVMODEL_SET_MIE (MIE_MSIE | MIE_MTIE)
+#endif
+#ifndef RVMODEL_CLEAR_MSTATUS_MPIE    
+        #define RVMODEL_CLEAR_MSTATUS_MPIE MSTATUS_MPIE
+#endif
+#ifndef RVMODEL_MTVEC_MODE    
+        #define RVMODEL_MTVEC_MODE 0x3
+#endif
+#ifndef RVMODEL_MSTATUS_MASK   
+        #define RVMODEL_MSTATUS_MASK (MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPP)
+#endif
+#ifndef RVMODEL_MIP_MASK   
+        #define RVMODEL_MIP_MASK RVMODEL_SET_MIE
+#endif
+
+#ifndef RVMODEL_MSTATUS_SIE    
+        #define RVMODEL_MSTATUS_SIE MSTATUS_SIE
+#endif
+#ifndef SIE_SSIE    
+        #define SIE_SSIE 0x2
+#endif
+#ifndef SIE_STIE    
+        #define SIE_STIE 0x20
+#endif
+#ifndef RVMODEL_SET_SIE    
+        #define RVMODEL_SET_SIE (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_SET_SIP    
+        #define RVMODEL_SET_SIP (SIE_SSIE | SIE_STIE)
+#endif
+#ifndef RVMODEL_CLEAR_SSTATUS_SPIE    
+        #define RVMODEL_CLEAR_SSTATUS_SPIE SSTATUS_SPIE
+#endif
+#ifndef RVMODEL_STVEC_MODE    
+        #define RVMODEL_STVEC_MODE 0
+#endif
+#ifndef RVMODEL_SSTATUS_MASK   
+        #define RVMODEL_SSTATUS_MASK (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP)
+#endif
+#ifndef RVMODEL_SIP_MASK   
+        #define RVMODEL_SIP_MASK RVMODEL_SET_SIE
+#endif
+#ifndef RVMODEL_SWITCH_TO_S_MODE    
+        #define RVMODEL_SWITCH_TO_S_MODE                     \
+        LI(   t0, (MSTATUS_SPP | RVMODEL_MSTATUS_MIE << 4)); \
+        csrrs x0, CSR_MSTATUS, t0;                           \
+        sret;
+#endif
+
+#ifndef RVMODEL_SET_MINT1
+        #define RVMODEL_SET_MINT1 
+#endif
+#ifndef RVMODEL_CLEAR_MINT1
+        #define RVMODEL_CLEAR_MINT1 
+#endif
+#ifndef RVMODEL_SET_MINT2
+        #define RVMODEL_SET_MINT2 
+#endif
+#ifndef RVMODEL_CLEAR_MINT2
+        #define RVMODEL_CLEAR_MINT2  
+#endif
+#ifndef RVMODEL_SET_SINT1
+        #define RVMODEL_SET_SINT1 
+#endif
+#ifndef RVMODEL_CLEAR_SINT1
+        #define RVMODEL_CLEAR_SINT1 
+#endif
+#ifndef RVMODEL_SET_SINT2
+        #define RVMODEL_SET_SINT2 
+#endif
+#ifndef RVMODEL_CLEAR_SINT2
+        #define RVMODEL_CLEAR_SINT2 
+#endif
+        
+        
+RVTEST_ISA("RV32I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+// Add any static CLIC setup (e.g. smclicconfig extension setup) to RVMODEL_BOOT macro in model_test.h
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_SIGBASE( a1,signature_a1) // a1 will point to signature_a1 label in the signature region
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*Ssclic.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",sclicwfi-01)
+    # ---------------------------------------------------------------------------------------------
+    LA(     t0,direct_mtvec_handler)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrrw s1,CSR_MTVEC, t0   ; // mtvec used by arch_test.h, restore at end of test_case 
+
+    LA(     t0,direct_stvec_handler)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrrw s2,CSR_STVEC, t0
+
+    LI(     t0,0x55555555)
+    csrrw s3,CSR_MSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    LI(     t0,0xAAAAAAAA)
+    csrrw s4,CSR_SSCRATCH, t0 ; // mscratch used by arch_test.h, restore at end of test_case 
+
+    // make sure platform irqs, e.g. mtimer irq, is cleared before starting test
+    RVMODEL_CLEAR_ALL_INTS
+
+    LI(     t0,RVMODEL_MINTTHRESH)
+    csrw    CSR_MINTTHRESH, t0
+
+    LI(     t0,RVMODEL_SINTTHRESH)
+    csrw    CSR_SINTTHRESH, t0
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT1_CLICINTCTL<<24 + RVMODEL_MINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_MINT2_CLICINTCTL<<24 + RVMODEL_MINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_MINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_MINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT1_CLICINTCTL<<24 + RVMODEL_SINT1_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+    // program interrupt2 CLICINTCTL/CLICINTATTR values
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1000 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,((RVMODEL_SINT2_CLICINTCTL<<24 + RVMODEL_SINT2_CLICINTATTR<<16)))
+    sw t1, (t0);                                                                          
+
+    // program interrupt1 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT1_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT1_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    // program interrupt2 CLICINTIE
+    LI(     t0,(RVMODEL_MCLICBASE + 0x1001 + (RVMODEL_SINT2_EXCCODE << 2)))
+    LI(     t1,RVMODEL_SINT2_CLICINTIE)
+    sb t1, (t0);                                                                          
+
+    LA(     t0,mtvtval)
+    csrw  CSR_MTVT, t0
+
+    LA(     t0,stvtval)
+    csrw  CSR_STVT, t0
+
+    LI(     t0,0x12345678)
+    csrw    CSR_SSCRATCH, t0
+
+    LI(     t0,RVMODEL_SET_MIE)
+    csrw  CSR_MIE, t0
+
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    RVTEST_SIGUPD( a1,t0)
+
+    // setup delegation before setting sie - not used in clic, expect 0 for signature
+    csrr    t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+
+    LI(     t0,RVMODEL_SET_SIE)
+    csrw  CSR_SIE, t0
+
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    RVTEST_SIGUPD( a1,t0)
+
+    RVMODEL_SET_MINT1
+    RVMODEL_SET_MINT2
+
+    RVMODEL_SET_SINT1
+    RVMODEL_SET_SINT2
+
+    fence; // ensure memory mapped registers are setup
+
+    LI(     t0,RVMODEL_MSTATUS_MIE)
+    csrrs x0, CSR_MSTATUS, t0; // enable global interrupts
+location_1:
+
+    LA(     t0,location_1s)
+    csrw  CSR_SEPC, t0
+    RVMODEL_SWITCH_TO_S_MODE
+location_1s:
+
+    RVMODEL_WFI
+
+    j     s_done
+
+
+    .align 6
+    .global direct_mtvec_handler
+direct_mtvec_handler:
+  
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    bgez  t0, mtvec_finish ; // check for exceptions (e.g. if CLIC CSRs not implemented, jump to finish)   
+    csrr  t0, CSR_MSTATUS
+    LI(   t1, RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MEPC
+    LA(   t1, location_1)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIP
+    LI(   t1, RVMODEL_MIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MIDELEG
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MTVEC
+    LA(   t1, direct_mtvec_handler)
+    ori   t1, t1, RVMODEL_MTVEC_MODE
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_MSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_MSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_SUPERVISOR_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    csrr  t0, CSR_MCAUSE
+    LI(   t1, CAUSE_MACHINE_ECALL)
+    beq t0, t1, mtvec_finish 
+
+    LA(   t0, mtvec_finish)
+    ori t0, t0, RVMODEL_MTVEC_MODE
+    csrw  CSR_MTVEC, t0
+
+    RVMODEL_CLEAR_MINT1
+    RVMODEL_CLEAR_MINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LA(     t0,s_done)
+    csrw  CSR_MEPC, t0
+
+    LI(     t0,RVMODEL_MINTTHRESH_HNDLR1)
+    csrw    CSR_MINTTHRESH, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_MNXTI, RVMODEL_MNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_MSTATUS
+    LI(     t1,RVMODEL_MSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_MSTATUS_MPIE )
+    csrrc x0, CSR_MSTATUS, t0; // clear mstatus.mpie to disable global interrupts after mret
+    mret
+
+   .align 6
+    .global direct_stvec_handler
+direct_stvec_handler:
+  
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(   t1, RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SEPC
+    LA(   t1, location_1s)
+    sub   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_STVAL
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSCRATCH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIP
+    LI(   t1, RVMODEL_SIP_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SIE
+    RVTEST_SIGUPD( a1,t0)
+    LA(   t1, direct_stvec_handler)
+    ori   t1, t1, RVMODEL_STVEC_MODE
+    sub   t0, t0, t1    
+    csrr  t0, CSR_STVEC
+    RVTEST_SIGUPD( a1,t0)
+
+    csrr  t0, CSR_SINTSTATUS
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SINTTHRESH
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SNXTI
+    RVTEST_SIGUPD( a1,t0)  
+    LI(     t0,0x12345678)
+    csrrw  t0, CSR_SSCRATCHCSW, t0
+    RVTEST_SIGUPD( a1,t0)
+    LI(     t0,0x98765432)
+    csrrw  t0, CSR_SSCRATCHCSWL, t0
+    RVTEST_SIGUPD( a1,t0)
+
+    LA(     t0,stvec_finish)
+    ori     t0, t0, RVMODEL_STVEC_MODE
+    csrw  CSR_STVEC, t0
+
+    RVMODEL_CLEAR_SINT1
+    RVMODEL_CLEAR_SINT2
+    fence; // ensure memory mapped registers are setup
+        
+    LI(     t0,MSTATUS_SIE )
+    csrrs x0, CSR_SSTATUS, t0; // enable global interrupts in s-mode
+    ; // CLINT will nest with pending and enabled interrupts, CLIC only nests if pending interrupt > max(intstatus,intthresh)
+    ; // CLIC only nests with pending and enabled interrupt level > max(intstatus,intthresh)
+location_2s:
+        
+    LA(     t0,s_done)
+    csrw  CSR_SEPC, t0
+        
+    LI(     t0,RVMODEL_SINTTHRESH_HNDLR1)
+    csrw    CSR_SINTTHRESH, t0
+        
+    csrrsi t0, CSR_SNXTI, RVMODEL_SNXTI_SIMMED
+    RVTEST_SIGUPD( a1,t0)
+        
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+    csrr  t0, CSR_SSTATUS
+    LI(     t1,RVMODEL_SSTATUS_MASK)
+    and   t0, t0, t1    
+    RVTEST_SIGUPD( a1,t0)
+        
+    LI(     t0,RVMODEL_CLEAR_SSTATUS_SPIE)
+    csrrc x0, CSR_SSTATUS, t0; // by default, clear previous global interrupts
+    sret
+
+    .align 6
+    .global mtvtval
+mtvtval:        .word vectored_m_handler0
+mtvtval1:       .word vectored_m_handler1
+mtvtval2:       .word vectored_m_handler2
+mtvtval3:       .word vectored_m_handler3
+mtvtval4:       .word vectored_m_handler4
+mtvtval5:       .word vectored_m_handler5
+mtvtval6:       .word vectored_m_handler6
+mtvtval7:       .word vectored_m_handler7
+mtvtval8:       .word vectored_m_handler8
+mtvtval9:       .word vectored_m_handler9
+mtvtval10:      .word vectored_m_handler10
+mtvtval11:      .word vectored_m_handler11
+mtvtval12:      .word vectored_m_handler12
+mtvtval13:      .word vectored_m_handler13
+mtvtval14:      .word vectored_m_handler14
+mtvtval15:      .word vectored_m_handler15
+
+
+    .align 2
+vectored_m_handler0:
+    li t0, 0    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler1:
+    li t0, 1    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler2:
+    li t0, 2    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler3:
+    li t0, 3    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler4:
+    li t0, 4    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler5:
+    li t0, 5    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler6:
+    li t0, 6    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler7:
+    li t0, 7    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler8:
+    li t0, 8    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler9:
+    li t0, 9    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler10:
+    li t0, 10    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler11:
+    li t0, 11    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler12:
+    li t0, 12    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler13:
+    li t0, 13    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler14:
+    li t0, 14    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 2
+vectored_m_handler15:
+    li t0, 15    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_mtvec_handler   
+
+    .align 6
+    .global stvtval
+stvtval:        .word vectored_s_handler0
+stvtval1:       .word vectored_s_handler1
+stvtval2:       .word vectored_s_handler2
+stvtval3:       .word vectored_s_handler3
+stvtval4:       .word vectored_s_handler4
+stvtval5:       .word vectored_s_handler5
+stvtval6:       .word vectored_s_handler6
+stvtval7:       .word vectored_s_handler7
+stvtval8:       .word vectored_s_handler8
+stvtval9:       .word vectored_s_handler9
+stvtval10:      .word vectored_s_handler10
+stvtval11:      .word vectored_s_handler11
+stvtval12:      .word vectored_s_handler12
+stvtval13:      .word vectored_s_handler13
+stvtval14:      .word vectored_s_handler14
+stvtval15:      .word vectored_s_handler15
+
+
+    .align 6
+vectored_s_handler0:
+    li t0, 16    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler1:
+    li t0, 17    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler2:
+    li t0, 18    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler3:
+    li t0, 19    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler4:
+    li t0, 20    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler5:
+    li t0, 21    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler6:
+    li t0, 22    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler7:
+    li t0, 23    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler8:
+    li t0, 24    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler9:
+    li t0, 25    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler10:
+    li t0, 26    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler11:
+    li t0, 27    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler12:
+    li t0, 28    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler13:
+    li t0, 29    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler14:
+    li t0, 30    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+
+    .align 2
+vectored_s_handler15:
+    li t0, 31    
+    RVTEST_SIGUPD( a1,t0)
+    j  direct_stvec_handler   
+        
+    .align 6
+stvec_finish:
+    csrr  t0, CSR_SCAUSE
+    RVTEST_SIGUPD( a1,t0)
+s_done:
+    ecall    
+
+    .align 6
+mtvec_finish:
+    csrr  t0, CSR_MCAUSE
+    RVTEST_SIGUPD( a1,t0)
+m_done:
+    csrw CSR_MTVEC, s1; // restore CSR_MTVEC
+    csrw CSR_STVEC, s2; // restore CSR_STVEC
+    csrw CSR_MSCRATCH, s3; // restore CSR_MSCRATCH
+    csrw CSR_SSCRATCH, s4; // restore CSR_SSCRATCH
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test part A - test sclicwfi-01\n");
+
+    RVMODEL_IO_WRITE_STR(x30, "# Test End\n")
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+# Input data section.
+    .data
+    .align 4
+
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+signature_a1:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+sig_begin_canary:
+CANARY;
+test_A_res:
+  .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+  .fill 4, 4, 0xdeadbeef
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/rv32i_m/Ssclic/src/ssclic.adoc
+++ b/riscv-test-suite/rv32i_m/Ssclic/src/ssclic.adoc
@@ -1,0 +1,387 @@
+==== sclicnodeleg-01.S 
+.Description: Verify when executing in s-mode, the m-mode interrupt will be handled even though mstatus.mie is 0:
+- generate m-mode interrupt (msw)
+- switch to s-mode (mstatus.mie disabled),
+- trigger (m-mode handler),
+- clear interrupt,
+- return to s-mode,
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE    = 0
+ RVMODEL_SET_MINT1      = RVMODEL_SET_MSW_INT;
+ RVMODEL_CLEAR_MINT1    = RVMODEL_CLEAR_MSW_INT;
+ RVMODEL_MINTTHRESH     = RVMODEL_MINTTHRESH_MAX
+----
+Coverage
+----
+clicintattr[msw].mode == 11 | verify interrupt is handled in m-mode
+mstatus.mie=0     | verify m-mode interrupt will occur in s-mode when mstatus.mie=0
+mcause signature  | verify msw cause signature
+----
+==== sclicdeleg-01.S 
+.Description: Verify when executing in s-mode, an s-mode interrupt will be handled when mstatus.sie is 1:
+- generate s-mode interrupt (sint1),
+- switch to s-mode,
+- trigger (s-mode handler),
+- clear interrupt,
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE       = MSTATUS_SIE
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_SINT1_EXCCODE     = 0x3
+----
+Coverage
+----
+clicintattr[sint1].mode == 01          | verify interrupt is handled in s-mode
+mstatus.sie=1     | verify s-mode interrupt will occur in s-mode when mstatus.sie=1
+scause signature  | verify msw signature
+mcause signature  | verify ecall signature
+----
+==== sclicorder-01.S 
+.Description: Verify order of 2 s-mode interrupts
+- generate 2 s-mode interrupts (msw, mtimer),
+- switch to s-mode,
+- trigger (s-mode handler),
+- clear interrupts,
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE       = MSTATUS_SIE
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_SINT2_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT2         = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_SINT2       = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_SINT1_CLICINTCTL  = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_SINT2_CLICINTCTL  = RVMODEL_CLICINTCTL_MIN  
+ RVMODEL_SINT1_EXCCODE     = 0x3
+ RVMODEL_SINT2_EXCCODE     = 0x7
+----
+Coverage
+----
+scause signature  | verify priority of int1/int2
+----
+==== sclicorder-02.S 
+.Description:
+- generate 2 s-mode interrupts (msw, mtimer),
+- switch to s-mode,
+- trigger (s-mode handler),
+- only sint1 is cleared,
+- re-enable mstatus.sie
+- trigger (go to stvec_finish, capture cause signature)
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE       = MSTATUS_SIE
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_SINT2_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT2         = RVMODEL_SET_MTIMER_INT
+ RVMODEL_SINT1_CLICINTCTL  = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_SINT2_CLICINTCTL  = RVMODEL_CLICINTCTL_MIN  
+ RVMODEL_SINT1_EXCCODE     = 0x3
+ RVMODEL_SINT2_EXCCODE     = 0x7
+ RVMODEL_CLEAR_SSTATUS_SPIE = 0
+----
+Coverage - same as order-01.S except
+----
+scause 2nd signature | verify sti occurs after ssi cleared and sret
+----
+==== sclicorder-03.S 
+.Description:
+- generate 2 s-mode interrupts (msw, mtimer),
+- switch to s-mode,
+- trigger (s-mode handler),
+- only sint1 is cleared,
+- set sintthresh
+- re-enable mstatus.sie
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE       = MSTATUS_SIE
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_SINT2_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT2         = RVMODEL_SET_MTIMER_INT
+ RVMODEL_SINT1_CLICINTCTL  = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_SINT2_CLICINTCTL  = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_SINTTHRESH_HNDLR1 = RVMODEL_SINTTHRESH_MAX
+ RVMODEL_SINT1_EXCCODE     = 0x3
+ RVMODEL_SINT2_EXCCODE     = 0x7
+ RVMODEL_CLEAR_SSTATUS_SPIE = 0
+----
+Coverage - same as order-01.S except
+----
+scause 2nd signature | verify sti only occurs after ssi cleared and sret if sti level > sintthresh
+----
+==== sclicorder-04.S 
+.Description:
+- generate 2 s-mode interrupts (msw, mtimer),
+- switch to s-mode,
+- trigger (s-mode handler),
+- only sint2 is cleared,
+- re-enable mstatus.sie
+- trigger (go to stvec_finish, capture cause signature)
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE       = MSTATUS_SIE
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_SINT2_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT2         = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_SINT2       = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_SINT1_CLICINTCTL  = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_SINT2_CLICINTCTL  = RVMODEL_CLICINTCTL_MIN  
+ RVMODEL_SINT1_EXCCODE     = 0x3
+ RVMODEL_SINT2_EXCCODE     = 0x7
+ RVMODEL_CLEAR_SSTATUS_SPIE = 0
+----
+Coverage - verify uncleared ssi interrupt will retrigger after sret
+----
+scause 2nd signature | verify 2nd signature
+----
+==== sclicprivorder-01.S 
+.Description: Verify m-mode interrupt is handled before s-mode interrupt
+- generate 1 m-mode interrupt (mtimer) and 1 s-mode interrupt (msw),
+- switch to s-mode,
+- trigger (m-mode handler),
+- clear m-mode interrupt
+- return to s-mode
+- trigger (s-mode handler)
+- clear s-mode interrupt
+- return to s-mode
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE       = MSTATUS_SIE
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_MINT2_CLICINTATTR = RVMODEL_CLICINTATTR_MMODE
+ RVMODEL_SET_MINT2         = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_MINT2       = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_SINT1_CLICINTCTL  = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_MINT2_CLICINTCTL  = RVMODEL_CLICINTCTL_MIN  
+ RVMODEL_SINT1_EXCCODE     = 0x3
+ RVMODEL_MINT2_EXCCODE     = 0x7
+----
+Coverage - same as order-04.S except
+----
+mcause 1st signature | verify m-mode int 1st signature
+scause 2nd signature | verify s-mode int 2nd signature
+----
+==== sclicprivorder-02.S 
+.Description: Verify m-mode interrupt is handled before s-mode interrupt setting sintthresh to max
+- generate 1 m-mode interrupt (mtimer) and 1 s-mode interrupt (msw),
+- switch to s-mode,
+- trigger (m-mode handler),
+- clear m-mode interrupt
+- return to s-mode
+- trigger (s-mode handler)
+- clear s-mode interrupt
+- return to s-mode
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE       = MSTATUS_SIE
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_MINT2_CLICINTATTR = RVMODEL_CLICINTATTR_MMODE
+ RVMODEL_SET_MINT2         = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_MINT2       = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_SINT1_CLICINTCTL  = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_MINT2_CLICINTCTL  = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_SINTTHRESH_HNDLR1 = RVMODEL_SINTTHRESH_MAX
+ RVMODEL_SINT1_EXCCODE     = 0x3
+ RVMODEL_MINT2_EXCCODE     = 0x7
+----
+Coverage
+----
+mcause 1st signature | verify m-mode int 1st signature
+scause 2nd signature | verify s-mode int 2nd signature
+----
+==== sclicprivorder-03.S 
+.Description: Verify m-mode interrupt is handled before s-mode interrupt setting mintthresh to max
+- generate 1 m-mode interrupt (mtimer) and 1 s-mode interrupt (msw),
+- switch to s-mode,
+- trigger (m-mode handler),
+- clear m-mode interrupt
+- return to s-mode
+- trigger (s-mode handler)
+- clear s-mode interrupt
+- return to s-mode
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE       = MSTATUS_SIE
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_MINT2_CLICINTATTR = RVMODEL_CLICINTATTR_MMODE
+ RVMODEL_SET_MINT2         = RVMODEL_SET_MTIMER_INT
+ RVMODEL_CLEAR_MINT2       = RVMODEL_CLEAR_MTIMER_INT
+ RVMODEL_SINT1_CLICINTCTL  = RVMODEL_CLICINTCTL_MAX
+ RVMODEL_MINT2_CLICINTCTL  = RVMODEL_CLICINTCTL_MIN
+ RVMODEL_MINTTHRESH_HNDLR1 = RVMODEL_MINTTHRESH_MAX
+ RVMODEL_SINT1_EXCCODE     = 0x3
+ RVMODEL_MINT2_EXCCODE     = 0x7
+----
+Coverage
+----
+mcause 1st signature | verify m-mode int 1st signature
+scause 2nd signature | verify s-mode int 2nd signature
+----
+==== sclicmdisable-01.S 
+.Description: Verify m-mode interrupt not taken in m-mode when mstatus.mie is 0
+- generate m-mode interrupt (msw)
+- stay in m-mode
+- wfi
+- wakeup
+- jump to done
+- ecall
+[%autofit]
+----
+ RVMODEL_SWITCH_TO_S_MODE  = <EMPTY>
+ RVMODEL_MSTATUS_MIE       = 0
+ RVMODEL_MINT1_CLICINTATTR = RVMODEL_CLICINTATTR_MMODE
+ RVMODEL_SET_MINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_MINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_MINT1_EXCCODE     = 0x3
+----
+Coverage 
+----
+mstatus.mie  | verify no m-mode interrupt taken when in m-mode and clicintie is 0
+----
+==== sclicmdisable-02.S 
+.Description: Verify m-mode interrupt not taken in m-mode when clicintie is 0
+- generate m-mode interrupt (msw)
+- stay in m-mode
+- nop
+- wakeup
+- jump to done
+- ecall
+[%autofit]
+----
+ RVMODEL_WFI               = nop
+ RVMODEL_SWITCH_TO_S_MODE  = <EMPTY>
+ RVMODEL_MSTATUS_MIE       = MSTATUS_MIE
+ RVMODEL_MINT1_CLICINTIE   = 0x0
+ RVMODEL_MINT1_CLICINTATTR = RVMODEL_CLICINTATTR_MMODE
+ RVMODEL_SET_MINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_MINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_MINT1_EXCCODE     = 0x3
+----
+Coverage 
+----
+clicintie=0  | verify m-mode interrupt not taken when in m-mode and clicintie is 0
+----
+==== sclicmdisable-03.S 
+.Description: Verify s-mode interrupt not taken in m-mode
+- generate s-mode interrupt (msw)
+- stay in m-mode
+- wfi
+- wakeup
+- jump to done
+- ecall
+[%autofit]
+----
+ RVMODEL_SWITCH_TO_S_MODE = <EMPTY>
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_SINT1_EXCCODE     = 0x3
+----
+Coverage 
+----
+mstatus.sie=1  | verify s-mode interrupt not taken when in m-mode
+----
+==== sclicsdisable-01.S 
+.Description: Verify s-mode interrupt not taken in s-mode when mstatus.sie is 0
+- generate s-mode interrupt (msw)
+- switch to s-mode,
+- wfi
+- wakeup
+- jump to done
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_MSTATUS_SIE       = 0
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_SINT1_EXCCODE     = 0x3
+----
+Coverage 
+----
+mstatus.mie=1, mstatus.sie=0  | verify s-mode interrupt not taken when in s-mode when mstatus.sie is 0
+----
+==== sclicsdisable-02.S 
+.Description: Verify s-mode interrupt not taken in s-mode when clcintie is 0
+- generate s-mode interrupt (msw)
+- switch to s-mode,
+- nop
+- jump to done
+- ecall back to m-mode
+[%autofit]
+----
+ RVMODEL_WFI               = nop
+ RVMODEL_MSTATUS_MIE       = MSTATUS_SIE
+ RVMODEL_SINT1_CLICINTIE   = 0x0
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_SINT1_EXCCODE     = 0x3
+----
+Coverage 
+----
+sie=0  | verify s-mode interrupt not taken when in s-mode when clicintie=0
+----
+==== sclicsdisable-03.S 
+.Description: Verify s-mode interrupt not taken in m-mode when mstatus.sie is 1 (but wfi acts as nop)
+- generate s-mode interrupt (msw)
+- wfi
+- wakeup
+- jump to done
+[%autofit]
+----
+ RVMODEL_SWITCH_TO_S_MODE  = <EMPTY>
+ RVMODEL_MSTATUS_MIE       = MSTATUS_SIE
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SET_SINT1         = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_SINT1       = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_SINT1_EXCCODE     = 0x3
+----
+Coverage 
+----
+mstatus.sie=1, mstatus.sie=1  | verify s-mode interrupt not taken when in m-mode when mstatus.sie is 1
+----
+==== sclicwfi-01.S
+.Description: expect wfi to behave like a nop when a single interrupt is pending when mstatus.mie is disabled
+- enable clicintie (default)
+- generate s-mode interrupt (msw)
+- wfi
+- wakeup
+- jump to finish
+[%autofit]
+----
+ RVMODEL_MSTATUS_MIE = 0
+ RVMODEL_SET_SINT1 = RVMODEL_SET_MSW_INT
+ RVMODEL_CLEAR_INT1 = RVMODEL_CLEAR_MSW_INT
+ RVMODEL_SINT1_CLICINTATTR = RVMODEL_CLICINTATTR_SMODE
+ RVMODEL_SINT1_EXCCODE     = 0x3
+----
+Coverage
+----
+mstatus.mie | verify no interrupt occurs in m-mode if mstatus.mie is 0
+wfi | verify wakeup/nop occurs with mstatus.mie = 0
+wfi | verify wakeup/nop occurs with pending interrupt
+----


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Provide a detailed description of the changes performed by the PR.

This is a draft version of the m-mode (Smclic) and s-mode (Ssclic) CLIC interrupt testcases using clint MSW and MTIMER macros.

Note: pulls are not yet available for spike or sail that support CLIC but these testcases should help enable their development. 

This pull requires:
https://github.com/riscv-software-src/riscv-config/pull/169, 
https://github.com/riscv-software-src/riscof/pull/106
https://github.com/riscv-software-src/riscv-isa-sim/pull/1596

To include m-mode CLIC interrupt tests in riscof testlist flow, add Smclic to riscof yaml file, e.g.:
spike/spike_isa.yaml:
  ISA: RV32IMCZicsr_Zifencei_Smclic

To include s-mode CLIC interrupt tests in riscof testlist flow, add Ssclic to riscof yaml file, e.g.:
spike/spike_isa.yaml:
  ISA: RV32IMCZicsr_Zifencei_Ssclic

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist

### Ratified/Unratified Extensions

- [ ] Ratified
- [x ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

Smclic, Ssclic

### Reference Model Used

- [x ] SAIL - No CLIC implementation available yet.  Tests complete but signatures will not match with actual implementations.
- [x ] Spike - No CLIC implementation available yet.  Tests complete but signatures will not match with actual implementations.
- [x ] Other - < Dut with CLIC implemented >

### Mandatory Checklist:

  - [ x] All tests are compliant with the test-format spec present in this repo ?
  - [ x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ x] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): N/A, CLIC not implemented on SAIL or spike yet.
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated : N/A 
  - [ ] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [ ] Were the tests hand-written/modified ?
  - [X ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
