### PR TITLE
Using pre-built Sail binary for CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -98,37 +98,12 @@ jobs:
           path: ${{ github.workspace }}/spike
           key: ${{ steps.cache-spike-restore.outputs.cache-primary-key }}
 
-      - name: Get Latest Sail Commit
-        run: |
-              SAIL_HASH=$(git ls-remote https://github.com/riscv/sail-riscv.git HEAD | awk '{ print $1}')
-              echo "SAIL_HASH=$SAIL_HASH" >> "$GITHUB_ENV"
-
-      - name: Restore cached Sail
-        id: cache-sail-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/sail
-          key: sail-${{ env.SAIL_HASH }}
-
       - name: Install Sail
-        if: steps.cache-sail-restore.outputs.cache-hit != 'true'
         run: |
-          sudo mkdir -p /usr/local
-          curl --location https://github.com/rems-project/sail/releases/latest/download/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
-          git clone https://github.com/riscv/sail-riscv.git
-          cd sail-riscv
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja
-          cmake --build build
+          mkdir sail-riscv
+          wget -qO- https://github.com/riscv/sail-riscv/releases/download/0.8/sail-riscv-Linux-x86_64.tar.gz | tar -xvzf - --directory=sail-riscv --strip-components=1
           mkdir -p $GITHUB_WORKSPACE/sail
-          mv build/c_emulator/sail_riscv_sim $GITHUB_WORKSPACE/sail/sail_riscv_sim
-
-      - name: Save cached Sail
-        if: steps.cache-sail-restore.outputs.cache-hit != 'true'
-        id: cache-sail-save
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/sail
-          key: ${{ steps.cache-sail-restore.outputs.cache-primary-key }}
+          mv sail-riscv/bin/sail_riscv_sim $GITHUB_WORKSPACE/sail/sail_riscv_sim
 
       - name: Set PATH
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,37 +107,12 @@ jobs:
           path: ${{ github.workspace }}/spike
           key: ${{ steps.cache-spike-restore.outputs.cache-primary-key }}
 
-      - name: Get Latest Sail Commit
-        run: |
-              SAIL_HASH=$(git ls-remote https://github.com/riscv/sail-riscv.git HEAD | awk '{ print $1}')
-              echo "SAIL_HASH=$SAIL_HASH" >> "$GITHUB_ENV"
-
-      - name: Restore cached Sail
-        id: cache-sail-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/sail
-          key: sail-${{ env.SAIL_HASH }}
-
       - name: Install Sail
-        if: steps.cache-sail-restore.outputs.cache-hit != 'true'
         run: |
-          sudo mkdir -p /usr/local
-          curl --location https://github.com/rems-project/sail/releases/latest/download/sail.tar.gz | sudo tar xvz --directory=/usr/local --strip-components=1
-          git clone https://github.com/riscv/sail-riscv.git
-          cd sail-riscv
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja
-          cmake --build build
+          mkdir sail-riscv
+          wget -qO- https://github.com/riscv/sail-riscv/releases/download/0.8/sail-riscv-Linux-x86_64.tar.gz | tar -xvzf - --directory=sail-riscv --strip-components=1
           mkdir -p $GITHUB_WORKSPACE/sail
-          mv build/c_emulator/sail_riscv_sim $GITHUB_WORKSPACE/sail/sail_riscv_sim
-
-      - name: Save cached Sail
-        if: steps.cache-sail-restore.outputs.cache-hit != 'true'
-        id: cache-sail-save
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/sail
-          key: ${{ steps.cache-sail-restore.outputs.cache-primary-key }}
+          mv sail-riscv/bin/sail_riscv_sim $GITHUB_WORKSPACE/sail/sail_riscv_sim
 
       - name: Set PATH
         run: |

--- a/coverage/sv32/rv32_vm_sv32.cgf
+++ b/coverage/sv32/rv32_vm_sv32.cgf
@@ -444,3 +444,15 @@ VA_all_ones:
   val_comb:
     'mode == "S" and mnemonic == {"sb", "lbu"} and (rs1_val & 0xFFFFFFFF) == 0xFFFFFFFF': 0
     'mode == "S" and mnemonic == "jalr" and (rs1_val & 0xFFFFFFFF) == 0xFFFFFFFC': 0
+
+VA_all_zeros:
+  config:
+    - check ISA:=regex(.*32.*); check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True;
+  mnemonics:
+    "{sw, csrrc, csrrs, csrrw, lw, jalr}": 0
+  op_comb:
+    'mode == "S" and (satp >> 31) ==  ${SATP_MODE_SV32}': 0
+  csr_comb:
+    '((satp) & 0x003FFFFF)  == get_addr("rvtest_Sroot_pg_tbl") >> 12': 0
+  val_comb:
+    'mode == "S" and mnemonic == {"sw", "lw", "jalr"} and ((rs1_val + imm_val) & 0xFFFFFFFF) == 0x0': 0

--- a/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv32/sail_cSim/riscof_sail_cSim.py
@@ -77,7 +77,6 @@ class sail_cSim(pluginTemplate):
             raise SystemExit(1)
         if shutil.which(self.sail_exe) is None:
             logger.error(self.sail_exe + ": executable not found. Please check environment setup.")
-            logger.error("Sail has been updated to use sail_riscv_sim instead of riscv_sim_rv(32/64)d. Please make sure that you have the latest version of Sail installed.")
             raise SystemExit(1)
         if shutil.which(self.make) is None:
             logger.error(self.make+": executable not found. Please check environment setup.")
@@ -124,7 +123,6 @@ class sail_cSim(pluginTemplate):
         # Enabling extensions that are disabled by default
         sail_config["extensions"]["Sv32"]["supported"] = True
         sail_config["extensions"]["Zcf"]["supported"] = True
-        sail_config["extensions"]["Svrsw60t59b"]["supported"] = False
 
         #For User-configuration: Replace this variable with your configuration. "/home/riscv-arch-test/custom_sail_config.json"
         sail_config_path = os.path.join(self.pluginpath, 'env', 'sail_config.json')

--- a/riscof-plugins/rv64/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugins/rv64/sail_cSim/riscof_sail_cSim.py
@@ -77,7 +77,6 @@ class sail_cSim(pluginTemplate):
             raise SystemExit(1)
         if shutil.which(self.sail_exe) is None:
             logger.error(self.sail_exe + ": executable not found. Please check environment setup.")
-            logger.error("Sail has been updated to use sail_riscv_sim instead of riscv_sim_rv(32/64)d. Please make sure that you have the latest version of Sail installed.")
             raise SystemExit(1)
         if shutil.which(self.make) is None:
             logger.error(self.make+": executable not found. Please check environment setup.")
@@ -120,9 +119,8 @@ class sail_cSim(pluginTemplate):
         sail_config["base"]["xlen"] = int(self.xlen)
         sail_config["memory"]["pmp"]["grain"] = pmp_flags["pmp-grain"]
         sail_config["memory"]["pmp"]["count"] = pmp_flags["pmp-count"]
-
-        sail_config["extensions"]["Svrsw60t59b"]["supported"] = False
-
+        sail_config["base"]["mtval_has_illegal_instruction_bits"] = True
+        
         #For User-configuration: Replace this variable with your configuration. "/home/riscv-arch-test/custom_sail_config.json"
         sail_config_path = os.path.join(self.pluginpath, 'env', 'sail_config.json')
 


### PR DESCRIPTION
CI starts to fail quite often mostly due to changes in Sail. [sail-riscv](https://github.com/riscv/sail-riscv) is a highly active repository with addition of many new features and changes each week. Therefore, on recommendation of @UmerShahidengr I've updated CI workflow to use pre-built Sail binary. Their latest release is version 0.8, and we could update CI and plugins accordingly on release of a newer version. This will make riscv-arch-test's CI more stable & reliable.