### PR TITLE
Fix ISA strings for Zcf, Zcd, and RV64 sra

### DIFF
--- a/riscv-test-suite/rv32i_m/D_Zcd/src/c.fld-01.S
+++ b/riscv-test-suite/rv32i_m/D_Zcd/src/c.fld-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IFDC")
+RVTEST_ISA("RV32IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fld)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fld)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/D_Zcd/src/c.fldsp-01.S
+++ b/riscv-test-suite/rv32i_m/D_Zcd/src/c.fldsp-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IFDC")
+RVTEST_ISA("RV32IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fldsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fldsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_SIGBASE(x1,signature_x1_1)

--- a/riscv-test-suite/rv32i_m/D_Zcd/src/c.fsd-01.S
+++ b/riscv-test-suite/rv32i_m/D_Zcd/src/c.fsd-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IFDC")
+RVTEST_ISA("RV32IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fsd)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fsd)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/D_Zcd/src/c.fsdsp-01.S
+++ b/riscv-test-suite/rv32i_m/D_Zcd/src/c.fsdsp-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IFDC,RV64IFDC")
+RVTEST_ISA("RV32IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*C.*);def TEST_CASE_1=True;",c.fsdsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fsdsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x4,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/F_Zcf/src/c.flw-01.S
+++ b/riscv-test-suite/rv32i_m/F_Zcf/src/c.flw-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.flw)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.flw)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/F_Zcf/src/c.flwsp-01.S
+++ b/riscv-test-suite/rv32i_m/F_Zcf/src/c.flwsp-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.flwsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.flwsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x4,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/F_Zcf/src/c.fsw-01.S
+++ b/riscv-test-suite/rv32i_m/F_Zcf/src/c.fsw-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.fsw)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.fsw)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/F_Zcf/src/c.fswsp-01.S
+++ b/riscv-test-suite/rv32i_m/F_Zcf/src/c.fswsp-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IFC")
+RVTEST_ISA("RV32IF_Zcf")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*C.*);def TEST_CASE_1=True;",c.fswsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.fswsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x4,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zcd/src/c.fld-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zcd/src/c.fld-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IFDC")
+RVTEST_ISA("RV64IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fld)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fld)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zcd/src/c.fldsp-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zcd/src/c.fldsp-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IFDC")
+RVTEST_ISA("RV64IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fldsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fldsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_SIGBASE(x1,signature_x1_1)

--- a/riscv-test-suite/rv64i_m/D_Zcd/src/c.fsd-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zcd/src/c.fsd-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IFDC")
+RVTEST_ISA("RV64IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fsd)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fsd)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zcd/src/c.fsdsp-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zcd/src/c.fsdsp-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IFDC")
+RVTEST_ISA("RV64IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*C.*);def TEST_CASE_1=True;",c.fsdsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fsdsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x4,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/I/src/sra-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/sra-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*);def TEST_CASE_1=True;",sra)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*);def TEST_CASE_1=True;",sra)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 


### PR DESCRIPTION
## Description

Fix inconsistent ISA strings in new Zcf and Zcd tests. Also restore `RV64` to sra ISA regex to avoid the following error:
```
ERROR | Error in test: /home/harris/cvw/addins/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sra-01.S
Test Selected without the relevant extensions being available on DUT.
```

### Related Issues

@UmerShahidengr fixes #590