### PR TITLE
README Updates: Sail Installation & Remove Old Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The files [`COPYING.BSD`](./COPYING.BSD), [`COPYING.APACHE`](./COPYING.APACHE) a
 ## Quick Links:
 
 - RISCOF \[[DOCS](https://riscof.readthedocs.io/en/latest/)\] \[[REPO](https://github.com/riscv-software-src/riscof)\]: This is the next version of the architectural test framework currently under development
-- RISCV-ISAC \[[DOCS](https://riscv-isac.readthedocs.io/en/latest/index.html)\] \[[REPO](https://github.com/riscv-software-src/riscv-isac)\] : This is an ISA level coverage extraction tool for RISC-V which used to generate the coverage statistics of the architectural tests.
-- RISCV-CTG: \[[DOCS](https://riscv-ctg.readthedocs.io/en/latest/index.html)\]\[[REPO](https://github.com/riscv-software-src/riscv-ctg)\]: This is a RISC-V Architectural Test generator used to generate some of the tests already checked into this repository.
+- RISCV-ISAC \[[DOCS](https://riscv-isac.readthedocs.io/en/latest/index.html)\]: This is an ISA level coverage extraction tool for RISC-V which used to generate the coverage statistics of the architectural tests.
+- RISCV-CTG: \[[DOCS](https://riscv-ctg.readthedocs.io/en/latest/index.html)\]: This is a RISC-V Architectural Test generator used to generate some of the tests already checked into this repository.
 - [Videos](https://youtu.be/VIW1or1Oubo): This Global Forum 2020 video provides an introduction to the above mentioned tools
 - [riscvOVPsim](https://github.com/riscv-ovpsim/imperas-riscv-tests): Imperas freeware RISC-V reference simulator for compliance testing
 - [riscvOVPsimPlus](https://www.ovpworld.org/riscvOVPsimPlus/): Imperas enhanced freeware RISC-V reference simulator for test development and verification

--- a/README.md
+++ b/README.md
@@ -209,22 +209,23 @@ Note: Use sudo if the installation path requires administrative privileges.
 
 
 ### 2. SAIL (SAIL C-emulator)
+First install the [Sail Compiler](https://github.com/rems-project/sail/). It is recommended to use the pre-compiled [binary release](https://github.com/rems-project/sail/releases). This can be performed as follows:
 
 ```bash
-$ sudo apt-get install opam build-essential libgmp-dev z3 pkg-config zlib1g-dev
-$ opam init -y --disable-sandboxing
-$ opam switch create ocaml-base-compiler
-$ opam install sail -y
-$ eval $(opam config env)
+$ sudo apt-get install libgmp-dev pkg-config zlib1g-dev curl
+$ curl --location https://github.com/rems-project/sail/releases/download/0.18-linux-binary/sail.tar.gz | [sudo] tar xvz --directory=/path/to/install --strip-components=1
+```
+Note: Make sure to add the path `/path/to/install` to your `$PATH`.
+
+Then build the RISC-V Sail Model:
+```bash
 $ git clone https://github.com/riscv/sail-riscv.git
 $ cd sail-riscv
 $ ARCH=RV32 make
 $ ARCH=RV64 make
-$ ln -s sail-riscv/c_emulator/riscv_sim_RV64 /usr/bin/riscv_sim_RV64
-$ ln -s sail-riscv/c_emulator/riscv_sim_RV32 /usr/bin/riscv_sim_RV32
 ```
 
-This will create a C simulator in `c_emulator/riscv_sim_RV64` and `c_emulator/riscv_sim_RV32`. You will need to add these paths to your `$PATH` or create an alias to execute them from the command line.
+This will create a C simulator in `c_emulator/riscv_sim_RV64` and `c_emulator/riscv_sim_RV32`. You will need to add this path to your `$PATH` or create an alias to execute them from the command line.
 
 
 ## Necessary Env Files


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

Update the Sail installation instructions in the README to recommend the binary release of Sail instead of using Opam.

Also removes the links to the riscv-isac and riscv-ctg repos since they have been combined with this repo.