### PR TITLE
Update CLI to show help instead of throwing an error

### DIFF
--- a/riscv-ctg/riscv_ctg/main.py
+++ b/riscv-ctg/riscv_ctg/main.py
@@ -2,6 +2,7 @@
 """Console script for riscv_ctg."""
 
 import click,os
+import sys
 
 from riscv_ctg.log import logger
 from riscv_ctg.ctg import ctg
@@ -22,10 +23,15 @@ from riscv_isac.cgf_normalize import expand_cgf
 @click.option("--z-inx", '-ix', type=bool, default='False', help="If the extension is Z*inx then pass True otherwise defaulted to False")
 @click.option("--filter", type=str, help="Filtering tests to be generated with regex")
 def cli(verbose, out_dir, randomize , cgf,procs,base_isa, flen,inst,z_inx,filter):
-    if not os.path.exists(out_dir):
-        os.mkdir(out_dir)
-    if '32' in base_isa:
-        xlen = 32
-    elif '64' in base_isa:
-        xlen = 64
-    ctg(verbose, out_dir, randomize ,xlen, int(flen), cgf,procs,base_isa,inst,z_inx,filter)
+    if len(sys.argv) == 1:
+        with click.get_current_context() as context:
+            click.echo(context.get_help())
+        sys.exit(0)
+    else:
+        if not os.path.exists(out_dir):
+            os.mkdir(out_dir)
+        if '32' in base_isa:
+            xlen = 32
+        elif '64' in base_isa:
+            xlen = 64
+        ctg(verbose, out_dir, randomize ,xlen, int(flen), cgf,procs,base_isa,inst,z_inx,filter)


### PR DESCRIPTION
This PR updates the RISC-V CTG to print options instead of throwing an error when running:

```
riscv_ctg
```
Previously, on running the above command:
![image](https://github.com/user-attachments/assets/52858d43-f64f-44bd-82d5-32dad9a9a095)

Now:

![image](https://github.com/user-attachments/assets/ab2275a8-4a5d-4399-bf49-7794b1dc70bc)
