### PR TITLE
(CI Fix) Disabled Svrsw60t59b extension from RV32 Sail plugin

### DIFF
--- a/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
@@ -124,6 +124,7 @@ class sail_cSim(pluginTemplate):
         # Enabling extensions that are disabled by default
         sail_config["extensions"]["Sv32"]["supported"] = True
         sail_config["extensions"]["Zcf"]["supported"] = True
+        sail_config["extensions"]["Svrsw60t59b"]["supported"] = False
 
         #For User-configuration: Replace this variable with your configuration. "/home/riscv-arch-test/custom_sail_config.json"
         sail_config_path = os.path.join(self.pluginpath, 'env', 'sail_config.json')

--- a/riscof-plugins/rv64/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv64/sail_cSim/riscof_sail_cSim.py
@@ -118,7 +118,6 @@ class sail_cSim(pluginTemplate):
             exit(1)
 
         sail_config["base"]["xlen"] = int(self.xlen)
-        sail_config["base"]["mtval_has_illegal_instruction_bits"] = True
         sail_config["memory"]["pmp"]["grain"] = pmp_flags["pmp-grain"]
         sail_config["memory"]["pmp"]["count"] = pmp_flags["pmp-count"]
 


### PR DESCRIPTION
Closes #697. 

The cause of failure was: 
**Svrsw60t59b** is enabled but Sv39 is disabled, supporting Svrsw60t59b requires supporting Sv39.
Therefore, I have disabled it from the RV32 plugin file.
["mtval_has_illegal_instruction_bits"] has a default value of True now, therefore that line in RV64 is no more required.