### PR TITLE
Fix missing val_comb values after expand_cgf

### DIFF
--- a/riscv-isac/riscv_isac/cgf_normalize.py
+++ b/riscv-isac/riscv_isac/cgf_normalize.py
@@ -623,8 +623,6 @@ def expand_cgf(cgf_files, xlen,flen, log_redundant=False):
                                     # so only do it for the first 100 entries.
                                     if i < 100:
                                         cgf[labels][label].yaml_add_eol_comment(comment, key=cp)
-                                    else:
-                                        cgf[labels][label][cp] = coverage
-
+                                    cgf[labels][label][cp] = coverage
                                     i += 1
     return dict(cgf)


### PR DESCRIPTION
## Description

@UmerShahidengr If I understand correctly, we are missing all the val_comb values when i < 100, `cgf[labels][label].yaml_add_eol_comment(comment, key=cp)` only added the comment.

When I use riscv-ctg for local generation, I want to generate a total of about 128 + x(<10) data, but the actual result is only 30+, which is too few, so I think it's a bug that was introduced by accident.
