### PR TITLE
Fix vclmul &vclmulh ISA bug

### DIFF
--- a/coverage/zvk/vclmul.cgf
+++ b/coverage/zvk/vclmul.cgf
@@ -2,7 +2,7 @@
 
 vclmul.vv:
     config:
-      - check ISA:=(.*I.*V.*Zvkb)
+      - check ISA:=(.*I.*V.*Zvbc)
     mnemonics:
       vclmul.vv: 0
     rs1:
@@ -16,7 +16,7 @@ vclmul.vv:
 
 vclmul.vx:
     config:
-      - check ISA:=(.*I.*V.*Zvkb)
+      - check ISA:=(.*I.*V.*Zvbc)
     mnemonics:
       vclmul.vx: 0
     rs1:

--- a/coverage/zvk/vclmulh.cgf
+++ b/coverage/zvk/vclmulh.cgf
@@ -2,7 +2,7 @@
 
 vclmulh.vv:
     config:
-      - check ISA:=(.*I.*V.*Zvkb)
+      - check ISA:=(.*I.*V.*Zvbc)
     mnemonics:
       vclmulh.vv: 0
     rs1:
@@ -16,7 +16,7 @@ vclmulh.vv:
 
 vclmulh.vx:
     config:
-      - check ISA:=(.*I.*V.*Zvkb)
+      - check ISA:=(.*I.*V.*Zvbc)
     mnemonics:
       vclmulh.vx: 0
     rs1:

--- a/riscv-test-suite/rv32i_m/Zvk/src/vclmul.vv-01.S
+++ b/riscv-test-suite/rv32i_m/Zvk/src/vclmul.vv-01.S
@@ -11,7 +11,7 @@
 
 #include "test_macros_vector.h"
 
-RVTEST_ISA("RV32IV_Zicsr_Zvkb,RV64IV_Zicsr_Zvkb")
+RVTEST_ISA("RV32IV_Zicsr_Zvbc,RV64IV_Zicsr_Zvbc")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvkb);def TEST_CASE_1=True;",vclmul.vv)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvbc);def TEST_CASE_1=True;",vclmul.vv)
 
 RVTEST_V_ENABLE()
 RVTEST_VALBASEUPD(DATA_BASE, dataset_tc1)

--- a/riscv-test-suite/rv32i_m/Zvk/src/vclmul.vx-01.S
+++ b/riscv-test-suite/rv32i_m/Zvk/src/vclmul.vx-01.S
@@ -11,7 +11,7 @@
 
 #include "test_macros_vector.h"
 
-RVTEST_ISA("RV32IV_Zicsr_Zvkb,RV64IV_Zicsr_Zvkb")
+RVTEST_ISA("RV32IV_Zicsr_Zvbc,RV64IV_Zicsr_Zvbc")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvkb);def TEST_CASE_1=True;",vclmul.vx)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvbc);def TEST_CASE_1=True;",vclmul.vx)
 
 RVTEST_V_ENABLE()
 RVTEST_VALBASEUPD(DATA_BASE, dataset_tc1)

--- a/riscv-test-suite/rv32i_m/Zvk/src/vclmulh.vv-01.S
+++ b/riscv-test-suite/rv32i_m/Zvk/src/vclmulh.vv-01.S
@@ -11,7 +11,7 @@
 
 #include "test_macros_vector.h"
 
-RVTEST_ISA("RV32IV_Zicsr_Zvkb,RV64IV_Zicsr_Zvkb")
+RVTEST_ISA("RV32IV_Zicsr_Zvbc,RV64IV_Zicsr_Zvbc")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvkb);def TEST_CASE_1=True;",vclmulh.vv)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvbc);def TEST_CASE_1=True;",vclmulh.vv)
 
 RVTEST_V_ENABLE()
 RVTEST_VALBASEUPD(DATA_BASE, dataset_tc1)

--- a/riscv-test-suite/rv32i_m/Zvk/src/vclmulh.vx-01.S
+++ b/riscv-test-suite/rv32i_m/Zvk/src/vclmulh.vx-01.S
@@ -11,7 +11,7 @@
 
 #include "test_macros_vector.h"
 
-RVTEST_ISA("RV32IV_Zicsr_Zvkb,RV64IV_Zicsr_Zvkb")
+RVTEST_ISA("RV32IV_Zicsr_Zvbc,RV64IV_Zicsr_Zvbc")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -22,7 +22,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvkb);def TEST_CASE_1=True;",vclmulh.vx)
+RVTEST_CASE(0,"//check ISA:=regex(.*I.*V.*Zicsr.*Zvbc);def TEST_CASE_1=True;",vclmulh.vx)
 
 RVTEST_V_ENABLE()
 RVTEST_VALBASEUPD(DATA_BASE, dataset_tc1)


### PR DESCRIPTION
## Description

Fixed a small problem with isa. `vclmul.v[xv]` and `vclmulh.v[vx]` are from Zvbc, but the test case and cgf mistakenly set isa to Zvkb.

### Related Issues

[#686](https://github.com/riscv-non-isa/riscv-arch-test/issues/686)

