### PR TITLE
Fixed TEST_JALR_OP macro that used the LA macro in ways incompatible with GCC later than 2023-12-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [3.8.10] -- 2024-03-24
+- Updated TEST_JALR_OP in test_macros.h
+- The macro no longer works when rd = x0 in versions of GCC newer than 2023.12.20
+- riscof throws a message /home/jstine/cvw/addins/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/jalr-01.S:72: Error: illegal operands `la x0,5b'
+- The TEST_JALR_OP  macro invokes LA, which does not like x0 as an operand
+- replacing LA(rd, 5b) with auipc rd, 0 in test_macros.h solves the compiler issue and produces similar code but without a bunch of preceeding nops
+
 ## [3.8.9] -- 2024-01-12
 - Fixed Check ISA fields to include 32/64 in Zicond tests.  Note that the riscv-ctg CGFs have not been updated.
 

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -401,7 +401,7 @@
 
 #define TEST_JALR_OP(tempreg, rd, rs1, imm, swreg, offset,adj)	;\
 5:					;\
-    LA(rd,5b)				;\
+    auipc rd, 0             ;\
     .if adj & 1 == 1			;\
     LA(rs1, 3f-imm+adj-1)		;\
     jalr rd, imm+1(rs1)			;\


### PR DESCRIPTION

<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

- Updated TEST_JALR_OP in test_macros.h
- The macro no longer works when rd = x0 in versions of GCC newer than 2023.12.20
- riscof throws a message /home/jstine/cvw/addins/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/jalr-01.S:72: Error: illegal operands `la x0,5b'
- The TEST_JALR_OP  macro invokes LA, which does not like x0 as an operand in the latest GCC
- replacing LA(rd, 5b) with auipc rd, 0 in test_macros.h solves the compiler issue and produces similar code but without a bunch of preceeding nops

### Related Issues

NA

### Ratified/Unratified Extensions

- [ I ] Ratified
- [ ] Unratified

### List Extensions

I

### Reference Model Used

- [x ] SAIL
- [x ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [n/a ] All tests are compliant with the test-format spec present in this repo ?
  - [ y ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ n ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ n ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [ n ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [ y ] Changelog entry created with a minor patch

### Optional Checklist:

  - [n ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [n ] Were the tests hand-written/modified ?
  - [y ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  https://github.com/openhwgroup/cvw/pull/677/files
  - [ n ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
