### PR TITLE
PMP test fix for M/U only implementation for RV64 (#584, #657)

### DIFF
--- a/riscv-test-suite/rv64i_m/pmp/src/pmp64-CSR-ALL-MODES.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmp64-CSR-ALL-MODES.S
@@ -19,7 +19,6 @@
 // Dependencies: model_test.h, arch_test.h
 // Total expected faults: 2+5+3+6+8 = 24.
 // ---------------------------------------------------------------------------
-#define rvtest_strap_routine
 #include "model_test.h"
 #include "arch_test.h"
 RVTEST_ISA("RV64I_Zicsr")
@@ -30,7 +29,8 @@ rvtest_entry_point:
 RVMODEL_BOOT
 RVTEST_CODE_BEGIN
 #ifdef TEST_CASE_1
-    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",PMP_access_permission)
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True",PMP_access_permission)
+    RVTEST_CASE(2,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I[^S]*Zicsr.*); def rvtest_mtrap_routine=True; def TEST_CASE_1=True",PMP_access_permission)
 RVTEST_SIGBASE( x13,signature_x13_1)
 	.option nopic
 	.attribute unaligned_access, 0
@@ -95,7 +95,9 @@ main:
 	.set pmpcfgi, pmpcfgi+2		// increment variable to next pmpcfg reg
 	.endr			// END OF LOOP BODY
 /////////////////// Switch to S-mode ////////////////////////////////////////////
+#ifdef rvtest_strap_routine
 	csrw satp, zero                // Disable address translation.
+#endif
 	LI(t2, -1)
 	csrw pmpaddr0, t2		// Updated pmpaddr0 to define PMP region consisting
 					// of whole physical memory
@@ -151,7 +153,9 @@ main:
 	nop				// Added nop in case of trap
 	RVTEST_SIGUPD(x13,a4)
 /////////////////// Switch to U-mode ////////////////////////////////////////////
+#ifdef rvtest_strap_routine
 	csrw satp, zero                 // Disable address translation.
+#endif
 	LI(t2, -1)
 	csrw pmpaddr0, t2		// Updated pmpaddr0 to define PMP region consisting
 					// of whole physical memory

--- a/riscv-test-suite/rv64i_m/pmp/src/pmp64-NA4-M.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmp64-NA4-M.S
@@ -37,7 +37,8 @@ RVMODEL_BOOT
 RVTEST_CODE_BEGIN
 
 
-RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-grain'] == 0); verify (PMP['pmp-writable'] >= 7); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NA4_M)
+RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I[^S]*Zicsr.*); def rvtest_mtrap_routine=True;                                verify (PMP['implemented']); verify (PMP['pmp-grain'] == 0); verify (PMP['pmp-writable'] >= 7); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NA4_M)
+RVTEST_CASE(2,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-grain'] == 0); verify (PMP['pmp-writable'] >= 7); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NA4_M)
 
 #ifdef TEST_CASE_1
 RVTEST_SIGBASE( x13,signature_x13_1)
@@ -142,7 +143,9 @@ main:
 #define PMPADDRESS_TEST			TEST_FOR_EXECUTION 										// Test Section address
 
 //											Test Setup Section
+#ifdef rvtest_strap_routine
 	csrw satp, x0																		// Disable Address Translation
+#endif
 
 	LA(x4, PMPADDRESS_TOP_GLOBAL)
 	srl x4, x4, PMP_SHIFT

--- a/riscv-test-suite/rv64i_m/pmp/src/pmp64-NA4-U.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmp64-NA4-U.S
@@ -36,7 +36,8 @@ rvtest_entry_point:
 RVMODEL_BOOT
 RVTEST_CODE_BEGIN
 
-RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-grain'] == 0); verify (PMP['pmp-writable'] >= 3); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NA4_S_U)
+RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I[^S]*Zicsr.*); def rvtest_mtrap_routine=True;                                verify (PMP['implemented']); verify (PMP['pmp-grain'] == 0); verify (PMP['pmp-writable'] >= 3); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NA4_S_U)
+RVTEST_CASE(2,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-grain'] == 0); verify (PMP['pmp-writable'] >= 3); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NA4_S_U)
 
 #ifdef TEST_CASE_1
 RVTEST_SIGBASE( x13,signature_x13_1)
@@ -141,7 +142,9 @@ main:
 #define PMPADDRESS0			TEST_FOR_EXECUTION 										// Test Section address
 
 //											Test Setup Section
+#ifdef rvtest_strap_routine
 	csrw satp, x0																	// Disable Address Translation
+#endif
 
 	LA(x4, PMPADDRESS_TOP_GLOBAL)
 	srl x4, x4, PMP_SHIFT

--- a/riscv-test-suite/rv64i_m/pmp/src/pmp64-NAPOT-M.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmp64-NAPOT-M.S
@@ -36,7 +36,8 @@ rvtest_entry_point:
 RVMODEL_BOOT
 RVTEST_CODE_BEGIN
 
-RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 7); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NAPOT_M)
+RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I[^S]*Zicsr.*); def rvtest_mtrap_routine=True;                                verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 7); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NAPOT_M)
+RVTEST_CASE(2,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 7); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NAPOT_M)
 
 #ifdef TEST_CASE_1
 RVTEST_SIGBASE( x13,signature_x13_1)
@@ -143,7 +144,9 @@ main:
 #define PMP_MASK				~(1 << (RVMODEL_PMP_GRAIN - 1))
 
 //											Test Setup Section
+#ifdef rvtest_strap_routine
 	csrw satp, x0																		// Disable Address Translation
+#endif
 
 	LA(x4, PMPADDRESS_TOP_GLOBAL)
 	srl x4, x4, PMP_SHIFT

--- a/riscv-test-suite/rv64i_m/pmp/src/pmp64-NAPOT-U.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmp64-NAPOT-U.S
@@ -36,7 +36,8 @@ rvtest_entry_point:
 RVMODEL_BOOT
 RVTEST_CODE_BEGIN
 
-RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 3); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NAPOT_S_U)
+RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I[^S]*Zicsr.*); def rvtest_mtrap_routine=True;                                verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 3); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NAPOT_S_U)
+RVTEST_CASE(2,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 3); def TEST_CASE_1=True; mac PMP_MACROS",PMP_NAPOT_S_U)
 
 #ifdef TEST_CASE_1
 RVTEST_SIGBASE( x13,signature_x13_1)
@@ -143,7 +144,9 @@ main:
 #define PMP_MASK			~(1 << (RVMODEL_PMP_GRAIN - 1))
 
 //											Test Setup Section
+#ifdef rvtest_strap_routine
 	csrw satp, x0																	// Disable Address Translation
+#endif
 
 	LA(x4, PMPADDRESS_TOP_GLOBAL)
 	srl x4, x4, PMP_SHIFT

--- a/riscv-test-suite/rv64i_m/pmp/src/pmp64-TOR-M.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmp64-TOR-M.S
@@ -36,7 +36,8 @@ rvtest_entry_point:
 RVMODEL_BOOT
 RVTEST_CODE_BEGIN
 
-RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 12); def TEST_CASE_1=True; mac PMP_MACROS",PMP_TOR_M)
+RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I[^S]*Zicsr.*); def rvtest_mtrap_routine=True;                                verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 12); def TEST_CASE_1=True; mac PMP_MACROS",PMP_TOR_M)
+RVTEST_CASE(2,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 12); def TEST_CASE_1=True; mac PMP_MACROS",PMP_TOR_M)
 
 #ifdef TEST_CASE_1
 RVTEST_SIGBASE( x13,signature_x13_1)
@@ -142,7 +143,9 @@ main:
 #define PMPADDRESS_TEST_BOTTOM		TEST_FOR_EXECUTION 										// Base address for the Test Region
 
 //											Test Setup Section
+#ifdef rvtest_strap_routine
 	csrw satp, x0																	// Disable Address Translation
+#endif
 
 	LA(x4, PMPADDRESS_TOP_GLOBAL)
 	srl x4, x4, PMP_SHIFT

--- a/riscv-test-suite/rv64i_m/pmp/src/pmp64-TOR-U.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmp64-TOR-U.S
@@ -36,7 +36,8 @@ rvtest_entry_point:
 RVMODEL_BOOT
 RVTEST_CODE_BEGIN
 
-RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 4); def TEST_CASE_1=True; mac PMP_MACROS",PMP_TOR_S_U)
+RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I[^S]*Zicsr.*); def rvtest_mtrap_routine=True;                                verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 4); def TEST_CASE_1=True; mac PMP_MACROS",PMP_TOR_S_U)
+RVTEST_CASE(2,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-writable'] >= 4); def TEST_CASE_1=True; mac PMP_MACROS",PMP_TOR_S_U)
 
 #ifdef TEST_CASE_1
 RVTEST_SIGBASE( x13,signature_x13_1)
@@ -142,7 +143,9 @@ main:
 #define PMPADDRESS0			TEST_FOR_EXECUTION 										// Base address for the Test Region
 
 //											Test Setup Section
+#ifdef rvtest_strap_routine
 	csrw satp, x0																	// Disable Address Translation
+#endif
 
 	LA(x4, PMPADDRESS_TOP_GLOBAL)
 	srl x4, x4, PMP_SHIFT


### PR DESCRIPTION
## Description

From #684.

> I will make similar fixes for `rv64i_m/pmp` if the current fixes are approved.

This is for `rv64i_m/pmp`.

`riscof run` command passed all tests with the following three settings.

- RV64IMCZicsr_Zifencei
- RV64IMCUZicsr_Zifencei
- RV64IMCSUZicsr_Zifencei

***

#661 fixed PMP tests, but they still work only on an implementation with S-mode.

By this MR;

- define rvtest_strap_routine only when S-mode is implemented
- use `satp` CSR only when rvtest_strap_routine is defined

### Related Issues

#584, #657

### Ratified/Unratified Extensions

- [x] Ratified
- [ ] Unratified

### List Extensions

PMP, M/U mode

### Reference Model Used

- [x] SAIL
- [x] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [x] All tests are compliant with the test-format spec present in this repo ?
  - [x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
    - ~~I could not find info how to generate a CFG file except for [the CGF specification](https://riscv-isac.readthedocs.io/en/latest/cgf.html).~~
    - I found CFG files are generated under `coverage/`.  But I could not run `riscof coverage` with success.
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >
    - no

### Optional Checklist:

  - [x] Were the tests hand-written/modified ?
    - yes 
  - [x] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
     - confirmed that signatures matched between Spike and a non-public implementation (RTL simulation).
  - [x] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
     - no