### PR TITLE
[CTG] Fix `cross()` missing inxFlag param

### DIFF
--- a/riscv-isac/riscv_isac/coverage.py
+++ b/riscv-isac/riscv_isac/coverage.py
@@ -166,7 +166,7 @@ class cross():
 
     BASE_REG_DICT = { 'x'+str(i) : 'x'+str(i) for i in range(32)}
 
-    def __init__(self,label,coverpoint,xlen,flen,addr_pairs,sig_addrs,window_size):
+    def __init__(self,label,coverpoint,xlen,flen,addr_pairs,sig_addrs,window_size,inxFlg):
 
         self.label = label
         self.coverpoint = coverpoint
@@ -1536,7 +1536,7 @@ def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xle
             if 'cross_comb' in value and len(value['cross_comb'])!=0:
                 for coverpt in value['cross_comb'].keys():
                     if(isinstance(coverpt,str)):
-                        new_obj = cross(cov_labels,coverpt,xlen,flen,addr_pairs,sig_addrs,window_size)
+                        new_obj = cross(cov_labels,coverpt,xlen,flen,addr_pairs,sig_addrs,window_size,inxFlg)
                         obj_dict[(cov_labels,coverpt)] = new_obj
 
 


### PR DESCRIPTION
## Description

`inxFlg` is use in `cross.__init__`

https://github.com/riscv-non-isa/riscv-arch-test/blob/3843c736e427a2b52a0d06e6220b073afa4be401/riscv-isac/riscv_isac/coverage.py#L169-L179

But it was not passed in