### PR TITLE
Fix RVTEST_CASE macro for rv32i bseti-01 test

### DIFF
--- a/riscv-test-suite/rv32i_m/B/src/bseti-01.S
+++ b/riscv-test-suite/rv32i_m/B/src/bseti-01.S
@@ -30,7 +30,7 @@ RVTEST_CODE_BEGIN
 #ifdef TEST_CASE_1
 
 RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*Zbs.*);def TEST_CASE_1=True;",bseti)
-RVTEST_CASE(0,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*B.*);def TEST_CASE_1=True;",bseti)
+RVTEST_CASE(1,"//check ISA:=regex(.*32.*);check ISA:=regex(.*I.*B.*);def TEST_CASE_1=True;",bseti)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 


### PR DESCRIPTION
#644 added a second `RVTEST_CASE` macro to the rv32i `bseti-01` test with the number 0, which breaks riscof. This switches it to be number 1, like all of the other tests.