### PR TITLE
Update test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ on:
 jobs:
 
   ACT-sail-spike:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR is coauthored by @UmerShahidengr. Umer has found the error in CI, the current CI is running on Ubuntu-latest (version 24) but unfortunately tools (riscv-isac, and riscv-ctg) are incompatible with Ubuntu-24 (python 3.12+), we have switched the CI to work on Ubuntu-22 with all python packages required to run the current version of ISAC and CTG. It will fix the dependencies issues for now.