### PR TITLE
Add ruff format check in pre-commit hook and CI

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,16 @@
+name: Lint and format
+
+on:
+  push:
+    branches: [ '**' ]
+  workflow_dispatch:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v1
+        with:
+          args: format
+          src: "."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.11.13
+  hooks:
+    # Run the formatter.
+    - id: ruff-format

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -9,7 +9,32 @@ Your inputs are welcome and greatly appreciated! We want to make contributing to
 - Becoming a maintainer
 
 ## We develop with Github
+
 We use github to host code, to track issues and feature requests, as well as accept pull requests.
+
+## Prepare
+
+We use [ruff](https://docs.astral.sh/ruff/) as our linter and formatter, all the changes you made will be checked by Github CI pipeline
+
+- install ruff: `pip install ruff` or [more install methods](https://docs.astral.sh/ruff/installation/)
+
+To run ruff locally, you can use [pre-commit](https://pre-commit.com/), it runs the same check as CI pipeline:
+
+- install pre-commit: `pip install pre-commit`
+
+then you can run check directly by: `pre-commit run`
+
+> notice that pre-commit will only run on the staged files, if you want to check all, please use `pre-commit run -a`
+
+If you use git, you can set [git hooks](https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks) automatically by:
+
+- set git hooks: `pre-commit install`
+
+then pre-commit check will be triggered automatically when you run `git commit`
+
+> if your think some changes are necessary even though they won't pass the check, you can use `git commit --no-verify` which will skip the pre-commit check.
+
+If you are using vscode, you can also use [Offical Ruff Extension for vscode](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) to automatically format/lint your code on save.
 
 ## We use a simple git flow where all code changes happen through Pull Requests
 
@@ -54,9 +79,11 @@ Note: You can have either a patch or minor or major update.
 Note: In case of a conflict, the maintainers will decide the final version to be assigned.
 
 ## Any contributions you make will be under the permissive open-source License
+
 In short, when you submit code changes, your submissions are understood to be under a permissive open source license like BSD-3, Apache-2.0 and CC, etc that covers the project. Feel free to contact the maintainers if that's a concern.
 
 ## Report bugs using Github's [issues](https://github.com/riscv/riscv-arch-test/issues)
+
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/riscv/riscv-arch-test/issues/new); it's that easy!
 
 ## Write bug reports with detail, background, and sample code
@@ -66,7 +93,7 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 - A quick summary and/or background
 - Steps to reproduce
   - Be specific!
-  - Give sample code if you can. 
+  - Give sample code if you can.
 - What you expected would happen
 - What actually happens
 - Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
@@ -74,4 +101,3 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 ## License
 By contributing, you agree that your contributions will be licensed under its permissive open source
 licenses.
-

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,61 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 128
+indent-width = 4
+
+# Assume Python 3.9
+target-version = "py39"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "preserve"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"


### PR DESCRIPTION
## Description

I believe that we will fully format the code anyway, as it is necessary for the maintainability of the project.

This PR adds a CI to check whether the PR is correctly formatted.
It also adds a pre-commit hook to help users perform format check locally

I created a basic formatted configuration and simply modified the default line-length 和 quote-style

The only thing to note is that the ruff format will break our manual alignment of the dictionary，ruff format also doesn't support many customization options, but this seems to be a common issue with formatting tools, and black (a more mature formatter) has the same problem https:github.com/psf/black/issues/4281