### PR TITLE
Updated Sail plugin to use new Sail executable & fixed CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -120,7 +120,7 @@ jobs:
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja
           cmake --build build
           mkdir -p $GITHUB_WORKSPACE/sail
-          mv build/c_emulator/riscv_sim_rv${{ matrix.xlen }}d $GITHUB_WORKSPACE/sail/riscv_sim_rv${{ matrix.xlen }}d
+          mv build/c_emulator/sail_riscv_sim $GITHUB_WORKSPACE/sail/sail_riscv_sim
 
       - name: Save cached Sail
         if: steps.cache-sail-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/sail
-          key: sail-${{ env.SAIL_HASH }}-RV${{ matrix.xlen }}
+          key: sail-${{ env.SAIL_HASH }}
 
       - name: Install Sail
         if: steps.cache-sail-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja
           cmake --build build
           mkdir -p $GITHUB_WORKSPACE/sail
-          mv build/c_emulator/riscv_sim_rv${{ matrix.xlen }}d $GITHUB_WORKSPACE/sail/riscv_sim_rv${{ matrix.xlen }}d
+          mv build/c_emulator/sail_riscv_sim $GITHUB_WORKSPACE/sail/sail_riscv_sim
 
       - name: Save cached Sail
         if: steps.cache-sail-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/sail
-          key: sail-${{ env.SAIL_HASH }}-RV${{ matrix.xlen }}
+          key: sail-${{ env.SAIL_HASH }}
 
       - name: Install Sail
         if: steps.cache-sail-restore.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ $ cd sail-riscv
 $ ./build-simulators.sh
 ```
 
-This will create a C simulator in `build/c_emulator/riscv_sim_rv64d` and `build/c_emulator/riscv_sim_rv32d`. You will need to add this path to your `$PATH` or create an alias to execute them from the command line.
+This will create a C simulator in `build/c_emulator/sail_riscv_sim`. You will need to add this path to your `$PATH` or create an alias to execute it from the command line.
 
 
 ## Necessary Env Files

--- a/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
@@ -29,8 +29,7 @@ class sail_cSim(pluginTemplate):
             raise SystemExit(1)
         self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
         self.pluginpath = os.path.abspath(config['pluginpath'])
-        self.sail_exe = { '32' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_rv32d"),
-                '64' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_rv64d")}
+        self.sail_exe = os.path.join(config['PATH'] if 'PATH' in config else "","sail_riscv_sim")
         self.isa_spec = os.path.abspath(config['ispec']) if 'ispec' in config else ''
         self.platform_spec = os.path.abspath(config['pspec']) if 'ispec' in config else ''
         self.make = config['make'] if 'make' in config else 'make'
@@ -76,8 +75,9 @@ class sail_cSim(pluginTemplate):
         if shutil.which(compiler) is None:
             logger.error(compiler+": executable not found. Please check environment setup.")
             raise SystemExit(1)
-        if shutil.which(self.sail_exe[self.xlen]) is None:
-            logger.error(self.sail_exe[self.xlen]+ ": executable not found. Please check environment setup.")
+        if shutil.which(self.sail_exe) is None:
+            logger.error(self.sail_exe + ": executable not found. Please check environment setup.")
+            logger.error("Sail has been updated to use sail_riscv_sim instead of riscv_sim_rv(32/64)d. Please make sure that you have the latest version of Sail installed.")
             raise SystemExit(1)
         if shutil.which(self.make) is None:
             logger.error(self.make+": executable not found. Please check environment setup.")
@@ -124,17 +124,21 @@ class sail_cSim(pluginTemplate):
                 pmp_flags = ""
 
             try:
-                sail_config = subprocess.run(["riscv_sim_rv32d", "--print-default-config"], check= True, text=True, capture_output=True)
+                sail_config = subprocess.run(["sail_riscv_sim", "--print-default-config"], check= True, text=True, capture_output=True)
                 sail_config = json.loads(sail_config.stdout)
             except subprocess.CalledProcessError as e:
-                print("riscv_sim_rv32d --print-default-config failed:", e.stderr)
+                print("sail_riscv_sim --print-default-config failed:", e.stderr)
                 exit(1)
             except json.JSONDecodeError:
-                print("riscv_sim_rv32d --print-default-config output is not valid JSON.")
+                print("sail_riscv_sim --print-default-config output is not valid JSON.")
                 exit(1)
 
+            sail_config["base"]["xlen"] = int(self.xlen)
             sail_config["memory"]["pmp"]["grain"] = pmp_flags["pmp-grain"]
             sail_config["memory"]["pmp"]["count"] = pmp_flags["pmp-count"]
+
+            # Enabling extensions that are disabled by default
+            sail_config["extensions"]["Sv32"]["supported"] = True
 
             #For User-configuration: Replace this variable with your configuration. "/home/riscv-arch-test/custom_sail_config.json"
             sail_config_path = os.path.join(self.pluginpath, 'env', 'sail_config.json')
@@ -143,7 +147,7 @@ class sail_cSim(pluginTemplate):
             with open(sail_config_path, 'w', encoding='utf-8') as file:
                 json.dump(sail_config, file, indent=4)
 
-            execute += self.sail_exe[self.xlen] + ' --config={0} -v --trace=step --signature-granularity=4  --test-signature={1} {2} > {3}.log 2>&1;'.format(sail_config_path, sig_file, elf, test_name)
+            execute += self.sail_exe + ' --config={0} -v --trace=step --signature-granularity=4  --test-signature={1} {2} > {3}.log 2>&1;'.format(sail_config_path, sig_file, elf, test_name)
 
             cov_str = ' '
             for label in testentry['coverage_labels']:


### PR DESCRIPTION
## Description

Sail previously had two executables **riscv_sim_rv32d** and **riscv_sim_rv64d**. These have been merged together to one executable **sail_riscv_sim** through PR https://github.com/riscv/sail-riscv/pull/870
**Riscof_sail_cSim.py** has been modified to use this new file. It's default base xlen is 64, therefore added code to set the base xlen according to the test. As default xlen is set to 64, therefore some extensions specific to rv32 are disabled by default. I enabled SV32 as it was required for CI.
Also added an error message to indicate Sail's update.

