### PR TITLE
Fixed reversed order of Zicboz and Zicsr in macros for cbo.zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+
+## [3.9.2] - 2024-06-11
+- Fixed reversed order of zicboz and Zicsr in cbo.zero RVTEST_ISA/RVTET_CASE strings.  Note that Sail does not yet handle cbo.zero
+	
 ## [3.9.1] - 2024-05-24
 - Split rv32i_m/F/fnmadd_b15.S, fnmsub_b15.S, fmadd_b15.S, fmsub_b15.S into multiple smaller tests
 - Split each _b15 file into 50 files consists of 768 (128*6) tests

--- a/riscv-test-suite/rv32i_m/CMO/src/cbo.zero-01.S
+++ b/riscv-test-suite/rv32i_m/CMO/src/cbo.zero-01.S
@@ -20,7 +20,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IZicsr_Zicboz")
+RVTEST_ISA("RV32IZicboz_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zicsr.*Zicboz.*);def TEST_CASE_1=True;",cbozero)
+RVTEST_CASE(0,"//check ISA:=regex(.*32.*I.*Zicboz.*Zicsr.*);def TEST_CASE_1=True;",cbozero)
 
 RVTEST_SIGBASE(x2,signature_x2_1)
 

--- a/riscv-test-suite/rv64i_m/CMO/src/cbo.zero-01.S
+++ b/riscv-test-suite/rv64i_m/CMO/src/cbo.zero-01.S
@@ -20,7 +20,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IZicboz")
+RVTEST_ISA("RV64IZicboz_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv64i_m/CMO/src/cbo.zero-01.S
+++ b/riscv-test-suite/rv64i_m/CMO/src/cbo.zero-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zicsr.*Zicboz.*);def TEST_CASE_1=True;",cbozero)
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*I.*Zicboz.*Zicsr.*);def TEST_CASE_1=True;",cbozero)
 
 RVTEST_SIGBASE(x3,signature_x3_1)
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Provide a detailed description of the changes performed by the PR.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist

### Ratified/Unratified Extensions

- [x] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [ ] SAIL
- [x] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [x] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
