### PR TITLE
Initialize link register with a code address in TEST_JAL_OP.

### DIFF
--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -615,6 +615,7 @@ Mend_PMP:                                    ;\
 #define TEST_JAL_OP(tempreg, rd, imm, label, swreg, offset, adj)	;\
 5:					;\
     LA(tempreg, 2f)			;\
+    mv rd, tempreg          ;\
     jalr x0,0(tempreg)			;\
 6:  LA(tempreg, 4f)			;\
     jalr x0,0(tempreg)			;\


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

This PR initializes the link register in `TEST_JAL_OP` to a code address. Without this line, RV32I_Zicsr-only cores that don't understand compressed instructions fail to match SAIL in the `misalign-jal-01.S` test by a single bit. Initializing the link register makes such cores match SAIL (absent other bugs in such cores :)...).

### Related Issues

#445 

### Ratified/Unratified Extensions

- [X] Ratified
- [ ] Unratified

### List Extensions

RV32I_Zicsr, _without C extension_.

### Reference Model Used

- [X] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [X] All tests are compliant with the test-format spec present in this repo ?
  - [X] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
    The provided command in the docs doesn't appear to work; I don't know where to get CGFs. Also, this is a bug fix, not a new test.
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): Not applicable? See above.

### Optional Checklist:

  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
