### PR TITLE
update ci workflow to use the latest sail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,13 @@
 
 name: CI test
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
 
   # Triggers the workflow on pull request events but only for the main & dev branch
   pull_request:
     branches: [ '**'  ]
-  
+
   # Triggers the workflow on push events
   push:
     branches: [ '**'  ]
@@ -47,7 +47,7 @@ jobs:
           sudo apt-get install -y autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev pkg-config
           sudo apt-get install -y device-tree-compiler libboost-regex-dev libboost-system-dev
           pip3 install git+https://github.com/riscv/riscof.git
-      
+
       - name: Build RISCV-GNU Toolchain (${{ matrix.xlen }} bit)
         run: |
           wget -c https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2024.09.03/riscv${{ matrix.xlen }}-elf-ubuntu-20.04-gcc-nightly-2024.09.03-nightly.tar.gz
@@ -112,7 +112,7 @@ jobs:
         if: steps.cache-sail-restore.outputs.cache-hit != 'true'
         run: |
           sudo mkdir -p /usr/local
-          curl --location https://github.com/rems-project/sail/releases/download/0.18-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
+          curl --location https://github.com/rems-project/sail/releases/download/0.19-linux-binary/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
           git clone https://github.com/riscv/sail-riscv.git
           cd sail-riscv
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja
@@ -132,7 +132,7 @@ jobs:
         run: |
               echo $GITHUB_WORKSPACE/spike/bin >> $GITHUB_PATH
               echo $GITHUB_WORKSPACE/sail >> $GITHUB_PATH
-      
+
       - name: Config and run riscof for RV${{ matrix.xlen }}
         run: |
           cd riscof-plugins/rv${{ matrix.xlen }}


### PR DESCRIPTION
To avoid the CI failure, we need to use the latest version of Sail