### PR TITLE
Modified trace argument in Sail Plugins

### DIFF
--- a/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
@@ -148,7 +148,7 @@ class sail_cSim(pluginTemplate):
             with open(sail_config_path, 'w', encoding='utf-8') as file:
                 json.dump(sail_config, file, indent=4)
 
-            execute += self.sail_exe + ' --config={0} -v --trace=step --signature-granularity=4  --test-signature={1} {2} > {3}.log 2>&1;'.format(sail_config_path, sig_file, elf, test_name)
+            execute += self.sail_exe + ' --config={0} --trace-all --signature-granularity=4  --test-signature={1} {2} > {3}.log 2>&1;'.format(sail_config_path, sig_file, elf, test_name)
 
             cov_str = ' '
             for label in testentry['coverage_labels']:

--- a/riscof-plugins/rv64/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv64/sail_cSim/riscof_sail_cSim.py
@@ -145,7 +145,7 @@ class sail_cSim(pluginTemplate):
             with open(sail_config_path, 'w', encoding='utf-8') as file:
                 json.dump(sail_config, file, indent=4)
 
-            execute += self.sail_exe + ' --config={0} -v --trace=step --signature-granularity=8  --test-signature={1} {2} > {3}.log 2>&1;'.format(sail_config_path, sig_file, elf, test_name)
+            execute += self.sail_exe + ' --config={0} --trace-all --signature-granularity=8  --test-signature={1} {2} > {3}.log 2>&1;'.format(sail_config_path, sig_file, elf, test_name)
 
             cov_str = ' '
             for label in testentry['coverage_labels']:


### PR DESCRIPTION
## Description

Tests execution on reference started failing due to a recent change in Sail (https://github.com/riscv/sail-riscv/pull/1129).
`-v` is no longer used for trace. It is separated into different trace arguments & `--trace-all` enables all of them. 

CI will fail without this fix.