### PR TITLE
Update Sail installation method in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python3 python3-pip python3-venv
           sudo apt-get install -y gcc git autoconf automake libtool curl make unzip
-          sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
+          sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev pkg-config
           pip3 install git+https://github.com/riscv/riscof.git
       
       - name: Build RISCV-GNU Toolchain (32 bit)
@@ -83,11 +83,8 @@ jobs:
 
       - name: Install Sail
         run: |
-          sudo apt-get install opam build-essential libgmp-dev z3 pkg-config zlib1g-dev
-          opam init -y --disable-sandboxing
-          opam switch create ocaml-base-compiler
-          opam install sail -y
-          eval $(opam config env)
+          sudo mkdir -p /usr/local
+          curl --location https://github.com/rems-project/sail/releases/download/0.18-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
           git clone https://github.com/riscv/sail-riscv.git
           cd sail-riscv
           ARCH=RV32 make


### PR DESCRIPTION
Use the new binary release of the Sail compiler instead of installing it using Opam. This matches the sail-riscv repository CI and reduces the CI time from 19 minutes to 13 minutes.