### PR TITLE
Speedup riscv_ctg

### DIFF
--- a/riscv-ctg/riscv_ctg/generator.py
+++ b/riscv-ctg/riscv_ctg/generator.py
@@ -488,10 +488,10 @@ class Generator():
                     problem = Problem()
 
                 for var in self.val_vars:
-                    if var == 'ea_align' and var not in req_val_comb:
-                        problem.addVariable(var, [0])
-                    else:
-                        problem.addVariable(var, self.datasets[var])
+                    dataset = self.datasets[var]
+                    if var not in req_val_comb:
+                        dataset = dataset[:1]
+                    problem.addVariable(var, dataset)
 
                 def condition(*argv):
                     for var,val in zip(self.val_vars,argv):


### PR DESCRIPTION
## Description

When I run riscv_ctg, some test cases run very slowly, for example:

```
self.val_vars: ['rs1_val', 'rs2_val', 'rs2_hi_val', 'imm_val', 'ea_align']
req_val_comb: imm_val == 0
```

It takes a few minutes, some spend even tens of minutes

So what I'd like to do is, for all the vars we're not interested in, just take the first one