### PR TITLE
Build Sail with cmake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,9 +115,10 @@ jobs:
           curl --location https://github.com/rems-project/sail/releases/download/0.18-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
           git clone https://github.com/riscv/sail-riscv.git
           cd sail-riscv
-          ARCH=RV${{ matrix.xlen }} make
+          cmake -S . -B build -DCMAKE_RELEASE_TYPE=RelWithDebInfo -GNinja
+          cmake --build build
           mkdir -p $GITHUB_WORKSPACE/sail
-          mv c_emulator/riscv_sim_RV${{ matrix.xlen }} $GITHUB_WORKSPACE/sail/riscv_sim_RV${{ matrix.xlen }}
+          mv build/c_emulator/riscv_sim_rv${{ matrix.xlen }}d $GITHUB_WORKSPACE/sail/riscv_sim_rv${{ matrix.xlen }}d
 
       - name: Save cached Sail
         if: steps.cache-sail-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
           curl --location https://github.com/rems-project/sail/releases/download/0.18-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
           git clone https://github.com/riscv/sail-riscv.git
           cd sail-riscv
-          cmake -S . -B build -DCMAKE_RELEASE_TYPE=RelWithDebInfo -GNinja
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja
           cmake --build build
           mkdir -p $GITHUB_WORKSPACE/sail
           mv build/c_emulator/riscv_sim_rv${{ matrix.xlen }}d $GITHUB_WORKSPACE/sail/riscv_sim_rv${{ matrix.xlen }}d

--- a/README.md
+++ b/README.md
@@ -221,11 +221,10 @@ Then build the RISC-V Sail Model:
 ```bash
 $ git clone https://github.com/riscv/sail-riscv.git
 $ cd sail-riscv
-$ ARCH=RV32 make
-$ ARCH=RV64 make
+$ ./build-simulators.sh
 ```
 
-This will create a C simulator in `c_emulator/riscv_sim_RV64` and `c_emulator/riscv_sim_RV32`. You will need to add this path to your `$PATH` or create an alias to execute them from the command line.
+This will create a C simulator in `build/c_emulator/riscv_sim_rv64d` and `build/c_emulator/riscv_sim_rv32d`. You will need to add this path to your `$PATH` or create an alias to execute them from the command line.
 
 
 ## Necessary Env Files

--- a/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
@@ -36,8 +36,8 @@ class sail_cSim(pluginTemplate):
         path = config['PATH'] if 'PATH' in config else ""
 
 
-        self.sail_exe = { '32' : os.path.join(path,"riscv_sim_RV32"),
-                '64' : os.path.join(path,"riscv_sim_RV64")}
+        self.sail_exe = { '32' : os.path.join(path,"riscv_sim_rv32d"),
+                '64' : os.path.join(path,"riscv_sim_rv64d")}
         self.isa_spec = os.path.abspath(config['ispec']) if 'ispec' in config else ''
         self.platform_spec = os.path.abspath(config['pspec']) if 'ispec' in config else ''
         self.make = config['make'] if 'make' in config else 'make'

--- a/riscof-plugins/rv64/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv64/sail_cSim/riscof_sail_cSim.py
@@ -28,8 +28,8 @@ class sail_cSim(pluginTemplate):
             raise SystemExit(1)
         self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
         self.pluginpath = os.path.abspath(config['pluginpath'])
-        self.sail_exe = { '32' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_RV32"),
-                '64' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_RV64")}
+        self.sail_exe = { '32' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_rv32d"),
+                '64' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_rv64d")}
         self.isa_spec = os.path.abspath(config['ispec']) if 'ispec' in config else ''
         self.platform_spec = os.path.abspath(config['pspec']) if 'ispec' in config else ''
         self.make = config['make'] if 'make' in config else 'make'


### PR DESCRIPTION
The RISC-V sail model has transitioned to using cmake as its build system. This updates the CI and README to use cmake to build the model. As part of the switch to cmake, the simulator was also renamed to `riscv_sim_rv64d` (the d has been added to indicate if was compiled with flen=64). This updates the riscof plugins to use the new name of the binary.