### PR TITLE
Reduced time for Reference Makefile generation

### DIFF
--- a/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
@@ -88,6 +88,50 @@ class sail_cSim(pluginTemplate):
             os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
         make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
         make.makeCommand = self.make + ' -j' + self.num_jobs
+
+        isa_yaml = utils.load_yaml(self.isa_yaml_path)
+        # Verify the availability of PMP:
+        if "PMP" in isa_yaml['hart0']:
+            pmp_flags = {}
+            if isa_yaml['hart0']["PMP"]["implemented"] == True:
+                if "pmp-grain" in isa_yaml['hart0']["PMP"]:
+                    pmp_flags["pmp-grain"] = isa_yaml['hart0']["PMP"]["pmp-grain"]
+                else:
+                    logger.error("PMP grain not defined")
+                    pmp_flags = ""
+                if "pmp-count" in isa_yaml['hart0']["PMP"]:
+                    pmp_flags["pmp-count"] = isa_yaml['hart0']["PMP"]["pmp-count"]
+                else:
+                    logger.error("PMP count not defined")
+                    pmp_flags = ""
+        else:
+            pmp_flags = ""
+
+        try:
+            sail_config = subprocess.run(["sail_riscv_sim", "--print-default-config"], check= True, text=True, capture_output=True)
+            sail_config = json.loads(sail_config.stdout)
+        except subprocess.CalledProcessError as e:
+            print("sail_riscv_sim --print-default-config failed:", e.stderr)
+            exit(1)
+        except json.JSONDecodeError:
+            print("sail_riscv_sim --print-default-config output is not valid JSON.")
+            exit(1)
+
+        sail_config["base"]["xlen"] = int(self.xlen)
+        sail_config["memory"]["pmp"]["grain"] = pmp_flags["pmp-grain"]
+        sail_config["memory"]["pmp"]["count"] = pmp_flags["pmp-count"]
+
+        # Enabling extensions that are disabled by default
+        sail_config["extensions"]["Sv32"]["supported"] = True
+        sail_config["extensions"]["Zcf"]["supported"] = True
+
+        #For User-configuration: Replace this variable with your configuration. "/home/riscv-arch-test/custom_sail_config.json"
+        sail_config_path = os.path.join(self.pluginpath, 'env', 'sail_config.json')
+
+        # Write the updated configuration back to the file
+        with open(sail_config_path, 'w', encoding='utf-8') as file:
+            json.dump(sail_config, file, indent=4)
+
         for file in testList:
             testentry = testList[file]
             test = testentry['test_path']
@@ -104,49 +148,6 @@ class sail_cSim(pluginTemplate):
 
             execute += self.objdump_cmd.format(elf, self.xlen, 'ref.disass')
             sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
-
-            isa_yaml = utils.load_yaml(self.isa_yaml_path)
-            # Verify the availability of PMP:
-            if "PMP" in isa_yaml['hart0']:
-                pmp_flags = {}
-                if isa_yaml['hart0']["PMP"]["implemented"] == True:
-                    if "pmp-grain" in isa_yaml['hart0']["PMP"]:
-                        pmp_flags["pmp-grain"] = isa_yaml['hart0']["PMP"]["pmp-grain"]
-                    else:
-                        logger.error("PMP grain not defined")
-                        pmp_flags = ""
-                    if "pmp-count" in isa_yaml['hart0']["PMP"]:
-                        pmp_flags["pmp-count"] = isa_yaml['hart0']["PMP"]["pmp-count"]
-                    else:
-                        logger.error("PMP count not defined")
-                        pmp_flags = ""
-            else:
-                pmp_flags = ""
-
-            try:
-                sail_config = subprocess.run(["sail_riscv_sim", "--print-default-config"], check= True, text=True, capture_output=True)
-                sail_config = json.loads(sail_config.stdout)
-            except subprocess.CalledProcessError as e:
-                print("sail_riscv_sim --print-default-config failed:", e.stderr)
-                exit(1)
-            except json.JSONDecodeError:
-                print("sail_riscv_sim --print-default-config output is not valid JSON.")
-                exit(1)
-
-            sail_config["base"]["xlen"] = int(self.xlen)
-            sail_config["memory"]["pmp"]["grain"] = pmp_flags["pmp-grain"]
-            sail_config["memory"]["pmp"]["count"] = pmp_flags["pmp-count"]
-
-            # Enabling extensions that are disabled by default
-            sail_config["extensions"]["Sv32"]["supported"] = True
-            sail_config["extensions"]["Zcf"]["supported"] = True
-
-            #For User-configuration: Replace this variable with your configuration. "/home/riscv-arch-test/custom_sail_config.json"
-            sail_config_path = os.path.join(self.pluginpath, 'env', 'sail_config.json')
-
-            # Write the updated configuration back to the file
-            with open(sail_config_path, 'w', encoding='utf-8') as file:
-                json.dump(sail_config, file, indent=4)
 
             execute += self.sail_exe + ' --config={0} --trace-all --signature-granularity=4  --test-signature={1} {2} > {3}.log 2>&1;'.format(sail_config_path, sig_file, elf, test_name)
 


### PR DESCRIPTION
"Running tests on Reference" took a greater amount of time as compared to "Running tests on DUT". First I though that Sail is relatively slower than Spike. However, that's not the case. The Makefile for Spike was being generated instantly, while the Makefile for Sail was taking a lot of time (~40s for RV64I). 
The issue is in the Sail plugin. It was loading sail_isa.yaml, setting configurations and writing those into sail_config.json in **every iteration** (where it is iterating through every test in the directory). 
This was a problem in the code as neither the isa.yaml would change nor the configurations. Therefore, I have changed the code to generate the sail_config.json file **once** and then enter the loop for generating Makefile.

**This has greatly reduced the runtime for Reference**. In case of RV64I
**Previous:**
```
  INFO | Running Tests on Reference Model.
  Time elapsed in generating Sail Makefile:  0:00:39.930905
```
**Now:**
```
  INFO | Running Tests on Reference Model.
  Time elapsed in generating Sail Makefile:  0:00:00.826270
```

After that the plugin executes the Makefile. This change **saves us about 40 seconds for RV64I.**

Similarly, **about 32 seconds are being saved for RV32I.**
