### PR TITLE
Correct RVTEST_ISA and RVTEST_CASE for rv64 fli tests

### DIFF
--- a/riscv-test-suite/rv64i_m/D_Zfa/src/fli.d-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zfa/src/fli.d-01.S
@@ -4,13 +4,12 @@
 //
 // This assembly file tests the fli.d instruction
 // for the following ISA configurations:
-// * RV32ID_Zfa
 // * RV64ID_Zfa
 
 #include "model_test.h"
 #include "arch_test.h"
 
-RVTEST_ISA("RV32ID_Zfa,RV64ID_Zfa")
+RVTEST_ISA("RV64ID_Zfa")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -22,7 +21,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fli.d)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*D.*Zfa.*);def TEST_CASE_1=True;",fli.d)
 
 // Registers with a special purpose
 #define SIG_BASEREG x1

--- a/riscv-test-suite/rv64i_m/F_Zfa/src/fli.s-01.S
+++ b/riscv-test-suite/rv64i_m/F_Zfa/src/fli.s-01.S
@@ -4,13 +4,12 @@
 //
 // This assembly file tests the fli.s instruction
 // for the following ISA configurations:
-// * RV32IF_Zfa
 // * RV64IF_Zfa
 
 #include "model_test.h"
 #include "arch_test.h"
 
-RVTEST_ISA("RV32IF_Zfa,RV64IF_Zfa")
+RVTEST_ISA("RV64IF_Zfa")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -22,7 +21,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fli.s)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*Zfa.*);def TEST_CASE_1=True;",fli.s)
 
 // Registers with a special purpose
 #define SIG_BASEREG x1


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> For all other tests in the `rv64i_m` directory, the test is restricted to run on rv64 configurations. The fli.d and fli.s tests had `RVTEST_ISA` and `RVTEST_CASE` values that caused them to be run on both 32 and 64 bit configurations. This updates these values to match those of the rest of the tests in the rv64i_m/D_Zfa and rv64i_m/F_Zfa directories.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist

### Ratified/Unratified Extensions

- [x] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [x] SAIL
- [x] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [x] All tests are compliant with the test-format spec present in this repo ?
  - [x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
  - [ ] Link to PR in RISCV-ISAC from which the reports were generated : < SPECIFY HERE > 
  - [ ] Changelog entry created with a minor patch

### Optional Checklist:

  - [ ] RISCV-V CTG PR link if tests were generated using it : < SPECIFY HERE >
  - [x] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
