### PR TITLE
Remove docker image after use

### DIFF
--- a/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
@@ -20,7 +20,7 @@ class sail_cSim(pluginTemplate):
     __model__ = "sail_c_simulator"
     __version__ = "0.5.0"
 
-    docker_cmd = 'docker run -w /work -v{0}:/work -a stdout -a stderr --init {1} {2}'
+    docker_cmd = 'docker run --rm -w /work -v{0}:/work -a stdout -a stderr --init {1} {2}'
 
     def __init__(self, *args, **kwargs):
         sclass = super().__init__(*args, **kwargs)


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

Docker docs recommends this flag for short running foreground processes

https://docs.docker.com/reference/cli/docker/container/run/#rm

Try running `docker ps -a | grep incoresemi | wc -l` to check how many containers are left over. I have thousands on my machine because riscof creates a new container for each test case.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist

https://gitlab.com/incoresemi/riscof-plugins/-/issues/20 I already reported it here. Not sure what is the relationship between this repo and incoresemi. Looks like this repo is more active.