### PR TITLE
Add misaligned c.jalr and c.jr instruction test

### DIFF
--- a/coverage/rvi_priv.cgf
+++ b/coverage/rvi_priv.cgf
@@ -128,6 +128,22 @@ misalign1-jalr:
     'imm_val%2 == 1 and ea_align == 1': 0
     'imm_val%2 == 0 and ea_align == 1': 0
 
+misalign1-cjalr:
+  config: 
+    - check ISA:=regex(.*I.*C.*); def rvtest_mtrap_routine=True
+  mnemonics:
+    c.jalr: 0
+  val_comb:
+    'ea_align == 1': 0
+
+misalign1-cjr:
+  config: 
+    - check ISA:=regex(.*I.*C.*); def rvtest_mtrap_routine=True
+  mnemonics:
+    c.jr: 0
+  val_comb:
+    'ea_align == 1': 0
+
 misalign-jal:
   config:
     - check ISA:=regex(.*I.*C.*)

--- a/riscv-test-suite/rv32e_m/C/src/misalign1-cjalr-01.S
+++ b/riscv-test-suite/rv32e_m/C/src/misalign1-cjalr-01.S
@@ -1,0 +1,92 @@
+// -----------
+// Copyright (c) 2020. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// -----------
+//
+// This assembly file tests the misaligned c.jalr instruction of the RISC-V C extension.
+//
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV32EC")
+
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*E.*C.*);def RVTEST_E = True;def TEST_CASE_1=True;",misalign1-cjalr)
+
+RVTEST_SIGBASE( x10,signature_x10_1)
+
+// ea_align == 1,
+// opcode: jalr; op1:x6; align:1
+// TEST_CJALR_OP(x11, x6, x10, 0)
+5:					;
+    LA(x6, 3f+1)				;
+					;
+2:  c.jalr x6				;
+    xori x1,x1, 0x2			;
+    j 4f				;
+					;
+3:  xori x1,x1, 0x3			;
+					;
+4: LA(x11, 5b)			;
+   andi x11,x11,~(3)		;
+    sub x1,x1,x11			;
+    RVTEST_SIGUPD(x10,x1,0)
+
+#endif
+
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+.align 4
+
+rvtest_data:
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+RVTEST_DATA_END
+
+
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+
+signature_x10_1:
+    .fill 0*(XLEN/32),4,0xdeadbeef
+
+
+signature_x1_1:
+    .fill 1*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+
+gpr_save:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv32e_m/C/src/misalign1-cjr-01.S
+++ b/riscv-test-suite/rv32e_m/C/src/misalign1-cjr-01.S
@@ -1,0 +1,92 @@
+// -----------
+// Copyright (c) 2020. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// -----------
+//
+// This assembly file tests the misaligned c.jr instruction of the RISC-V C extension.
+//
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV32EC")
+
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*E.*C.*);def RVTEST_E = True;def TEST_CASE_1=True;",cjr)
+
+RVTEST_SIGBASE( x10,signature_x10_1)
+
+// ea_align == 1,
+// opcode: jr; op1:x6; align:1
+// TEST_CJR_OP(x11, x6, x10, 0)
+5:					;
+    LA(x6, 3f+1)				;
+					;
+2:  c.jr x6				;
+    xori x6,x6, 0x2			;
+    j 4f				;
+					;
+3:  xori x6,x6, 0x3			;
+					;
+4: LA(x11, 5b)			;
+   andi x11,x11,~(3)		;
+    sub x6,x6,x11			;
+    RVTEST_SIGUPD(x10,x6,0)
+
+#endif
+
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+.align 4
+
+rvtest_data:
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+RVTEST_DATA_END
+
+
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+
+signature_x10_1:
+    .fill 0*(XLEN/32),4,0xdeadbeef
+
+
+signature_x1_1:
+    .fill 1*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+
+gpr_save:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv32i_m/C/src/misalign1-cjalr-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/misalign1-cjalr-01.S
@@ -1,0 +1,92 @@
+// -----------
+// Copyright (c) 2020. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// -----------
+//
+// This assembly file tests the misaligned c.jalr instruction of the RISC-V C extension.
+//
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV32IC")
+
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*C.*);def TEST_CASE_1=True;",misalign1-cjalr)
+
+RVTEST_SIGBASE( x10,signature_x10_1)
+
+// ea_align == 1,
+// opcode: jalr; op1:x17; align:1
+// TEST_CJALR_OP(x12, x17, x10, 0)
+5:					;
+    LA(x17, 3f+1)				;
+					;
+2:  c.jalr x17				;
+    xori x1,x1, 0x2			;
+    j 4f				;
+					;
+3:  xori x1,x1, 0x3			;
+					;
+4: LA(x12, 5b)			;
+   andi x12,x12,~(3)		;
+    sub x1,x1,x12			;
+    RVTEST_SIGUPD(x10,x1,0)
+
+#endif
+
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+.align 4
+
+rvtest_data:
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+RVTEST_DATA_END
+
+
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+
+signature_x10_1:
+    .fill 0*(XLEN/32),4,0xdeadbeef
+
+
+signature_x1_1:
+    .fill 1*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+
+gpr_save:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv32i_m/C/src/misalign1-cjr-01.S
+++ b/riscv-test-suite/rv32i_m/C/src/misalign1-cjr-01.S
@@ -1,0 +1,92 @@
+// -----------
+// Copyright (c) 2020. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// -----------
+//
+// This assembly file tests the misaligned c.jr instruction of the RISC-V C extension.
+//
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV32IC")
+
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*C.*);def TEST_CASE_1=True;",misalign1-cjr)
+
+RVTEST_SIGBASE( x10,signature_x10_1)
+
+// ea_align == 1,
+// opcode: jalr; op1:x17; align:1
+// inline TEST_CJR_OP(x12, x17, x10, 0)
+5:					;
+    LA(x17, 3f+1)				;
+					;
+2:  c.jr x17				;
+    xori x17,x17, 0x2			;
+    j 4f				;
+					;
+3:  xori x17,x17, 0x3			;
+					;
+4: LA(x12, 5b)			;
+   andi x12,x12,~(3)		;
+    sub x17,x17,x12			;
+    RVTEST_SIGUPD(x10,x17,0)
+
+#endif
+
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+.align 4
+
+rvtest_data:
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+RVTEST_DATA_END
+
+
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+
+signature_x10_1:
+    .fill 0*(XLEN/32),4,0xdeadbeef
+
+
+signature_x1_1:
+    .fill 1*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+
+gpr_save:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/C/src/misalign1-cjalr-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/misalign1-cjalr-01.S
@@ -1,0 +1,92 @@
+// -----------
+// Copyright (c) 2020. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// -----------
+//
+// This assembly file tests the misaligned c.jalr instruction of the RISC-V C extension.
+//
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV64IC")
+
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*);check ISA:=regex(.*I.*C.*);def TEST_CASE_1=True;",misalign1-cjalr)
+
+RVTEST_SIGBASE( x10,signature_x10_1)
+
+// ea_align == 1,
+// opcode: c.jalr; op1:x17; align:1
+// TEST_CJALR_OP(x12, x17, x10, 0)
+5:					;
+    LA(x17, 3f+1)				;
+					;
+2:  c.jalr x17				;
+    xori x1,x1, 0x2			;
+    j 4f				;
+					;
+3:  xori x1,x1, 0x3			;
+					;
+4: LA(x12, 5b)			;
+   andi x12,x12,~(3)		;
+    sub x1,x1,x12			;
+    RVTEST_SIGUPD(x10,x1,0)
+
+#endif
+
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+.align 4
+
+rvtest_data:
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+RVTEST_DATA_END
+
+
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+
+signature_x10_1:
+    .fill 0*(XLEN/32),4,0xdeadbeef
+
+
+signature_x1_1:
+    .fill 1*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+
+gpr_save:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/C/src/misalign1-cjr-01.S
+++ b/riscv-test-suite/rv64i_m/C/src/misalign1-cjr-01.S
@@ -1,0 +1,91 @@
+// -----------
+// Copyright (c) 2020. RISC-V International. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// -----------
+//
+// This assembly file tests the misaligned c.jr instruction of the RISC-V C extension.
+//
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV64IC")
+
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*);check ISA:=regex(.*I.*C.*);def TEST_CASE_1=True;",misalign1-cjr)
+
+RVTEST_SIGBASE( x10,signature_x10_1)
+
+// ea_align == 1,
+// opcode: c.jr; op1:x17; align:1
+// inline TEST_CJR_OP(x12, x17, x10, 0)
+5:					;
+    LA(x17, 3f+1)				;
+					;\
+2:  c.jr x17				;
+    xori x17,x17, 0x2			;
+    j 4f				;
+					;
+3:  xori x17,x17, 0x3			;
+					;
+4: LA(x12, 5b)			;
+   andi x12,x12,~(3)		;
+    sub x17,x17,x12			;
+    RVTEST_SIGUPD(x10,x17,0)
+#endif
+
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+.align 4
+
+rvtest_data:
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+RVTEST_DATA_END
+
+
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+
+signature_x10_1:
+    .fill 0*(XLEN/32),4,0xdeadbeef
+
+
+signature_x1_1:
+    .fill 1*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+
+gpr_save:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END


### PR DESCRIPTION
## Description

This PR added the additional test case for c.jalr and c.jr with the misaligned address in the register to verify the implementation.

### Related Issues

NA

### Ratified/Unratified Extensions

- [x] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [X] SAIL
- [X] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [X] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [X] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [ ] Changelog entry created with a minor patch

### Optional Checklist:

  - [X] RISCV-V CTG PR link if tests were generated using it : https://github.com/riscv-software-src/riscv-ctg/pull/116
  - [X] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
