### PR TITLE
ci: add ci test for run ACT on sail and Spike

### DIFF
--- a/.github/isa_templates/RV32IFZicsr.yaml
+++ b/.github/isa_templates/RV32IFZicsr.yaml
@@ -1,0 +1,29 @@
+hart_ids: [0]
+hart0:
+  ISA: RV32IFZicsr
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [32]
+  misa:
+   reset-val: 0x40000120
+   rv32:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x1]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x0000120, 0x0000000]
+              wr_illegal:
+                - Unchanged
+ 

--- a/.github/isa_templates/RV32IMCZicsr_Zifencei.yaml
+++ b/.github/isa_templates/RV32IMCZicsr_Zifencei.yaml
@@ -1,0 +1,29 @@
+hart_ids: [0]
+hart0:
+  ISA: RV32IMCZicsr_Zifencei
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [32]
+  misa:
+   reset-val: 0x40001104
+   rv32:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x1]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x0001104, 0x0000000]
+              wr_illegal:
+                - Unchanged
+ 

--- a/.github/isa_templates/RV32IZba_Zbb_Zbc_Zbs.yaml
+++ b/.github/isa_templates/RV32IZba_Zbb_Zbc_Zbs.yaml
@@ -1,0 +1,29 @@
+hart_ids: [0]
+hart0:
+  ISA: RV32IZba_Zbb_Zbc_Zbs
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [32]
+  misa:
+   reset-val: 0x40000100
+   rv32:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x1]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x0000100, 0x0000000]
+              wr_illegal:
+                - Unchanged
+ 

--- a/.github/isa_templates/RV64IFZicsr.yaml
+++ b/.github/isa_templates/RV64IFZicsr.yaml
@@ -1,0 +1,29 @@
+hart_ids: [0]
+hart0:
+  ISA: RV64IFZicsr
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [64]
+  misa:
+   reset-val: 0x8000000000000120
+   rv64:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x2]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x0000120, 0x0000000]
+              wr_illegal:
+                - Unchanged
+ 

--- a/.github/isa_templates/RV64IMCZicsr_Zifencei.yaml
+++ b/.github/isa_templates/RV64IMCZicsr_Zifencei.yaml
@@ -1,0 +1,29 @@
+hart_ids: [0]
+hart0:
+  ISA: RV64IMCZicsr_Zifencei
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [64]
+  misa:
+   reset-val: 0x8000000000001104
+   rv64:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x2]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x0001104, 0x0000000]
+              wr_illegal:
+                - Unchanged
+ 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,35 +1,52 @@
 # This is a basic workflow to help you get started with Actions
 
-name: test
+name: CI test
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  pull_request:
-    branches: [ main ]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Triggers the workflow on pull request events but only for the main & dev branch
+  pull_request:
+    branches: [ main , dev ]
+  
+  # Triggers the workflow on push events
+  push:
+    branches: [ main , dev ]
+
+  # Allows you to run this workflow Actions manually
   workflow_dispatch:
+
+   # Triggers the action 2am every day
+  schedule:
+    - cron: "0 2 * * *"
+
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  check-version:
+
+  ACT-sail-spike:
     runs-on: ubuntu-latest
+    container: ghcr.io/riscv-software-src/riscof/act:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        isa_group: 
+          - RV32IMCZicsr_Zifencei
+          - RV64IMCZicsr_Zifencei
+
+
     steps:
-      - uses: actions/checkout@v2
-      
-      - uses: actions-ecosystem/action-get-latest-tag@v1
-        id: get-latest-tag
-      
-      - name: version check
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Config riscof
         run: |
-          export CHNGVER=$(grep -P -o '(?<=## \[).*(?=\])' -m1 CHANGELOG.md); 
-          echo "CHANGELOG VERSION: $CHNGVER"
-          export TAGVER=${{ steps.get-latest-tag.outputs.tag }}; 
-          echo "TAG VERSION: $TAGVER"
-          if [ "$CHNGVER" = "$TAGVER" ]; then
-              echo "No changelog update."
-              exit 1
-          else
-              echo "Changelog updated."
-          fi
+          git config --global --add safe.directory '*'
+          riscof setup --dutname=spike
+          cp .github/isa_templates/${{ matrix.isa_group }}.yaml spike/spike_isa.yaml
+
+
+      - name: Run riscof
+        run: |
+          riscof --verbose debug run --suite . --env ./riscv-test-suite/env


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

This PR update Github Action CI to the `riscv-arch-test`
- CI will run on both `dev` brand or `main` branch, when there is PR against it (pull request event)
- CI will also run when there is code been merged into those 2 branches
- Current test runs on Sail model against spike model, and runs on `RV32IMCZicsr` and `RV64IMCZicsr`   
- This PR did change any existing test cases.
- Model test covering other riscv extensions will be added

------------
### Related Issues

No

------------

### Ratified/Unratified Extensions

Not applicable 

------------


### Reference Model Used

- [x] SAIL
- [x] Spike

------------

### Mandatory Checklist:

  - [x] All tests are compliant with the test-format spec present in this repo ?
  - [x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - ~[ ] Ran the new tests on RISCOF in [coverage mode]~(https://riscof.readthedocs.io/en/stable/commands.html#coverage)~
  - ~[ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >~
  - ~[ ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE >~
  - ~[ ] Changelog entry created with a minor patch~

------------

### Optional Checklist:

  - ~[ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >~
  - ~[ ] Were the tests hand-written/modified ?~
  - ~[ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description~
  - ~[ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.~
