### PR TITLE
Update test_macros.h

### DIFF
--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -599,9 +599,9 @@ Mend_PMP:                                    ;\
 
 #define RVTEST_BASEUPD(_BR,...)				;\
  /* deal with case where offset>=2047 */		;\
-       .set corr 2048-REGWIDTH				;\
+       .set corr, 2048-REGWIDTH				;\
     .if offset <2048 					;\
-       .set corr offset					;\
+       .set corr, offset				;\
     .endif						;\
     .set offset, offset-corr				;\
 							;\


### PR DESCRIPTION
When trying to use this macro I run into the following compiler error:  
Error: expected comma after "corr"

Added commas after all of the corr variables in the function and it worked.