### PR TITLE
Resolved Issue#488

### DIFF
--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-001.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-001.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-002.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-002.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-003.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-003.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-004.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-004.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-005.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-005.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-006.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-006.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-007.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-007.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-008.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-008.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-009.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-009.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-010.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-010.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-011.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-011.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-012.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-012.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-013.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-013.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-014.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-014.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-015.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-015.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-016.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-016.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-017.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-017.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-018.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-018.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-019.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-019.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-020.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-020.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-021.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-021.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-022.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-022.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-023.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-023.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-024.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-024.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-025.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-025.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-026.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-026.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-027.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-027.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-028.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-028.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-029.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-029.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-030.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-030.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-031.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-031.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-032.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-032.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-033.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-033.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-034.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-034.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-035.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-035.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-036.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-036.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-037.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-037.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-038.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-038.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-039.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-039.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-040.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-040.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-041.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-041.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-042.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-042.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-043.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-043.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-044.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-044.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-045.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-045.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-046.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-046.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-047.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-047.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-048.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-048.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-049.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-049.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-050.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-050.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-051.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-051.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-052.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-052.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-053.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-053.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-054.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-054.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-055.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-055.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-056.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-056.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-057.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-057.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-058.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-058.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-059.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-059.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-060.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-060.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-061.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-061.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-062.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-062.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-063.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-063.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-064.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-064.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-065.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-065.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-066.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-066.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-067.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-067.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-068.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-068.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-069.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-069.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-070.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-070.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-071.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-071.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-072.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-072.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-073.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-073.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-074.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-074.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-075.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-075.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-076.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-076.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-077.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-077.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-078.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-078.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-079.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-079.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-080.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-080.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-081.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-081.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-082.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-082.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-083.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-083.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-084.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-084.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-085.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-085.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-086.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-086.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-087.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-087.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-088.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-088.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-089.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-089.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-090.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-090.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-091.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-091.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-092.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-092.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-093.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-093.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-094.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-094.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-095.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-095.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-096.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-096.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-097.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-097.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-098.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-098.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-099.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-099.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-100.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-100.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-101.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-101.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-102.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-102.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-103.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-103.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-104.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-104.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-105.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-105.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-106.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-106.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-107.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-107.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-108.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-108.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-109.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-109.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-110.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-110.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-111.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-111.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-112.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-112.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-113.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-113.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-114.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-114.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-115.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-115.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-116.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-116.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-117.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-117.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-118.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-118.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-119.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-119.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-120.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-120.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-121.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-121.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-122.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-122.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-123.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-123.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-124.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-124.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-125.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-125.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-126.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-126.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-127.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-127.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-128.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-128.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-129.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-129.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-130.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-130.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-131.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-131.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-132.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-132.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-133.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmadd.d_b15/fmadd.d_b15-133.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-001.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-001.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-002.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-002.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-003.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-003.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-004.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-004.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-005.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-005.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-006.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-006.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-007.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-007.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-008.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-008.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-009.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-009.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-010.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-010.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-011.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-011.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-012.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-012.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-013.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-013.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-014.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-014.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-015.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-015.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-016.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-016.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-017.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-017.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-018.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-018.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-019.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-019.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-020.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-020.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-021.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-021.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-022.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-022.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-023.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-023.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-024.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-024.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-025.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-025.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-026.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-026.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-027.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-027.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-028.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-028.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-029.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-029.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-030.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-030.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-031.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-031.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-032.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-032.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-033.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-033.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-034.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-034.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-035.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-035.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-036.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-036.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-037.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-037.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-038.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-038.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-039.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-039.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-040.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-040.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-041.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-041.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-042.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-042.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-043.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-043.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-044.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-044.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-045.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-045.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-046.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-046.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-047.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-047.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-048.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-048.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-049.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-049.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-050.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-050.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-051.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-051.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-052.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-052.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-053.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-053.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-054.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-054.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-055.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-055.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-056.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-056.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-057.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-057.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-058.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-058.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-059.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-059.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-060.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-060.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-061.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-061.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-062.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-062.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-063.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-063.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-064.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-064.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-065.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-065.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-066.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-066.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-067.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-067.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-068.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-068.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-069.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-069.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-070.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-070.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-071.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-071.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-072.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-072.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-073.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-073.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-074.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-074.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-075.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-075.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-076.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-076.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-077.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-077.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-078.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-078.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-079.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-079.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-080.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-080.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-081.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-081.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-082.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-082.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-083.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-083.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-084.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-084.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-085.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-085.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-086.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-086.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-087.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-087.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-088.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-088.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-089.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-089.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-090.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-090.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-091.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-091.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-092.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-092.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-093.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-093.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-094.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-094.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-095.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-095.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-096.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-096.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-097.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-097.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-098.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-098.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-099.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-099.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-100.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-100.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-101.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-101.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-102.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-102.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-103.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-103.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-104.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-104.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-105.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-105.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-106.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-106.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-107.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-107.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-108.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-108.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-109.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-109.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-110.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-110.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-111.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-111.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-112.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-112.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-113.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-113.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-114.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-114.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-115.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-115.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-116.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-116.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-117.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-117.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-118.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-118.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-119.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-119.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-120.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-120.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-121.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-121.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-122.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-122.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-123.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-123.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-124.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-124.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-125.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-125.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-126.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-126.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-127.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-127.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-128.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-128.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-129.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-129.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-130.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-130.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-131.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-131.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-132.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-132.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-133.S
+++ b/riscv-test-suite/rv32i_m/D/src/fmsub.d_b15/fmsub.d_b15-133.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-001.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-001.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-002.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-002.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-003.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-003.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-004.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-004.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-005.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-005.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-006.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-006.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-007.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-007.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-008.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-008.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-009.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-009.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-010.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-010.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-011.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-011.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-012.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-012.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-013.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-013.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-014.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-014.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-015.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-015.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-016.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-016.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-017.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-017.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-018.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-018.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-019.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-019.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-020.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-020.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-021.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-021.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-022.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-022.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-023.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-023.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-024.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-024.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-025.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-025.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-026.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-026.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-027.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-027.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-028.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-028.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-029.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-029.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-030.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-030.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-031.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-031.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-032.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-032.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-033.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-033.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-034.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-034.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-035.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-035.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-036.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-036.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-037.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-037.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-038.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-038.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-039.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-039.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-040.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-040.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-041.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-041.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-042.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-042.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-043.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-043.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-044.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-044.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-045.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-045.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-046.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-046.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-047.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-047.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-048.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-048.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-049.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-049.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-050.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-050.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-051.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-051.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-052.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-052.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-053.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-053.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-054.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-054.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-055.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-055.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-056.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-056.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-057.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-057.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-058.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-058.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-059.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-059.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-060.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-060.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-061.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-061.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-062.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-062.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-063.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-063.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-064.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-064.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-065.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-065.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-066.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-066.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-067.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-067.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-068.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-068.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-069.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-069.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-070.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-070.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-071.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-071.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-072.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-072.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-073.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-073.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-074.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-074.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-075.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-075.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-076.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-076.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-077.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-077.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-078.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-078.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-079.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-079.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-080.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-080.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-081.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-081.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-082.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-082.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-083.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-083.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-084.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-084.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-085.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-085.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-086.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-086.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-087.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-087.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-088.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-088.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-089.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-089.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-090.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-090.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-091.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-091.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-092.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-092.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-093.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-093.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-094.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-094.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-095.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-095.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-096.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-096.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-097.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-097.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-098.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-098.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-099.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-099.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-100.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-100.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-101.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-101.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-102.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-102.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-103.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-103.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-104.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-104.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-105.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-105.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-106.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-106.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-107.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-107.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-108.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-108.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-109.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-109.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-110.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-110.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-111.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-111.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-112.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-112.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-113.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-113.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-114.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-114.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-115.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-115.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-116.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-116.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-117.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-117.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-118.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-118.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-119.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-119.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-120.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-120.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-121.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-121.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-122.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-122.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-123.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-123.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-124.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-124.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-125.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-125.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-126.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-126.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-127.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-127.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-128.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-128.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-129.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-129.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-130.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-130.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-131.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-131.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-132.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-132.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-133.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmadd.d_b15/fnmadd.d_b15-133.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-001.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-001.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-002.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-002.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-003.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-003.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-004.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-004.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-005.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-005.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-006.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-006.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-007.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-007.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-008.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-008.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-009.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-009.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-010.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-010.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-011.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-011.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-012.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-012.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-013.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-013.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-014.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-014.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-015.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-015.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-016.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-016.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-017.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-017.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-018.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-018.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-019.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-019.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-020.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-020.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-021.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-021.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-022.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-022.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-023.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-023.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-024.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-024.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-025.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-025.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-026.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-026.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-027.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-027.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-028.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-028.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-029.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-029.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-030.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-030.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-031.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-031.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-032.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-032.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-033.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-033.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-034.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-034.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-035.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-035.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-036.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-036.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-037.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-037.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-038.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-038.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-039.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-039.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-040.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-040.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-041.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-041.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-042.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-042.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-043.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-043.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-044.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-044.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-045.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-045.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-046.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-046.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-047.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-047.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-048.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-048.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-049.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-049.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-050.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-050.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-051.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-051.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-052.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-052.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-053.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-053.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-054.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-054.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-055.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-055.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-056.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-056.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-057.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-057.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-058.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-058.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-059.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-059.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-060.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-060.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-061.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-061.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-062.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-062.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-063.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-063.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-064.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-064.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-065.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-065.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-066.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-066.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-067.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-067.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-068.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-068.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-069.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-069.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-070.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-070.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-071.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-071.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-072.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-072.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-073.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-073.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-074.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-074.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-075.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-075.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-076.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-076.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-077.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-077.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-078.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-078.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-079.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-079.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-080.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-080.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-081.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-081.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-082.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-082.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-083.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-083.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-084.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-084.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-085.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-085.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-086.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-086.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-087.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-087.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-088.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-088.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-089.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-089.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-090.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-090.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-091.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-091.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-092.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-092.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-093.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-093.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-094.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-094.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-095.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-095.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-096.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-096.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-097.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-097.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-098.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-098.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-099.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-099.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-100.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-100.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-101.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-101.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-102.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-102.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-103.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-103.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-104.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-104.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-105.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-105.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-106.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-106.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-107.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-107.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-108.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-108.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-109.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-109.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-110.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-110.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-111.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-111.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-112.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-112.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-113.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-113.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-114.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-114.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-115.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-115.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-116.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-116.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-117.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-117.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-118.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-118.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-119.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-119.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-120.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-120.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-121.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-121.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-122.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-122.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-123.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-123.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-124.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-124.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-125.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-125.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-126.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-126.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-127.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-127.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-128.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-128.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-129.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-129.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-130.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-130.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-131.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-131.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-132.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-132.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point

--- a/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-133.S
+++ b/riscv-test-suite/rv32i_m/D/src/fnmsub.d_b15/fnmsub.d_b15-133.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IF_Zicsr,RV32IFD_Zicsr,RV64IF_Zicsr,RV64IFD_Zicsr,RV32EF_Zicsr,RV32EFD_Zicsr,RV64EF_Zicsr,RV64EFD_Zicsr")
+RVTEST_ISA("RV32IFD_Zicsr,RV64IFD_Zicsr")
 
 .section .text.init
 .globl rvtest_entry_point


### PR DESCRIPTION

## Description
The fix for Issue#488. Updated the RVTEST_ISA string for fnmadd.d_b15, fmadd.d_b15, fnmsub.d_b15, fmsub.d_b15 tests to stop running it on RV32F/RV64F. These tests will only run for RV32FD/RV64FD now.

### Related Issues
Issue#488
 
### Ratified/Unratified Extensions

- [x] Ratified
- [ ] Unratified