### PR TITLE
Update test_macros.h, removed TEST_RI macro

### DIFF
--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -888,13 +888,6 @@ ADDI(swreg, swreg, RVMODEL_CBZ_BLOCKSIZE)
       inst destreg, reg1, reg2, imm		;\
     )
 
-//Tests for a instructions with register-register operand
-#define TEST_RI_OP(inst, destreg, reg1, reg2, imm, correctval, val1, val2, swreg, offset, testreg) \
-    TEST_CASE(testreg, destreg, correctval, swreg, offset, \
-      LI(reg1, MASK_XLEN(val1))			;\
-      LI(reg2, MASK_XLEN(val2))			;\
-      inst destreg, reg1, reg2, imm		;\
-    )
 
 //Tests for a instructions with register-register operand
 #define TEST_RR_OP(inst, destreg, reg1, reg2, correctval, val1, val2, swreg, offset, testreg) \


### PR DESCRIPTION
This PR is coauthored by @UmerShahidengr, to resolve Issue #272, we have removed TEST_RI_OP macro as there was no further reference to it in any test