### PR TITLE
Solving rtn2mmode NOTE: (Ecall must NOT delegate when T2=0 or this fails).

### DIFF
--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -319,6 +319,7 @@
 #define MPP_LSB   11    //bit pos of LSB of the mstatus.MPP  field
 #define MPRV_LSB  17    //bit pos of LSB of the mstatus.MPRV field
 #define MPV_LSB    7    // bit pos of prev vmod mstatush.MPV in either mstatush or mstatus upper
+#define SPV_LSB    7    // bit pos of prev vmod hstatus.SPV 
 #define MPP_SMODE (1<<MPP_LSB)
 #define MPP_MMODE (3<<MPP_LSB)
 //define sizes
@@ -813,6 +814,26 @@
 .option pop
 .endm
 
+/***********************************************************************************/     
+/**** This is a helper macro that causes harts to transition from               ****/
+/**** U-mode to a higher priv mode at the instruction that follows              ****/
+/***********************************************************************************/
+
+.macro  RVTEST_GOTO_SMODE
+.option push
+.option norvc
+#ifdef  rvtest_strap_routine    /**** this can be empty if no Umode ****/
+    mv   t0, x2                 /* FIXME: Hacky way to preserve x2 as stack pointer by trashing t0 instead */
+    li   x2, 0                  /* Ecall w/x2=0 is handled specially to rtn here */
+
+    ecall                   /* ECALL: traps always, but returns immediately to */
+                                /* the next op if x2=0, else handles trap normally */
+    mv   x2, t0                 /* FIXME: Hacky way to preserve x2 as stack pointer by trashing t0 instead */
+
+ #endif
+.option pop
+.endm
+
 
 /**** This is a helper macro that causes harts to transition from               ****/
 /**** M-mode to a lower priv mode at the instruction that follows               ****/
@@ -1193,7 +1214,11 @@ spcl_\__MODE__\()2mmode_test:
         addi    T4, T4, -8                      // map cause 8..11 to 0.  Mmode should avoid ECALL 0
         bnez    T4, \__MODE__\()trapsig_ptr_upd // no, not in special mode, just continue
         LREG    T2, trap_sv_off+7*REGWIDTH(sp)  // get test x2 (which is sp, which has been saved in the trap_sv area
+.ifc \__MODE__ , S
+        beqz    T2, rtn2smode                   // if T2==0, then we are in Umode, so go to Mmode
+.else 
         beqz    T2, rtn2mmode                   // spcl code 0 in T2 means spcl ECALL goto_mmode, just rtn after ECALL
+.endif
 //------pre-update trap_sig pointer so handlers can themselves trap-----
 \__MODE__\()trapsig_ptr_upd:                    // calculate entry size based on int vs. excpt, int type, and h mode
         li      T2, 4*REGWIDTH                  // standard entry length
@@ -1724,10 +1749,53 @@ excpt_\__MODE__\()hndlr_tbl:            // handler code should only touch T2..T6
 
 .ifc \__MODE__ , M
 
-/***************  Spcl handler for returning from GOTO_MMODE.            ********/
-/***************  Only gets executed if GOTO_MMODE not called from Mmode ********/
-/***************  Executed in M-mode. Enter w/ T1=ptr to Mregsave, T2=0  ********/
-/***************  NOTE: Ecall must NOT delegate when T2=0 or this fails  ********/
+
+
+
+//*********************************************************************************************************************/
+/***************  Spcl handler for returning from GOTO_SMODE                                                   ********/
+/***************  Executed in S-mode. Enter w/ T1=ptr to Mregsave, T2=0                                        ********/
+/***************  T5 = SCAUSE                                                                                  ********/
+/***************  NOTE: Code needs to be updated when rvtest_vtrap_routine= True, currently commented out      ********/
+/***************  NOTE: There is a relocation calculation that is not currently working (commented out)        ********/
+/***************  Created to solve rtn2mmode NOTE: (Ecall must NOT delegate when T2=0 or this fails)           ********/
+/***************  rtn2smode solve the delegation failure and also uses CSRs that can be accessed in supervisor ********/
+/**********************************************************************************************************************/
+
+rtn2smode:
+        addi    T4,T5, -CAUSE_SUPERVISOR_ECALL    
+        beqz    T4, rtn_fm_smode                                /* shortcut if called from Smode        */
+// #if (rvtest_vtrap_routine)                                   /* uncommented when needed for V*/
+//         csrr    T2, CSR_HSTATUS                              /* find out originating mode if RV64/128*/
+//         slli    T2, T2, WDSZ-SPV_LSB-1                       /* but V into MSB  ****FIXME if RV128   */ 
+// #endif
+        LREG    T6, code_bgn_off+1*sv_area_sz(sp)               /* Access S-mode save area: get U/S mode code begin */
+        bgez    T2, rtn_fm_smode                                /* V==0, not virtualized, *1 offset  */
+// from_vir:
+//         LREG    T6, code_bgn_off+2*sv_area_sz(sp)            /* get VU/VS   mode code begin */
+
+// /* Don't understand the logic behind the operations to find CODE_BEGIN */
+// /* Obtain the correct epc to come back to the running code without this so it might be needed for rtn2smode */
+// from_u_ss:                                                   /* get u/s modes CODE_BEGIN             */
+//         sub     T4, T4, T6                                   /* calc relocation amount               */
+rtn_fm_smode:
+        csrr    T2, CSR_SEPC                                    /* get return address in orig mode's VM */
+        //add     T2, T2, T4                                    /* calc rtn_addr in Mmode VM           */
+
+        LREG    T1, trap_sv_off+1*REGWIDTH(sp)
+ //     LREG    T2, trap_sv_off+2*REGWIDTH(sp)                  /* this holds the return address  */
+        LREG    T3, trap_sv_off+3*REGWIDTH(sp)
+        LREG    T4, trap_sv_off+4*REGWIDTH(sp)  
+        LREG    T5, trap_sv_off+5*REGWIDTH(sp)  
+        LREG    T6, trap_sv_off+6*REGWIDTH(sp)
+        LREG    sp, trap_sv_off+7*REGWIDTH(sp)                  // restore temporaries
+        jr      4(T2)                                           /* return after GOTO_SMODE in S-mode    */
+        
+        
+/***************  Spcl handler for returning from GOTO_MMODE.                                   ********/
+/***************  Only gets executed if GOTO_MMODE not called from Mmode                        ********/
+/***************  Executed in M-mode. Enter w/ T1=ptr to Mregsave, T2=0                         ********/
+/***************  NOTE: Ecall must NOT delegate when T2=0 or this fails -> branch to rtn2smode  ********/
 
 rtn2mmode:
         addi    T4,T5, -CAUSE_MACHINE_ECALL


### PR DESCRIPTION
Spcl handler created for returning from GOTO_SMODE                                                    
(Executed in S-mode. Enter w/ T1=ptr to Mregsave, T2=0)

Created to solve rtn2mmode NOTE: (Ecall must NOT delegate when T2=0 or this fails). rtn2smode solve the delegation failure and also uses CSRs that can be accessed in supervisor                                      

 NOTE: 
- Code needs to be updated when rvtest_vtrap_routine= True, currently commented out     
- There is a relocation calculation that is not currently working (commented out)
