### PR TITLE
Added missing .*32 in rv32i_m/C/src/clh-01.S

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [3.8.15] - 2024-04-20
+Corrected missing 32 string in RVTEST_CASE macros for Zcb rv32i_m/C/clh-01.S
+	
 ## [3.8.14] - 2024-04-16
 Add missing `Zfh` ISA in RVTEST_CASE for `Zfh` fdiv related tests
 

--- a/riscv-test-suite/rv32i_m/C/src/clh-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/clh-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clh)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zca.*Zcb.*);def TEST_CASE_1=True;",clh)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

Added missing .*32 in rv32i_m/C/src/clh-01.S
Tested on https://github.com/openhwgroup/cvw

### Related Issues

N/A

### Ratified/Unratified Extensions

- [ ] Ratified
- [x ] Unratified

### List Extensions

Zcb

### Reference Model Used

- [ x] SAIL
- [ x] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ x] All tests are compliant with the test-format spec present in this repo ?
  - [ x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [x ] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [ x] Were the tests hand-written/modified ?
  - [ x] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  -
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
