### PR TITLE
Some fixes and consistency in PMP tests

### DIFF
--- a/riscv-test-suite/rv32i_m/pmp/src/pmpm_csr_walk.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpm_csr_walk.S
@@ -171,6 +171,10 @@ main:
     slli t2, t2, 1               // Shift walking one to left
     bnez t2, 2b                  // Continue loop while t2 != 0
 
+	RVTEST_GOTO_MMODE
+	li a4, 0xbeefcafe							// Clean Test exit verification signature.
+    RVTEST_SIGUPD(x13, a4)       				// Signature update
+	j exit										// Verification Complete, exit the test
 
 .align 10
 .align (RVMODEL_PMP_GRAIN+2)

--- a/riscv-test-suite/rv32i_m/pmp/src/pmps_csr_access.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmps_csr_access.S
@@ -75,7 +75,7 @@ main:
 	LA(x4, -1)
 
 	.set pmpaddri, CSR_PMPADDR0
-	.rept RVMODEL_NUM_PMPS
+	.rept 64
     RVTEST_GOTO_LOWER_MODE	Smode		// SWITCH TO S-mode
 	csrw pmpaddri, x4
     nop
@@ -84,7 +84,7 @@ main:
 	.endr
 
 	.set pmpcfgi, CSR_PMPCFG0
-	.rept RVMODEL_NUM_PMPS/4
+	.rept 16
     RVTEST_GOTO_LOWER_MODE	Smode		// SWITCH TO S-mode
 	csrw pmpcfgi , x4
     nop

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpu_csr_access.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpu_csr_access.S
@@ -76,7 +76,7 @@ main:
 	LA(x4, -1)
 
 	.set pmpaddri, CSR_PMPADDR0
-	.rept RVMODEL_NUM_PMPS
+	.rept 64
     RVTEST_GOTO_LOWER_MODE	Umode		// SWITCH TO U-mode
 	csrw pmpaddri, x4
     nop
@@ -85,7 +85,7 @@ main:
 	.endr
 
 	.set pmpcfgi, CSR_PMPCFG0
-	.rept RVMODEL_NUM_PMPS/4
+	.rept 16
     RVTEST_GOTO_LOWER_MODE	Umode		// SWITCH TO U-mode
 	csrw pmpcfgi , x4
     nop

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpzca_legal_lxwr.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpzca_legal_lxwr.S
@@ -51,7 +51,7 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 	.attribute unaligned_access, 0
 	.attribute stack_align, 16
   	.align	3   
-#define NOP 		0x13
+#define NOP 		0x00010001
 
 .macro VERIFICATION_RWX ADDRESS  
 
@@ -64,6 +64,7 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 1:
 	c.nop
     c.nop
+	
     LI(x15, NOP)                  							// Value to write (NOP)
     // Store Access Check
     LA(x8, \ADDRESS)             							// Address to be verified
@@ -85,6 +86,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 	c.nop
 	c.nop
 	c.lwsp x15, 0(sp)
+	c.nop
+	c.nop
 	c.nop
 	c.nop
 

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpzca_misaligned_tor.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpzca_misaligned_tor.S
@@ -47,6 +47,7 @@ RVTEST_CODE_BEGIN
 RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*C[^S]*Zicsr.*); def rvtest_mtrap_routine=True;                                verify (PMP['implemented']); def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_misaligned_tor)
 RVTEST_CASE(2,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*C.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_misaligned_tor)
 #ifdef TEST_CASE_1
+
 RVTEST_SIGBASE( x13,signature_x13_1)
 	.attribute unaligned_access, 0
 	.attribute stack_align, 16

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpzcb_legal_lxwr.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpzcb_legal_lxwr.S
@@ -43,7 +43,7 @@ RVTEST_CODE_BEGIN
 	#define RVMODEL_NUM_PMPS 16
 #endif
 
-RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*C[^S]*Zicsr.*Zcb.*); def rvtest_mtrap_routine=True;								 verify (PMP['implemented']); def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_cfg_RW)
+RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*C[^S]*Zicsr.*Zcb.*); def rvtest_mtrap_routine=True;								verify (PMP['implemented']); def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_cfg_RW)
 RVTEST_CASE(2,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*C.*S.*Zicsr.*Zcb.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_cfg_RW)
 
 #ifdef TEST_CASE_1

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpzcf_legal_lxwr.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpzcf_legal_lxwr.S
@@ -44,7 +44,7 @@ RVTEST_FP_ENABLE()
 	#define RVMODEL_NUM_PMPS 16
 #endif
 
-RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*F[^S]*Zicsr.*Zcf.*); def rvtest_mtrap_routine=True; 								 verify (PMP['implemented']); def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_cfg_RW)
+RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*F[^S]*Zicsr.*Zcf.*); def rvtest_mtrap_routine=True; 								verify (PMP['implemented']); def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_cfg_RW)
 RVTEST_CASE(2,"//check ISA:=regex(.*32.*); check ISA:=regex(.*I.*F.*S.*Zicsr.*Zcf.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_cfg_RW)
 
 #ifdef TEST_CASE_1

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpzicbo_prefetch.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpzicbo_prefetch.S
@@ -43,8 +43,8 @@ RVTEST_CODE_BEGIN
 	#define RVMODEL_NUM_PMPS 16
 #endif
 
-RVTEST_CASE(1,"//check ISA:=regex(.*32.*); # CHECK ISA := regex(.*I[^S]*Zicbop.*Zicsr.*); def rvtest_mtrap_routine=True;								def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_prefetch)
-RVTEST_CASE(2,"//check ISA:=regex(.*32.*); # CHECK ISA := regex(.*I.*S.*Zicbop.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_prefetch)
+RVTEST_CASE(1,"//check ISA:=regex(.*32.*); check ISA:= regex(.*I[^S]*Zicbop.*Zicsr.*); def rvtest_mtrap_routine=True;								def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_prefetch)
+RVTEST_CASE(2,"//check ISA:=regex(.*32.*); check ISA:= regex(.*I.*S.*Zicbop.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_prefetch)
 
 #ifdef TEST_CASE_1
 RVTEST_SIGBASE( x13,signature_x13_1)
@@ -255,5 +255,4 @@ gpr_save:
 sig_end_canary:
 CANARY;
 rvtest_sig_end:
-PMP_region_High:
 RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpm_csr_walk.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpm_csr_walk.S
@@ -170,6 +170,11 @@ main:
 	.set pmpcfgi, pmpcfgi+1
 	.endr
 
+	RVTEST_GOTO_MMODE
+	li a4, 0xbeefcafe							// Clean Test exit verification signature.
+    RVTEST_SIGUPD(x13, a4)       				// Signature update
+	j exit										// Verification Complete, exit the test
+
 .align 10
 .align (RVMODEL_PMP_GRAIN+2)
 

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpm_csr_walk.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpm_csr_walk.S
@@ -146,13 +146,6 @@ main:
     slli t2, t2, 1               // Shift walking one to left
     bnez t2, 1b                  // Continue loop while t2 != 0
 
-	// Loop to SET ALL pmpcfg REGs to zero
-	.set pmpcfgi, CSR_PMPCFG0
-	.rept RVMODEL_NUM_PMPS/4
-	csrw pmpcfgi , x0
-	.set pmpcfgi, pmpcfgi+1
-	.endr
-
     li t2, 1                     // walking one: 0x00000001
 
 2:  // Outer loop for walking ones
@@ -170,6 +163,12 @@ main:
     slli t2, t2, 1               // Shift walking one to left
     bnez t2, 2b                  // Continue loop while t2 != 0
 
+	// Loop to SET ALL pmpcfg REGs to zero
+	.set pmpcfgi, CSR_PMPCFG0
+	.rept RVMODEL_NUM_PMPS/4
+	csrw pmpcfgi , x0
+	.set pmpcfgi, pmpcfgi+1
+	.endr
 
 .align 10
 .align (RVMODEL_PMP_GRAIN+2)

--- a/riscv-test-suite/rv64i_m/pmp/src/pmps_csr_access.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmps_csr_access.S
@@ -76,7 +76,7 @@ main:
 	LA(x4, -1)
 
 	.set pmpaddri, CSR_PMPADDR0
-	.rept RVMODEL_NUM_PMPS
+	.rept 64
     RVTEST_GOTO_LOWER_MODE	Smode		// SWITCH TO S-mode
 	csrw pmpaddri, x4
     nop
@@ -85,8 +85,7 @@ main:
 	.endr
 
 	.set pmpcfgi, CSR_PMPCFG0
-	.rept RVMODEL_NUM_PMPS/4
-	
+	.rept 16
     RVTEST_GOTO_LOWER_MODE	Smode		// SWITCH TO S-mode
 	csrw pmpcfgi , x4
     nop

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpu_csr_access.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpu_csr_access.S
@@ -76,7 +76,7 @@ main:
 	LA(x4, -1)
 
 	.set pmpaddri, CSR_PMPADDR0
-	.rept RVMODEL_NUM_PMPS
+	.rept 64
     RVTEST_GOTO_LOWER_MODE	Umode		// SWITCH TO U-mode
 	csrw pmpaddri, x4
     nop
@@ -85,8 +85,7 @@ main:
 	.endr
 
 	.set pmpcfgi, CSR_PMPCFG0
-	.rept RVMODEL_NUM_PMPS/4
-	
+	.rept 16
     RVTEST_GOTO_LOWER_MODE	Umode		// SWITCH TO U-mode
 	csrw pmpcfgi , x4
     nop

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpzca_legal_lwxr.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpzca_legal_lwxr.S
@@ -51,7 +51,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 	.attribute unaligned_access, 0
 	.attribute stack_align, 16
   	.align	3   
-#define NOP 		(0x13<<32)+0x13
+#define DOUBLE_CNOP 		(0x00010001)
+#define TETRA_CNOP			(0x00010001<<32)+0x00010001
 
 .macro VERIFICATION_RWX ADDRESS  
 
@@ -64,29 +65,50 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 1:
 	c.nop
     c.nop
-    LI(x15, NOP)                  							// Value to write (NOP)
+
+    LI(x15, DOUBLE_CNOP)                  							// Value to write (NOP)
     // Store Access Check
     LA(x8, \ADDRESS)             							// Address to be verified
     c.sw x15, 0(x8)
     c.nop
     c.nop
+    LA(sp, \ADDRESS)             							// Address to be verified
+    c.swsp x15, 0(sp)
     c.nop
     c.nop
+
+    LI(x15, TETRA_CNOP)                  							// Value to write (NOP)
+    // Store Access Check
+    LA(x8, \ADDRESS)             							// Address to be verified
+    c.sd x15, 0(x8)
+    c.nop
+    c.nop
+    LA(sp, \ADDRESS)             							// Address to be verified
+    c.sdsp x15, 0(sp)
+    c.nop
+    c.nop
+
+    LI(x15, DOUBLE_CNOP)                  							// Value to write (NOP)
+    // Store Access Check
+    LA(x8, \ADDRESS)             							// Address to be verified
     c.lw x15, 0(x8)
     c.nop
     c.nop
-	c.nop
-	c.nop
+    LA(sp, \ADDRESS)             							// Address to be verified
+    c.lwsp x15, 0(sp)
+    c.nop
+    c.nop
 
-	addi sp, x8, 0
-	c.swsp x15, 0(sp)
-	c.nop
-	c.nop
-	c.nop
-	c.nop
-	c.lwsp x15, 0(sp)
-	c.nop
-	c.nop
+    LI(x15, TETRA_CNOP)                  							// Value to write (NOP)
+    // Store Access Check
+    LA(x8, \ADDRESS)             							// Address to be verified
+    c.ld x15, 0(x8)
+    c.nop
+    c.nop
+    LA(sp, \ADDRESS)             							// Address to be verified
+    c.ldsp x15, 0(sp)
+    c.nop
+    c.nop
 
 .endm
 
@@ -239,14 +261,14 @@ rvtest_sig_begin:
 sig_begin_canary:
 CANARY;
 signature_x13_1:
-    .fill 32*(XLEN/32),4,0xdeadbeef
+    .fill 128*(XLEN/32),4,0xdeadbeef
 
 #ifdef rvtest_mtrap_routine
 
 tsig_begin_canary:
 CANARY;
 mtrap_sigptr:
-    .fill 256*(XLEN/32),4,0xdeadbeef
+    .fill 512*(XLEN/32),4,0xdeadbeef
 tsig_end_canary:
 CANARY;
 

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpzicbo_prefetch.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpzicbo_prefetch.S
@@ -43,8 +43,8 @@ RVTEST_CODE_BEGIN
 	#define RVMODEL_NUM_PMPS 16
 #endif
 
-RVTEST_CASE(1,"//check ISA:=regex(.*64.*); # CHECK ISA := regex(.*I[^S]*Zicbop.*Zicsr.*); def rvtest_mtrap_routine=True;								def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_prefetch)
-RVTEST_CASE(2,"//check ISA:=regex(.*64.*); # CHECK ISA := regex(.*I.*S.*Zicbop.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_prefetch)
+RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:= regex(.*I[^S]*Zicbop.*Zicsr.*); def rvtest_mtrap_routine=True;								def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_prefetch)
+RVTEST_CASE(2,"//check ISA:=regex(.*64.*); check ISA:= regex(.*I.*S.*Zicbop.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True; mac PMP_MACROS; mac PMP_helper_Coverpoints",cp_prefetch)
 
 #ifdef TEST_CASE_1
 RVTEST_SIGBASE( x13,signature_x13_1)
@@ -255,5 +255,4 @@ gpr_save:
 sig_end_canary:
 CANARY;
 rvtest_sig_end:
-PMP_region_High:
 RVMODEL_DATA_END


### PR DESCRIPTION
- In pmpzicbo_prefetch test file, regex check was commente out and it was getting selected even for RV32E. 
- In pmpzca_legal_lxwr test, pmp checks for {c.ld, c.ldsp, c.sd, c.sdsp} for XLEN 64 was missing.
- In pmp{s,u}_csr_access, we're supposed to check the access on all PMP entries even if writable pmp entries are not 64 in S/U mode. 