### PR TITLE
Ci checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,8 +143,8 @@ jobs:
         run: |
           folder_size=$(du -sm /home/runner/work/riscv-arch-test/riscv-arch-test/riscof-plugins/rv${{ matrix.xlen }}/riscof_work | cut -f1)
           echo "Folder size: ${folder_size} MB"
-          if [ "$folder_size" -gt 150 ]; then
-            echo "Size exceeds 150 MB. Skipping upload."
+          if [ "$folder_size" -gt 1000 ]; then
+            echo "Size exceeds 1 GB. Skipping upload."
             echo "upload=false" >> $GITHUB_ENV  # Set an environment variable to skip upload
           else
             echo "Size is within limit. Proceeding with upload."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
   ACT-sail-spike:
     name: ACT-sail-spike (RV${{ matrix.xlen }})
     runs-on: ubuntu-22.04
+    # Set a 15-minute time limit for this job
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -42,8 +44,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python3 python3-pip python3-venv
           sudo apt-get install -y gcc git autoconf automake libtool curl make unzip
-          sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev pkg-config
-          sudo apt-get install device-tree-compiler libboost-regex-dev libboost-system-dev
+          sudo apt-get install -y autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev pkg-config
+          sudo apt-get install -y device-tree-compiler libboost-regex-dev libboost-system-dev
           pip3 install git+https://github.com/riscv/riscof.git
       
       - name: Build RISCV-GNU Toolchain (${{ matrix.xlen }} bit)
@@ -134,3 +136,31 @@ jobs:
         run: |
           cd riscof-plugins/rv${{ matrix.xlen }}
           riscof run --config config.ini --suite ../../riscv-test-suite/rv${{ matrix.xlen }}i_m/ --env ../../riscv-test-suite/env
+
+        
+      - name: Check size of riscof_work folder
+        id: check_size
+        run: |
+          folder_size=$(du -sm /home/runner/work/riscv-arch-test/riscv-arch-test/riscof-plugins/rv${{ matrix.xlen }}/riscof_work | cut -f1)
+          echo "Folder size: ${folder_size} MB"
+          if [ "$folder_size" -gt 150 ]; then
+            echo "Size exceeds 150 MB. Skipping upload."
+            echo "upload=false" >> $GITHUB_ENV  # Set an environment variable to skip upload
+          else
+            echo "Size is within limit. Proceeding with upload."
+            echo "upload=true" >> $GITHUB_ENV  # Set an environment variable to proceed with upload
+          fi
+
+     # Upload the riscof_work for rv ${{ matrix.xlen }} folder if size check passes
+      - name: Upload the riscof_work for rv ${{ matrix.xlen }} folder
+        # Proceed with upload only if the size is within limit  
+        if: ${{ env.upload == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: riscof-test-report-rv${{ matrix.xlen }}
+          path: /home/runner/work/riscv-arch-test/riscv-arch-test/riscof-plugins/rv${{ matrix.xlen }}/riscof_work/
+          if-no-files-found: warn
+          retention-days: 3
+          compression-level: 6  # Default compression level; adjust if needed
+          overwrite: true  # Allows overwriting existing artifacts with the same name
+          include-hidden-files: false  # Only uploads visible files (adjust if hidden files are required)


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

This PR is meant to update the CI such that:
  - Add a time limit of 15 minutes.
  - Upload the artifacts to review them in case of failure/pass
  - Only upload the artifacts if their size is less than 1GB.


### Related Issues

  - CI was running for 360 minutes which is the maximum time limit when I added the tests of Virtual Memory. To avoid such scenerios again, we need to put a upper limit for the job.
  - There was no artifacts maintained for the job run. When there is a failure, the user may want to review the logs for better understanding.
