### PR TITLE
Fized Zfh fcvt RVTEST_CASE macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+
+## [3.8.12] - 2024-03-26
+Corrected missing RV64 strings in RVTEST_CASE macros for Zfh fcvt.h.l and similar tests
+
 ## [3.8.11] - 2024-03-26
 - Added test suites for Zfh extensions.
 - Introduced half word and half width in Nan boxing functionality to accomdate Zfh extensions.

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.h.l_b25-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.h.l_b25-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.h.l_b25)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.h.l_b25)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.h.lu_b25-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.h.lu_b25-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.h.lu_b25)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.h.lu_b25)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b1-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b22-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b22-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b22)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b22)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b23-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b23-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b23)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b23)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b24-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b24-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b24)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b24)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b27-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b27-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b27)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b27)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b28-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b28-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b28)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b28)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b29-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.l.h_b29-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b29)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zfh.*);def TEST_CASE_1=True;",fcvt.l.h_b29)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b1-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b22-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b22-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b22)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b22)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b23-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b23-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b23)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b23)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b24-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b24-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b24)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b24)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b27-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b27-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b27)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b27)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b28-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b28-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b28)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b28)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b29-01.S
+++ b/riscv-test-suite/rv64i_m/Zfh/src/fcvt.lu.h_b29-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b29)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfh.*);def TEST_CASE_1=True;",fcvt.lu.h_b29)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Added .*RV64 to RVTEST_CASE macros for various fcvt.h.l / fcvt.l.h tests

### Related Issues

> N/A

### Ratified/Unratified Extensions

- [ x] Ratified
- [ ] Unratified

### List Extensions

> Zfh

### Reference Model Used

- [ x] SAIL
- [ x] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [x ] All tests are compliant with the test-format spec present in this repo ?
  - [ x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [x ] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [ x] Were the tests hand-written/modified ?
  - [ x] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description  CORE-V Wally
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
