### PR TITLE
Cache Spike and Sail in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,18 +94,41 @@ jobs:
           path: ${{ github.workspace }}/spike
           key: ${{ steps.cache-spike-restore.outputs.cache-primary-key }}
 
+      - name: Get Latest Sail Commit
+        run: |
+              SAIL_HASH=$(git ls-remote https://github.com/riscv/sail-riscv.git HEAD | awk '{ print $1}')
+              echo "SAIL_HASH=$SAIL_HASH" >> "$GITHUB_ENV"
+
+      - name: Restore cached Sail
+        id: cache-sail-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/sail
+          key: sail-${{ env.SAIL_HASH }}-RV${{ matrix.xlen }}
+
       - name: Install Sail
+        if: steps.cache-sail-restore.outputs.cache-hit != 'true'
         run: |
           sudo mkdir -p /usr/local
           curl --location https://github.com/rems-project/sail/releases/download/0.18-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
           git clone https://github.com/riscv/sail-riscv.git
           cd sail-riscv
           ARCH=RV${{ matrix.xlen }} make
-          echo $PWD/c_emulator >> $GITHUB_PATH
+          mkdir -p $GITHUB_WORKSPACE/sail
+          mv c_emulator/riscv_sim_RV${{ matrix.xlen }} $GITHUB_WORKSPACE/sail/riscv_sim_RV${{ matrix.xlen }}
+
+      - name: Save cached Sail
+        if: steps.cache-sail-restore.outputs.cache-hit != 'true'
+        id: cache-sail-save
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/sail
+          key: ${{ steps.cache-sail-restore.outputs.cache-primary-key }}
 
       - name: Set PATH
         run: |
               echo $GITHUB_WORKSPACE/spike/bin >> $GITHUB_PATH
+              echo $GITHUB_WORKSPACE/sail >> $GITHUB_PATH
       
       - name: Config and run riscof for RV${{ matrix.xlen }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
           sudo apt-get install -y python3 python3-pip python3-venv
           sudo apt-get install -y gcc git autoconf automake libtool curl make unzip
           sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev pkg-config
+          sudo apt-get install device-tree-compiler libboost-regex-dev libboost-system-dev
           pip3 install git+https://github.com/riscv/riscof.git
       
       - name: Build RISCV-GNU Toolchain (${{ matrix.xlen }} bit)
@@ -61,18 +62,37 @@ jobs:
         run: |
           cd riscv-ctg
           pip3 install --editable .
-      
+
+      - name: Get Latest Spike Commit
+        run: |
+              SPIKE_HASH=$(git ls-remote https://github.com/riscv/riscv-isa-sim.git HEAD | awk '{ print $1}')
+              echo "SPIKE_HASH=$SPIKE_HASH" >> "$GITHUB_ENV"
+
+      - name: Restore cached Spike
+        id: cache-spike-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/spike
+          key: spike-${{ env.SPIKE_HASH }}-RV${{ matrix.xlen }}
+
       - name: Install Spike
+        if: steps.cache-spike-restore.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/riscv/riscv-isa-sim.git
-          sudo apt-get install device-tree-compiler libboost-regex-dev libboost-system-dev
           cd riscv-isa-sim
           mkdir build
           cd build
-          ../configure --prefix=$GITHUB_WORKSPACE/riscv64
+          ../configure --prefix=$GITHUB_WORKSPACE/spike
           make -j$(nproc)
-          sudo make install
-          echo $GITHUB_WORKSPACE/riscv64/bin >> $GITHUB_PATH      
+          make install
+
+      - name: Save cached Spike
+        if: steps.cache-spike-restore.outputs.cache-hit != 'true'
+        id: cache-spike-save
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/spike
+          key: ${{ steps.cache-spike-restore.outputs.cache-primary-key }}
 
       - name: Install Sail
         run: |
@@ -81,7 +101,11 @@ jobs:
           git clone https://github.com/riscv/sail-riscv.git
           cd sail-riscv
           ARCH=RV${{ matrix.xlen }} make
-          echo $PWD/c_emulator >> $GITHUB_PATH            
+          echo $PWD/c_emulator >> $GITHUB_PATH
+
+      - name: Set PATH
+        run: |
+              echo $GITHUB_WORKSPACE/spike/bin >> $GITHUB_PATH
       
       - name: Config and run riscof for RV${{ matrix.xlen }}
         run: |


### PR DESCRIPTION
@UmerShahidengr More CI enhancements. 

This caches the builds of Spike and Sail and only rebuilds them if there is a newer version since the last time the CI was run. If no newer version exists, it restores the cached version and entirely skips building that tool. When it can restore from the cache (which should hopefully be most of the time) CI is down from 10 minutes to less than 4 minutes.