### PR TITLE
remove duplicate RVMODEL_BOOT macro

### DIFF
--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -1878,6 +1878,7 @@ rvtest_\__MODE__\()end:
 rvtest_init:                            //instantiate prologs here
   INSTANTIATE_MODE_MACRO RVTEST_TRAP_PROLOG
 rvtest_entrypoint:
+// RVMODEL_BOOT                        // Commenting this one as temporary fix
   RVTEST_INIT_GPRS                      // 0xF0E1D2C3B4A59687
 rvtest_code_begin:
  .option pop

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -1878,7 +1878,6 @@ rvtest_\__MODE__\()end:
 rvtest_init:                            //instantiate prologs here
   INSTANTIATE_MODE_MACRO RVTEST_TRAP_PROLOG
 rvtest_entrypoint:
-  RVMODEL_BOOT
   RVTEST_INIT_GPRS                      // 0xF0E1D2C3B4A59687
 rvtest_code_begin:
  .option pop


### PR DESCRIPTION
This was causing compile of test suites to crash

<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description
Removed RVMODEL_BOOT from arch_test.h  -- This macro is already included in all of the test code (.S) files,
NOTE: Current repo from RVI is not usable and crashes during compile of the test code (.S) files. 

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist

### Ratified/Unratified Extensions

- [X ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [ ] SAIL
- [ ] Spike
- [X ] Other - Ran our tests with this fix in place. Works

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [ X] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ X] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [ ] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
