### PR TITLE
Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [3.9] - 2024-05-17
+- Cleanup: Fix RVTEST_CASE macros for Zfa tests.
+- Fix warning assembler warning message from test_macros.h
+
 ## [3.8.20] - 2024-05-08
 - Updated the Zcmop extension
 - Add Zimop extension.

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -385,7 +385,7 @@ Mend_PMP:                                    ;\
 		      .hword 0xffff         ;\
         .else				        ;\
 	        .word 0xffffffff		;\
-        .endif                      ;\    
+        .endif                      ;\
     .endr					;
 
 #define ZERO_EXTEND(__val__,__width__,__max__)	;\

--- a/riscv-test-suite/rv32i_m/D_Zfa/src/fli.d-01.S
+++ b/riscv-test-suite/rv32i_m/D_Zfa/src/fli.d-01.S
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*);def TEST_CASE_1=True;",fli.d)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*.Zfa.*);def TEST_CASE_1=True;",fli.d)
 
 // Registers with a special purpose
 #define SIG_BASEREG x1

--- a/riscv-test-suite/rv32i_m/F_Zfa/src/fli.s-01.S
+++ b/riscv-test-suite/rv32i_m/F_Zfa/src/fli.s-01.S
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*);def TEST_CASE_1=True;",fli.s)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fli.s)
 
 // Registers with a special purpose
 #define SIG_BASEREG x1

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b22-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b22-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b22)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b22)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b23-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b23-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b23)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b23)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b24-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b24-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b24)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b24)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b27-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b27-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b27)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b27)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b28-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b28-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b28)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b28)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b29-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fcvtmod.w.d_b29-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b29)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fcvtmod.w.d_b29)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fleq.d_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fleq.d_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fleq.d_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fleq.d_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fleq.d_b19-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fleq.d_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fleq.d_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fleq.d_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fleq_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fleq_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fleq_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fleq_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fleq_b19-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fleq_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fleq_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fleq_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fli.d-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fli.d-01.S
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*);def TEST_CASE_1=True;",fli.d)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fli.d)
 
 // Registers with a special purpose
 #define SIG_BASEREG x1

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fltq.d_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fltq.d_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fltq.d_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fltq.d_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fltq.d_b19-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fltq.d_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fltq.d_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fltq.d_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fltq_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fltq_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fltq_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fltq_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fltq_b19-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fltq_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fltq_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fltq_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fmaxm.d_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fmaxm.d_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fmaxm.d_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fmaxm.d_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fmaxm.d_b19-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fmaxm.d_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fmaxm.d_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fmaxm.d_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fmaxm_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fmaxm_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fmaxm_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fmaxm_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fmaxm_b19-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fmaxm_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fmaxm_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fmaxm_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fminm.d_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fminm.d_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fminm.d_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fminm.d_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fminm.d_b19-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fminm.d_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fminm.d_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fminm.d_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fminm_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fminm_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fminm_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fminm_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fminm_b19-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fminm_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fminm_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fminm_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fround.d_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fround.d_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fround.d_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fround.d_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fround_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fround_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fround_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fround_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/froundnx.d_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/froundnx.d_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",froundnx.d_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",froundnx.d_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zfa/src/froundnx_b1-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/froundnx_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",froundnx_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",froundnx_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fleq_b1-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fleq_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fleq_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fleq_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fleq_b19-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fleq_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fleq_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fleq_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fli.s-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fli.s-01.S
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*);def TEST_CASE_1=True;",fli.s)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fli.s)
 
 // Registers with a special purpose
 #define SIG_BASEREG x1

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fltq_b1-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fltq_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fltq_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fltq_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fltq_b19-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fltq_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fltq_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fltq_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fmaxm_b1-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fmaxm_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fmaxm_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fmaxm_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fmaxm_b19-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fmaxm_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fmaxm_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fmaxm_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fminm_b1-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fminm_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fminm_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fminm_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fminm_b19-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fminm_b19-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fminm_b19)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fminm_b19)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fround_b1-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fround_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fround_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fround_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/froundnx_b1-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/froundnx_b1-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",froundnx_b1)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",froundnx_b1)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY THE DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

- fli.* tests got selected by the RISCOF even if `zfa` extension is not included in the ISA string in yaml configuration file. RVTEST_CASE macro is updated to check for `zfa` extension in the ISA string to select the test.
- If DUT is configured for RV32, RISCOF tries to select and throws an error for most of `rv64i_m/D_Zfa` and `rv64i_m/F_zfa` tests that says `tests selected without enabling the appropriate extensions`. These tests are for RV64 - hence RVTEST_CASE macro is updated to check for RV64 in ISA string to select these tests.
- Empty in one of the macros inside test_macros.h results in scary assembler warnings. so removed those spaces.

:warning: It is important to note that the fixes in RVTEST_CASE macro for Zfa tests are not pulled in the corresponding cgf files. If the tests are generated from these GCF files again, they will have the same issues again. The best is to fix those cgf files or there should be an issue with open tracking (but I'm not sure where, either in riscv-arch-test or riscv-ctg?)

