### PR TITLE
ACTs for Virtual Memory SV57

### DIFF
--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -291,23 +291,40 @@ Mend_PMP:                                    ;\
     LI(a1, PERMS)                               /* Load permissions into a1 */              ;\
     PTE_SETUP_SV48(a0, a1, t0, t1, VA, level)   /* Call PTE_SETUP_SV48 macro */             ;\
 
-#define PTE_SETUP_SV57(_PAR, _PR, _TR0, _TR1, _VAR, level)  	  ;\
-    .if (level==4)                                                ;\
-        LA(_TR1, rvtest_Sroot_pg_tbl)                             ;\
-    .endif                                                        ;\
-    .if (level==3)                                                ;\
-        LA(_TR1, rvtest_slvl4_pg_tbl)                             ;\
-    .endif                                                        ;\
-    .if (level==2)                                                ;\
-        LA(_TR1, rvtest_slvl3_pg_tbl)                             ;\
-    .endif                                                        ;\
-    .if (level==1)                                                ;\
-        LA(_TR1, rvtest_slvl2_pg_tbl)                             ;\
-    .endif                                                        ;\
-    .if (level==0)                                                ;\
-        LA(_TR1, rvtest_slvl1_pg_tbl)                             ;\
-    .endif                                                        ;\
-    PTE_SETUP_COMMON(_PAR, _PR, _TR0, _TR1, _VAR, level)
+#define PTE_SETUP_SV57(_PAR, _PR, _TR0, _TR1, VA, level)                                    ;\
+    srli _PAR, _PAR, 12                 /* Shift PA right by 12 to get PPN */               ;\
+    slli _PAR, _PAR, 10                 /* Shift left by 10 to align PPN in PTE format */   ;\
+    or _PAR, _PAR, _PR                  /* Combine PPN with permissions */                  ;\
+    .if (level==4)                      /* Level 4 (256TB superpage) */                     ;\
+        LA(_TR1, rvtest_Sroot_pg_tbl)   /* Load root page table address */                  ;\
+        LI(_TR0, ((VA>>48)&0x1FF)<<3)   /* Calculate index for LEVEL3 (bits 56:48) */       ;\
+    .endif                                                                                  ;\
+    .if (level==3)                      /* Level 3 (512GB superpage) */                     ;\
+        LA(_TR1, rvtest_slvl4_pg_tbl)   /* Load level 3 page table address */               ;\
+        LI(_TR0, ((VA>>39)&0x1FF)<<3)   /* Calculate index for LEVEL3 (bits 47:39) */       ;\
+    .endif                                                                                  ;\
+    .if (level==2)                      /* Level 2 (1GB superpage) */                       ;\
+        LA(_TR1, rvtest_slvl3_pg_tbl)   /* Load level 2 page table address */               ;\
+        LI(_TR0, ((VA>>30)&0x1FF)<<3)   /* Calculate index for LEVEL2 (bits 38:30) */       ;\
+    .endif                                                                                  ;\
+    .if (level==1)                      /* Level 1 (2MB superpage) */                       ;\
+        LA(_TR1, rvtest_slvl2_pg_tbl)   /* Load level 1 page table address */               ;\
+        LI(_TR0, ((VA>>21)&0x1FF)<<3)   /* Calculate index for LEVEL1 (bits 29:21) */       ;\
+    .endif                                                                                  ;\
+    .if (level==0)                      /* Level 0 (4KB page) */                            ;\
+        LA(_TR1, rvtest_slvl1_pg_tbl)   /* Load level 0 page table address */               ;\
+        LI(_TR0, ((VA>>12)&0x1FF)<<3)   /* Calculate index for LEVEL0 (bits 20:12) */       ;\
+    .endif                                                                                  ;\
+    add _TR1, _TR1, _TR0                /* Add index to page table base */                  ;\
+    SREG _PAR, 0(_TR1)                  /* Store PTE at calculated address */               ;\
+
+// More Robust version of PTE_SETUP_SV57 to setup a PTE for a PA using VA in a single line.
+// args: PA_LBL: Label of Physical Address, PERMS: permissions in hex
+// args: VA: Virtual Address in hex, level: Level to store at (0, 1, 2, 3 or 4)
+#define PTE_SETUP_SV57_New(PA_LBL, PERMS, VA, level)                                        ;\
+    LA(a0, PA_LBL)                                                                          ;\
+    LI(a1, PERMS)                                                                           ;\
+    PTE_SETUP_SV57(a0, a1, t0, t1, VA, level)                                               ;\
 
 
 #define PTE_SETUP_RV64(_PAR, _PR, _TR0, _TR1, VA, level, mode)  ;\
@@ -1508,3 +1525,4 @@ ADDI(swreg, swreg, RVMODEL_CBZ_BLOCKSIZE)
 #ifdef RVTEST_IO_CHECK
   #warning "RVTEST_IO_CHECK is deprecated in v0.2.
 #endif
+

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv57/sv57_pmp_on_pa_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv57/sv57_pmp_on_pa_S_mode.S
@@ -1,0 +1,464 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure test data region as NAPOT with RX permissions (pmp1cfg0)
+// 1-5. Setup a PTE at Level (4/3/2/1/0) with RWX permissions
+//      → Then, in S-Mode, the page is accessed --> required: 5 Store access faults
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure test data region as NAPOT with RW permissions (pmp1cfg0)
+// 6-10. Setup a PTE at Level (4/3/2/1/0) with RWX permissions
+//      → Then, in S-Mode, the page is accessed --> required: 5 Instruction access faults
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure test data region as NAPOT with X permission (pmp1cfg0)
+// 11-15. Setup a PTE at Level (4/3/2/1/0) with RWX permissions
+//      → Then, in S-Mode, the page is accessed --> required: 5 Store access faults, 5 Load access faults
+//
+// Total Expected Faults :: 20
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+.align 11
+// The preceding test region is 2KB by default. If G increases, adjusting alignment to expand the test region accordingly.
+.align (RVMODEL_PMP_GRAIN+2)
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-grain'] <= 4); def TEST_CASE_1=True; mac SV48_MACROS", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+// PMP Macros
+#define PMP_GLOBAL_RWX		(((PMP_TOR | PMP_X | PMP_W | PMP_R) & 0xFF) << PMP3_CFG_SHIFT)
+#define PMP1CFG_RX			(((PMP_NAPOT | PMP_X | PMP_R) & 0xFF) << PMP1_CFG_SHIFT)
+#define PMP1CFG_RW			(((PMP_NAPOT | PMP_W | PMP_R) & 0xFF) << PMP1_CFG_SHIFT)
+#define PMP1CFG_X			(((PMP_NAPOT | PMP_X) & 0xFF) << PMP1_CFG_SHIFT)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Setup pmpaddr registers
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	li t2, 0							// Set PMP permission for all memory in pmp3cfg0 (TOR)
+	csrw pmpaddr2, t2
+	li t2, -1
+	csrw pmpaddr3, t2
+
+	LI (t2, 0x80000000)					// Configure test region as NAPOT, Start = 0x8000_0000
+	srl t2, t2, 2
+
+	.if (RVMODEL_PMP_GRAIN < 10)
+		LI (t1, 0xFF)								// Range = 2^(8+3) = 2048 Bytes
+	.else
+		LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)		// Range = 2^(G+3) Bytes
+	.endif
+
+	or t2, t2, t1						
+	csrw pmpaddr1, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400              	// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	// If G increases more than 9, size of test region increases. Therefore, adjust address of rvtest_code_begin accordingly
+	.if (RVMODEL_PMP_GRAIN < 10)
+		.set va_rvtest_code_begin,  0x6000080000B9C
+	.else
+		.set va_rvtest_code_begin,  0x600008000039C | (1<<(RVMODEL_PMP_GRAIN+2))
+	.endif
+	.set va_rvtest_data_begin,  0x7000080005530	
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  	// Set SATP for virtualization
+	sfence.vma                                                            	// Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 							Configure test data region as NAPOT with RX permissions (pmp1cfg0)
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t2, PMP_GLOBAL_RWX | PMP1CFG_RX)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in S-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in S-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in S-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in S-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 							Configure test data region as NAPOT with RW permissions (pmp1cfg0)
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LI (t2, PMP_GLOBAL_RWX | PMP1CFG_RW)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RW permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 6: Test in S-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RW permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: Test in S-Mode | RWX bit set | expected = Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RW permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 8: Test in S-Mode | RWX bit set | expected = Instruction access fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RW permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 9: Test in S-Mode | RWX bit set | expected = Instruction access fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RW permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 10: Test in S-Mode | RWX bit set | expected = Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 							Configure test data region as NAPOT with X permissions (pmp1cfg0)
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LI (t2, PMP_GLOBAL_RWX | PMP1CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 11: Test in S-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 12: Test in S-Mode | RWX bit set | expected = Store access fault, Load access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 13: Test in S-Mode | RWX bit set | expected = Store access fault, Load access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 14: Test in S-Mode | RWX bit set | expected = Store access fault, Load access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 15: Test in S-Mode | RWX bit set | expected = Store access fault, Load access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 128*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv57/sv57_pmp_on_pa_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv57/sv57_pmp_on_pa_U_mode.S
@@ -1,0 +1,464 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure test data region as NAPOT with RX permissions (pmp1cfg0)
+// 1-5. Setup a PTE at Level (4/3/2/1/0) with RWX permissions
+//      → Then, in U-Mode, the page is accessed --> required: 5 Store access faults
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure test data region as NAPOT with RW permissions (pmp1cfg0)
+// 6-10. Setup a PTE at Level (4/3/2/1/0) with RWX permissions
+//      → Then, in U-Mode, the page is accessed --> required: 5 Instruction access faults
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure test data region as NAPOT with X permission (pmp1cfg0)
+// 11-15. Setup a PTE at Level (4/3/2/1/0) with RWX permissions
+//      → Then, in U-Mode, the page is accessed --> required: 5 Store access faults, 5 Load access faults
+//
+// Total Expected Faults :: 20
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+.align 11
+// The preceding test region is 2KB by default. If G increases, adjusting alignment to expand the test region accordingly.
+.align (RVMODEL_PMP_GRAIN+2)
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-grain'] <= 4); def TEST_CASE_1=True; mac SV48_MACROS", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+// PMP Macros
+#define PMP_GLOBAL_RWX		(((PMP_TOR | PMP_X | PMP_W | PMP_R) & 0xFF) << PMP3_CFG_SHIFT)
+#define PMP1CFG_RX			(((PMP_NAPOT | PMP_X | PMP_R) & 0xFF) << PMP1_CFG_SHIFT)
+#define PMP1CFG_RW			(((PMP_NAPOT | PMP_W | PMP_R) & 0xFF) << PMP1_CFG_SHIFT)
+#define PMP1CFG_X			(((PMP_NAPOT | PMP_X) & 0xFF) << PMP1_CFG_SHIFT)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Setup pmpaddr registers
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	li t2, 0							// Set PMP permission for all memory in pmp3cfg0 (TOR)
+	csrw pmpaddr2, t2
+	li t2, -1
+	csrw pmpaddr3, t2
+
+	LI (t2, 0x80000000)					// Configure test region as NAPOT, Start = 0x8000_0000
+	srl t2, t2, 2
+
+	.if (RVMODEL_PMP_GRAIN < 10)
+		LI (t1, 0xFF)								// Range = 2^(8+3) = 2048 Bytes
+	.else
+		LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)		// Range = 2^(G+3) Bytes
+	.endif
+
+	or t2, t2, t1						
+	csrw pmpaddr1, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400              	// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	// If G increases more than 9, size of test region increases. Therefore, adjust address of rvtest_code_begin accordingly
+	.if (RVMODEL_PMP_GRAIN < 10)
+		.set va_rvtest_code_begin,  0x6000080000B9C
+	.else
+		.set va_rvtest_code_begin,  0x600008000039C | (1<<(RVMODEL_PMP_GRAIN+2))
+	.endif
+	.set va_rvtest_data_begin,  0x7000080005530	
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  	// Set SATP for virtualization
+	sfence.vma                                                            	// Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 							Configure test data region as NAPOT with RX permissions (pmp1cfg0)
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t2, PMP_GLOBAL_RWX | PMP1CFG_RX)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in U-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in U-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in U-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in U-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in U-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 							Configure test data region as NAPOT with RW permissions (pmp1cfg0)
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LI (t2, PMP_GLOBAL_RWX | PMP1CFG_RW)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RW permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 6: Test in U-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RW permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: Test in U-Mode | RWX bit set | expected = Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RW permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 8: Test in U-Mode | RWX bit set | expected = Instruction access fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RW permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 9: Test in U-Mode | RWX bit set | expected = Instruction access fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RW permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 10: Test in U-Mode | RWX bit set | expected = Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 							Configure test data region as NAPOT with X permissions (pmp1cfg0)
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LI (t2, PMP_GLOBAL_RWX | PMP1CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 11: Test in U-Mode | RWX bit set | expected = Store access fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 12: Test in U-Mode | RWX bit set | expected = Store access fault, Load access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 13: Test in U-Mode | RWX bit set | expected = Store access fault, Load access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 14: Test in U-Mode | RWX bit set | expected = Store access fault, Load access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 15: Test in U-Mode | RWX bit set | expected = Store access fault, Load access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 128*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv57/sv57_pmp_on_pte_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv57/sv57_pmp_on_pte_S_mode.S
@@ -1,0 +1,402 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// .if (RVMODEL_PMP_GRAIN < 10)
+// Configure level 4 PTE as NAPOT with X permission (pmp0cfg0)
+// 1. Setup a PTE at Level 4 with RWX permissions
+//      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// .endif
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure level 3 PTE as NAPOT with X permission (pmp0cfg0)
+// 2. Setup a PTE at Level 3 with RWX permissions
+//      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure level 2 PTE as NAPOT with X permission (pmp0cfg0)
+// 3. Setup a PTE at Level 2 with RWX permissions
+//      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure level 1 PTE as NAPOT with X permission (pmp0cfg0)
+// 4. Setup a PTE at Level 1 with RWX permissions
+//      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure level 0 PTE as NAPOT with X permission (pmp0cfg0)
+// 5. Setup a PTE at Level 0 with RWX permissions
+//      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+//
+// .if (RVMODEL_PMP_GRAIN < 10)
+// 		Total Expected Faults :: 15
+// .else
+// 		Total Expected Faults :: 12
+// .endif
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-grain'] <= 4); def TEST_CASE_1=True; mac SV48_MACROS", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+// PMP Macros
+#define PMP_GLOBAL_RWX		(((PMP_TOR | PMP_X | PMP_W | PMP_R) & 0xFF) << PMP2_CFG_SHIFT)
+#define PMP0CFG_X			(((PMP_NAPOT | PMP_X) & 0xFF) << PMP0_CFG_SHIFT)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Setup pmpaddr registers
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	li t2, 0							// Set PMP permission for all memory in pmp2cfg0 (TOR)
+	csrw pmpaddr1, t2
+	li t2, -1
+	csrw pmpaddr2, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x0000000000400              	// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0xFFFE0000800007BC
+	.set va_rvtest_data_begin,  0xFFFF000080004530	
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x0000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  	// Set SATP for virtualization
+	sfence.vma                                                            	// Flush the TLB
+
+// This test case for root page table is skipped if G >= 10, because with PMP granularity ≥ 4KB,
+// the entire root page table will lose its read/write permissions, preventing entry into S-Mode.
+.if (RVMODEL_PMP_GRAIN < 10)
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 								Configure level 3 PTE as NAPOT region with X permission
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LA (t2, rvtest_Sroot_pg_tbl)
+	srl t2, t2, 2
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
+	csrw pmpaddr0, t2
+
+	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 1: Test in S-Mode | RWX bit set | expected = Store access fault, Load access fault, Instruction access fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34
+
+.endif
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 								Configure level 3 PTE as NAPOT region with X permission
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LA (t2, rvtest_slvl4_pg_tbl)
+	srl t2, t2, 2
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
+	csrw pmpaddr0, t2
+
+	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 1: Test in S-Mode | RWX bit set | expected = Store access fault, Load access fault, Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 								Configure level 2 PTE as NAPOT region with X permission
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LA (t2, rvtest_slvl3_pg_tbl)
+	srl t2, t2, 2
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
+	csrw pmpaddr0, t2
+
+	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: Test in S-Mode | RWX set | expected = Store access fault, Load access fault, Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 								Configure level 1 PTE as NAPOT region with X permission
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LA (t2, rvtest_slvl2_pg_tbl)
+	srl t2, t2, 2
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
+	csrw pmpaddr0, t2
+
+	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 3: Test in S-Mode | RWX set | expected = Store access fault, Load access fault, Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 								Configure level 0 PTE as NAPOT region with X permission
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LA (t2, rvtest_slvl1_pg_tbl)
+	srl t2, t2, 2
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
+	csrw pmpaddr0, t2
+
+	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 4: Test in S-Mode | RWX set | expected = Store access fault, Load access fault, Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data
+
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+.align (RVMODEL_PMP_GRAIN+2)
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+.align (RVMODEL_PMP_GRAIN+2)
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+.align (RVMODEL_PMP_GRAIN+2)
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+.align (RVMODEL_PMP_GRAIN+2)
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+.align (RVMODEL_PMP_GRAIN+2)
+RVTEST_DATA_END                               
+.align 12
+.align (RVMODEL_PMP_GRAIN+2)
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv57/sv57_pmp_on_pte_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv57/sv57_pmp_on_pte_U_mode.S
@@ -1,0 +1,402 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// .if (RVMODEL_PMP_GRAIN < 10)
+// Configure level 4 PTE as NAPOT with X permission (pmp0cfg0)
+// 1. Setup a PTE at Level 4 with RWX permissions
+//      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// .endif
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure level 3 PTE as NAPOT with X permission (pmp0cfg0)
+// 2. Setup a PTE at Level 3 with RWX permissions
+//      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure level 2 PTE as NAPOT with X permission (pmp0cfg0)
+// 3. Setup a PTE at Level 2 with RWX permissions
+//      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure level 1 PTE as NAPOT with X permission (pmp0cfg0)
+// 4. Setup a PTE at Level 1 with RWX permissions
+//      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// ----------------------------------------------------------------------------------------------------------------------
+// Configure level 0 PTE as NAPOT with X permission (pmp0cfg0)
+// 5. Setup a PTE at Level 0 with RWX permissions
+//      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+//
+// .if (RVMODEL_PMP_GRAIN < 10)
+// 		Total Expected Faults :: 15
+// .else
+// 		Total Expected Faults :: 12
+// .endif
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (PMP['implemented']); verify (PMP['pmp-grain'] <= 4); def TEST_CASE_1=True; mac SV48_MACROS", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+// PMP Macros
+#define PMP_GLOBAL_RWX		(((PMP_TOR | PMP_X | PMP_W | PMP_R) & 0xFF) << PMP2_CFG_SHIFT)
+#define PMP0CFG_X			(((PMP_NAPOT | PMP_X) & 0xFF) << PMP0_CFG_SHIFT)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Setup pmpaddr registers
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	li t2, 0							// Set PMP permission for all memory in pmp2cfg0 (TOR)
+	csrw pmpaddr1, t2
+	li t2, -1
+	csrw pmpaddr2, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x0000000000400              	// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0xFFFE0000800007BC
+	.set va_rvtest_data_begin,  0xFFFF000080004530	
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x0000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  	// Set SATP for virtualization
+	sfence.vma                                                            	// Flush the TLB
+
+// This test case for root page table is skipped if G >= 10, because with PMP granularity ≥ 4KB,
+// the entire root page table will lose its read/write permissions, preventing entry into U-Mode.
+.if (RVMODEL_PMP_GRAIN < 10)
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 								Configure level 3 PTE as NAPOT region with X permission
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LA (t2, rvtest_Sroot_pg_tbl)
+	srl t2, t2, 2
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
+	csrw pmpaddr0, t2
+
+	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 1: Test in U-Mode | RWX bit set | expected = Store access fault, Load access fault, Instruction access fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34
+
+.endif
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 								Configure level 3 PTE as NAPOT region with X permission
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LA (t2, rvtest_slvl4_pg_tbl)
+	srl t2, t2, 2
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
+	csrw pmpaddr0, t2
+
+	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 1: Test in U-Mode | RWX bit set | expected = Store access fault, Load access fault, Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 								Configure level 2 PTE as NAPOT region with X permission
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LA (t2, rvtest_slvl3_pg_tbl)
+	srl t2, t2, 2
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
+	csrw pmpaddr0, t2
+
+	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: Test in U-Mode | RWX set | expected = Store access fault, Load access fault, Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 								Configure level 1 PTE as NAPOT region with X permission
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LA (t2, rvtest_slvl2_pg_tbl)
+	srl t2, t2, 2
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
+	csrw pmpaddr0, t2
+
+	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 3: Test in U-Mode | RWX set | expected = Store access fault, Load access fault, Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+// 								Configure level 0 PTE as NAPOT region with X permission
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	LA (t2, rvtest_slvl1_pg_tbl)
+	srl t2, t2, 2
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
+	csrw pmpaddr0, t2
+
+	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
+	csrw pmpcfg0, t2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 4: Test in U-Mode | RWX set | expected = Store access fault, Load access fault, Instruction access fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data
+
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+.align (RVMODEL_PMP_GRAIN+2)
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+.align (RVMODEL_PMP_GRAIN+2)
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+.align (RVMODEL_PMP_GRAIN+2)
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+.align (RVMODEL_PMP_GRAIN+2)
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+.align (RVMODEL_PMP_GRAIN+2)
+RVTEST_DATA_END                               
+.align 12
+.align (RVMODEL_PMP_GRAIN+2)
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_A_and_D_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_A_and_D_S_mode.S
@@ -1,0 +1,506 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. D-bit unset, A-bit set at level 4, RWX permissions (read, write, execute page):
+//    	Then, access the page in S-Mode. Expected: Store-page-fault
+// 2. D-bit set, A-bit set at level 4, RWX permissions (read, write, execute page):
+//    	Then, access the page in S-Mode. Expected: No fault should occur.
+// 3. D-bit set, A-bit unset at level 4, RWX permissions (read, write, execute page):
+//    	Then access the page in S-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. D-bit unset, A-bit unset at level 4, RWX permissions (read, write, execute page):
+//    	Then access the page in S-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 5. D-bit unset, A-bit set at level 3, RWX permissions (read, write, execute page):
+//    	Then, access the page in S-Mode. Expected: Store-page-fault
+// 6. D-bit set, A-bit set at level 3, RWX permissions (read, write, execute page):
+//    	Then, access the page in S-Mode. Expected: No fault should occur.
+// 7. D-bit set, A-bit unset at level 3, RWX permissions (read, write, execute page):
+//    	Then access the page in S-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 8. D-bit unset, A-bit unset at level 3, RWX permissions (read, write, execute page):
+//    	Then access the page in S-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 9. D-bit unset, A-bit set at level 2, RWX permissions (read, write, execute page):
+//    	Then, access the page in S-Mode. Expected: Store-page-fault
+// 10. D-bit set, A-bit set at level 2, RWX permissions (read, write, execute page):
+//    	Then, access the page in S-Mode. Expected: No fault should occur.
+// 11. D-bit set, A-bit unset at level 2, RWX permissions (read, write, execute page):
+//    	Then access the page in S-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 12. D-bit unset, A-bit unset at level 2, RWX permissions (read, write, execute page):
+//    	Then access the page in S-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 13. D-bit unset, A-bit set at level 1, RWX permissions (read, write, execute page):
+//    	Then, access the page in S-Mode. Expected: Store-page-fault
+// 14. D-bit set, A-bit set at level 1, RWX permissions (read, write, execute page):
+//    	Then, access the page in S-Mode. Expected: No fault should occur.
+// 15. D-bit set, A-bit unset at level 1, RWX permissions (read, write, execute page):
+//    	Then access the page in S-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 16. D-bit unset, A-bit unset at level 1, RWX permissions (read, write, execute page):
+//    	Then access the page in S-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 17. D-bit unset, A-bit set at level 0, RWX permissions (read, write, execute page):
+//    	Then, access the page in S-Mode. Expected: Store-page-fault
+// 18. D-bit set, A-bit set at level 0, RWX permissions (read, write, execute page):
+//    	Then, access the page in S-Mode. Expected: No fault should occur.
+// 19. D-bit set, A-bit unset at level 0, RWX permissions (read, write, execute page):
+//    	Then access the page in S-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 20. D-bit unset, A-bit unset at level 0, RWX permissions (read, write, execute page):
+//    	Then access the page in S-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+//
+// Total Expected Faults :: 35
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080006530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: D bit unset and A bit set | Test in S-Mode | RWX bit set | expected = Store page fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Both D and A bit set | Test in S-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: D bit set and A bit unset | Test in S-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Both D and A bit unset | Test in S-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: D bit unset and A bit set | Test in S-Mode | RWX bit set | expected = Store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 6: Both D and A bit set | Test in S-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: D bit set and A bit unset | Test in S-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 8: Both D and A bit unset | Test in S-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 9: D bit unset and A bit set | Test in S-Mode | RWX bit set | expected = Store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 10: Both D and A bit set | Test in S-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 11: D bit set and A bit unset | Test in S-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 12: Both D and A bit unset | Test in S-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 13: D bit unset and A bit set | Test in S-Mode | RWX bit set | expected = Store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 14: Both D and A bit set | Test in S-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 15: D bit set and A bit unset | Test in S-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 16: Both D and A bit unset | Test in S-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 17: D bit unset and A bit set | Test in S-Mode | RWX bit set | expected = Store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 18: Both D and A bit set | Test in S-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 19: D bit set and A bit unset | Test in S-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 20: Both D and A bit unset | Test in S-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0	
+    
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 256*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_A_and_D_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_A_and_D_U_mode.S
@@ -1,0 +1,506 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. D-bit unset, A-bit set at level 4, RWX permissions (read, write, execute page):
+//    	Then, access the page in U-Mode. Expected: Store-page-fault
+// 2. D-bit set, A-bit set at level 4, RWX permissions (read, write, execute page):
+//    	Then, access the page in U-Mode. Expected: No fault should occur.
+// 3. D-bit set, A-bit unset at level 4, RWX permissions (read, write, execute page):
+//    	Then access the page in U-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. D-bit unset, A-bit unset at level 4, RWX permissions (read, write, execute page):
+//    	Then access the page in U-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 5. D-bit unset, A-bit set at level 3, RWX permissions (read, write, execute page):
+//    	Then, access the page in U-Mode. Expected: Store-page-fault
+// 6. D-bit set, A-bit set at level 3, RWX permissions (read, write, execute page):
+//    	Then, access the page in U-Mode. Expected: No fault should occur.
+// 7. D-bit set, A-bit unset at level 3, RWX permissions (read, write, execute page):
+//    	Then access the page in U-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 8. D-bit unset, A-bit unset at level 3, RWX permissions (read, write, execute page):
+//    	Then access the page in U-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 9. D-bit unset, A-bit set at level 2, RWX permissions (read, write, execute page):
+//    	Then, access the page in U-Mode. Expected: Store-page-fault
+// 10. D-bit set, A-bit set at level 2, RWX permissions (read, write, execute page):
+//    	Then, access the page in U-Mode. Expected: No fault should occur.
+// 11. D-bit set, A-bit unset at level 2, RWX permissions (read, write, execute page):
+//    	Then access the page in U-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 12. D-bit unset, A-bit unset at level 2, RWX permissions (read, write, execute page):
+//    	Then access the page in U-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 13. D-bit unset, A-bit set at level 1, RWX permissions (read, write, execute page):
+//    	Then, access the page in U-Mode. Expected: Store-page-fault
+// 14. D-bit set, A-bit set at level 1, RWX permissions (read, write, execute page):
+//    	Then, access the page in U-Mode. Expected: No fault should occur.
+// 15. D-bit set, A-bit unset at level 1, RWX permissions (read, write, execute page):
+//    	Then access the page in U-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 16. D-bit unset, A-bit unset at level 1, RWX permissions (read, write, execute page):
+//    	Then access the page in U-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 17. D-bit unset, A-bit set at level 0, RWX permissions (read, write, execute page):
+//    	Then, access the page in U-Mode. Expected: Store-page-fault
+// 18. D-bit set, A-bit set at level 0, RWX permissions (read, write, execute page):
+//    	Then, access the page in U-Mode. Expected: No fault should occur.
+// 19. D-bit set, A-bit unset at level 0, RWX permissions (read, write, execute page):
+//    	Then access the page in U-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 20. D-bit unset, A-bit unset at level 0, RWX permissions (read, write, execute page):
+//    	Then access the page in U-Mode. Expected: Load-page-fault, Store-page-fault, Fetch-page-fault
+//
+// Total Expected Faults :: 35
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080006530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: D bit unset and A bit set | Test in U-Mode | RWX bit set | expected = Store page fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Both D and A bit set | Test in U-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: D bit set and A bit unset | Test in U-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Both D and A bit unset | Test in U-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: D bit unset and A bit set | Test in U-Mode | RWX bit set | expected = Store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 6: Both D and A bit set | Test in U-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: D bit set and A bit unset | Test in U-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 8: Both D and A bit unset | Test in U-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 9: D bit unset and A bit set | Test in U-Mode | RWX bit set | expected = Store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 10: Both D and A bit set | Test in U-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 11: D bit set and A bit unset | Test in U-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 12: Both D and A bit unset | Test in U-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 13: D bit unset and A bit set | Test in U-Mode | RWX bit set | expected = Store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 14: Both D and A bit set | Test in U-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 15: D bit set and A bit unset | Test in U-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 16: Both D and A bit unset | Test in U-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 17: D bit unset and A bit set | Test in U-Mode | RWX bit set | expected = Store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 18: Both D and A bit set | Test in U-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 19: D bit set and A bit unset | Test in U-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 20: Both D and A bit unset | Test in U-Mode | RWX bit set | expected = Load-page-fault, Store-page-fault, Fetch-page-fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0	
+    
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 256*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_VA_all_ones_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_VA_all_ones_S_mode.S
@@ -1,0 +1,260 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. Perform Load & Store at virtual address 0xffffffffffffffff (last byte)
+// 2. Perform Execute at virtual address 0xfffffffffffffffc (last word)
+
+// Total Expected Faults :: 0
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+
+.macro TEST_CASES_RUNNER_RW LOWER_MODE, VA, level
+    .if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+    .else
+    	RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+    .endif
+	
+	.align 2
+	LI(a5, \VA)                    		// Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+    
+	// Test store permission
+    sb  a2, 0(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lbu  a4, 0(a5)        				// Load back data
+    nop
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    	nop
+    	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    	nop
+    	addi x13, x13, REGWIDTH
+.endm	
+
+
+.macro TEST_CASES_RUNNER_X LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	
+	.align 2
+	LI(a5, \VA)                    		// Load virtual address
+	LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+	LA(x4, 1f)							// Store the return Address in x4
+	jalr ra, 0(a5)
+	nop
+	nop
+1:
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data_rw,          	0xffffffffffffffff			// Store & Load will be performed at this VA
+	.set va_data_x,          	0xfffffffffffffffc			// Execute will be performed at this VA
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x600008000039C
+	.set va_rvtest_data_begin,  0x7000080003530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | RW bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_rw, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data_rw, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data_rw, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data_rw, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1_l0_rw, (PTE_D | PTE_A | PTE_W | PTE_R | PTE_V), va_data_rw, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER_RW Smode, va_data_rw, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permission given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in S-Mode | X bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_x, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data_x, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data_x, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data_x, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1_l0_x, (PTE_D | PTE_A | PTE_X | PTE_V), va_data_x, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER_X Smode, va_data_x, LEVEL0
+
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGIONS FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0
+// This region will be used to Store and then Load from the last byte
+.align 12
+rvtest_data_1_l0_rw:
+	nop																		// trap return back skip
+	addi ra, ra, REGWIDTH
+	jr ra																	// jump back for the trap on level 1
+	nop
+	.word 0xbeefcaf1														// Random word
+	.word 0xbeefcaf2														// Random word
+	.skip ((1 << 10) - 7)*4 												// Added to make occupied space of data region 4KB 
+	.word 0xbeefcaf3
+
+// Physical Address region under testing for LEVEL 0
+// This region will be used to execute the last instruction at (4KB - 4)
+.align 12
+rvtest_data_1_l0_x:
+	nop																		// trap return back skip
+	addi ra, ra, REGWIDTH
+	jr ra																	// jump back for the trap on level 1
+	nop
+	.word 0xbeefcaf1														// Random word
+	.word 0xbeefcaf2														// Random word
+	.skip ((1 << 10) - 7)*4 												// Added to make occupied space of data region 4KB 
+	jr ra
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_VA_all_zeros_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_VA_all_zeros_S_mode.S
@@ -1,0 +1,246 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. Perform Load & Store at virtual address 0x0
+// 2. Perform Execute at virtual address 0x0
+
+// Total Expected Faults :: 0
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+
+.macro TEST_CASES_RUNNER_RW LOWER_MODE, VA, level
+
+    RVTEST_GOTO_LOWER_MODE \LOWER_MODE
+	.align 2
+
+	LI(a5, \VA)
+    addi a2, a2, 16
+    
+	// Test store permission
+    sw  a2, 0(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw	a4, 0(a5)        				// Load back data
+    nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)
+    nop
+    addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)
+    nop
+    addi x13, x13, REGWIDTH
+.endm	
+
+
+.macro TEST_CASES_RUNNER_X LOWER_MODE, VA, level
+
+	RVTEST_GOTO_LOWER_MODE \LOWER_MODE
+	.align 2
+
+	LI(a5, \VA)
+	LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+	LA(x4, 1f)							// Store the return Address in x4
+	jalr ra, 0(a5)
+	nop
+	nop
+1:
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,         	 	0x0000000000000000
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x600008000039C
+	.set va_rvtest_data_begin,  0x7000080003530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | RW bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1_l0_rw, (PTE_D | PTE_A | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER_RW Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permission given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in S-Mode | X bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1_l0_x, (PTE_D | PTE_A | PTE_X | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER_X Smode, va_data, LEVEL0
+
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGIONS FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0
+// This region will be used to Store and then Load back from the first word
+.align 12
+rvtest_data_1_l0_rw:
+	.word 0xbeefcaf1														// Random word
+	.word 0xbeefcaf2														// Random word
+	.skip ((1 << 10) - 3)*4 												// Added to make occupied space of data region 4KB 
+	.word 0xbeefcaf3
+
+// Physical Address region under testing for LEVEL 0
+// This region will be used to execute its first instruction
+.align 12
+rvtest_data_1_l0_x:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1														// Random word
+	.word 0xbeefcaf2														// Random word
+	.skip ((1 << 10) - 7)*4 												// Added to make occupied space of data region 4KB 
+	jr ra
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_canonical_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_canonical_S_mode.S
@@ -1,0 +1,292 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. PTE with incorrectly sign extended VA is set up at level 4, RWX permissions (read, write, execute page) given:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 2. PTE with incorrectly sign extended VA is set up at level 3, RWX permissions (read, write, execute page) given:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 3. PTE with incorrectly sign extended VA is set up at level 2, RWX permissions (read, write, execute page) given:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. PTE with incorrectly sign extended VA is set up at level 1, RWX permissions (read, write, execute page) given:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 5. PTE with incorrectly sign extended VA is set up at level 0, RWX permissions (read, write, execute page) given:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 15
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x8005000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x8005000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in S-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in S-Mode | RWX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in S-Mode | RWX bit set | expected = RWX fault  
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in S-Mode | RWX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_canonical_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_canonical_U_mode.S
@@ -1,0 +1,292 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. PTE with incorrectly sign extended VA is set up at level 4, RWX permissions (read, write, execute page) given:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 2. PTE with incorrectly sign extended VA is set up at level 3, RWX permissions (read, write, execute page) given:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 3. PTE with incorrectly sign extended VA is set up at level 2, RWX permissions (read, write, execute page) given:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. PTE with incorrectly sign extended VA is set up at level 1, RWX permissions (read, write, execute page) given:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 5. PTE with incorrectly sign extended VA is set up at level 0, RWX permissions (read, write, execute page) given:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 15
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x8005000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x8005000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in U-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in U-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in U-Mode | RWX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in U-Mode | RWX bit set | expected = RWX fault  
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in U-Mode | RWX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_global_pte_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_global_pte_S_mode.S
@@ -1,0 +1,337 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. G bit is Set for the page at level 4:
+//		Then, in S-Mode, the page is accessed --> required: Successful page table walk 
+// 		sfence.vma with ASID flushes TLB entries for that ASID, keeping global (G=1) entries intact.  
+// 		Since the page is global, it remains accessible without a new page table walk on second access.
+// 2. G bit is Set for the page at level 3:
+//		Then, in S-Mode, the page is accessed --> required: Successful page table walk 
+// 		sfence.vma with ASID flushes TLB entries for that ASID, keeping global (G=1) entries intact.  
+// 		Since the page is global, it remains accessible without a new page table walk on second access.
+// 3. G bit is Set for the page at level 2:
+//		Then, in S-Mode, the page is accessed --> required: Successful page table walk 
+// 		sfence.vma with ASID flushes TLB entries for that ASID, keeping global (G=1) entries intact.  
+// 		Since the page is global, it remains accessible without a new page table walk on second access.
+// 4. G bit is Set for the page at level 1:
+//		Then, in S-Mode, the page is accessed --> required: Successful page table walk 
+// 		sfence.vma with ASID flushes TLB entries for that ASID, keeping global (G=1) entries intact.  
+// 		Since the page is global, it remains accessible without a new page table walk on second access.
+// 5. G bit is Set for the page at level 0:
+//		Then, in S-Mode, the page is accessed --> required: Successful page table walk 
+// 		sfence.vma with ASID flushes TLB entries for that ASID, keeping global (G=1) entries intact.  
+// 		Since the page is global, it remains accessible without a new page table walk on second access.
+
+// Total Expected Faults :: 0
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | G bit set | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_G | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+	
+	csrr t2, satp			// Extract ASID (SV48, ASID is in bits 59:44 of satp)
+  	slli t2, t2, 4
+    srli t2, t2, 48        
+    sfence.vma x0, t2       // Invalidate TLB entries for the ASID (Global entries remain valid)
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4  	// No pagetable walk, as the PTE is not invalidated by sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in S-Mode | G bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_G | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+	
+	csrr t2, satp			// Extract ASID (SV48, ASID is in bits 59:44 of satp)
+  	slli t2, t2, 4
+    srli t2, t2, 48        
+    sfence.vma x0, t2       // Invalidate TLB entries for the ASID (Global entries remain valid)
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3  	// No pagetable walk, as the PTE is not invalidated by sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in S-Mode | G bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_G | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+	
+	csrr t2, satp			// Extract ASID (SV48, ASID is in bits 59:44 of satp)
+  	slli t2, t2, 4
+    srli t2, t2, 48        
+    sfence.vma x0, t2       // Invalidate TLB entries for the ASID (Global entries remain valid)
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2  	// No pagetable walk, as the PTE is not invalidated by sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in S-Mode | G bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_G | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+	
+	csrr t2, satp			// Extract ASID (SV48, ASID is in bits 59:44 of satp)
+  	slli t2, t2, 4
+    srli t2, t2, 48        
+    sfence.vma x0, t2       // Invalidate TLB entries for the ASID (Global entries remain valid)
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1  	// No pagetable walk, as the PTE is not invalidated by sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in S-Mode | G bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_G | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+	
+	csrr t2, satp			// Extract ASID (SV48, ASID is in bits 59:44 of satp)
+  	slli t2, t2, 4
+    srli t2, t2, 48        
+    sfence.vma x0, t2       // Invalidate TLB entries for the ASID (Global entries remain valid)
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0  	// No pagetable walk, as the PTE is not invalidated by sfence.vma
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_global_pte_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_global_pte_U_mode.S
@@ -1,0 +1,337 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. G bit is Set for the page at level 4:
+//		Then, in U-Mode, the page is accessed --> required: Successful page table walk 
+// 		sfence.vma with ASID flushes TLB entries for that ASID, keeping global (G=1) entries intact.  
+// 		Since the page is global, it remains accessible without a new page table walk on second access.
+// 2. G bit is Set for the page at level 3:
+//		Then, in U-Mode, the page is accessed --> required: Successful page table walk 
+// 		sfence.vma with ASID flushes TLB entries for that ASID, keeping global (G=1) entries intact.  
+// 		Since the page is global, it remains accessible without a new page table walk on second access.
+// 3. G bit is Set for the page at level 2:
+//		Then, in U-Mode, the page is accessed --> required: Successful page table walk 
+// 		sfence.vma with ASID flushes TLB entries for that ASID, keeping global (G=1) entries intact.  
+// 		Since the page is global, it remains accessible without a new page table walk on second access.
+// 4. G bit is Set for the page at level 1:
+//		Then, in U-Mode, the page is accessed --> required: Successful page table walk 
+// 		sfence.vma with ASID flushes TLB entries for that ASID, keeping global (G=1) entries intact.  
+// 		Since the page is global, it remains accessible without a new page table walk on second access.
+// 5. G bit is Set for the page at level 0:
+//		Then, in U-Mode, the page is accessed --> required: Successful page table walk 
+// 		sfence.vma with ASID flushes TLB entries for that ASID, keeping global (G=1) entries intact.  
+// 		Since the page is global, it remains accessible without a new page table walk on second access.
+
+// Total Expected Faults :: 0
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in U-Mode | G bit set | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_G | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+	
+	csrr t2, satp			// Extract ASID (SV48, ASID is in bits 59:44 of satp)
+  	slli t2, t2, 4
+    srli t2, t2, 48        
+    sfence.vma x0, t2       // Invalidate TLB entries for the ASID (Global entries remain valid)
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4  	// No pagetable walk, as the PTE is not invalidated by sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in U-Mode | G bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_G | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+	
+	csrr t2, satp			// Extract ASID (SV48, ASID is in bits 59:44 of satp)
+  	slli t2, t2, 4
+    srli t2, t2, 48        
+    sfence.vma x0, t2       // Invalidate TLB entries for the ASID (Global entries remain valid)
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3  	// No pagetable walk, as the PTE is not invalidated by sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in U-Mode | G bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_G | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+	
+	csrr t2, satp			// Extract ASID (SV48, ASID is in bits 59:44 of satp)
+  	slli t2, t2, 4
+    srli t2, t2, 48        
+    sfence.vma x0, t2       // Invalidate TLB entries for the ASID (Global entries remain valid)
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2  	// No pagetable walk, as the PTE is not invalidated by sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in U-Mode | G bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_G | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+	
+	csrr t2, satp			// Extract ASID (SV48, ASID is in bits 59:44 of satp)
+  	slli t2, t2, 4
+    srli t2, t2, 48        
+    sfence.vma x0, t2       // Invalidate TLB entries for the ASID (Global entries remain valid)
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1  	// No pagetable walk, as the PTE is not invalidated by sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in U-Mode | G bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_G | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+	
+	csrr t2, satp			// Extract ASID (SV48, ASID is in bits 59:44 of satp)
+  	slli t2, t2, 4
+    srli t2, t2, 48        
+    sfence.vma x0, t2       // Invalidate TLB entries for the ASID (Global entries remain valid)
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0  	// No pagetable walk, as the PTE is not invalidated by sfence.vma
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_invalid_pte_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_invalid_pte_S_mode.S
@@ -1,0 +1,293 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. V bit is UnSet for the page at level 4 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 2. V bit is UnSet for the page at level 3 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 3. V bit is UnSet for the page at level 2 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. V bit is UnSet for the page at level 1 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 5. V bit is UnSet for the page at level 0 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 15
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: V bit unset | Test in S-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: V bit unset | Test in S-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: V bit unset | Test in S-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: V bit unset | Test in S-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: V bit unset | Test in S-Mode | RWX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_invalid_pte_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_invalid_pte_U_mode.S
@@ -1,0 +1,293 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. V bit is UnSet for the page at level 4 with RWX Permissions (Read, write, execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 2. V bit is UnSet for the page at level 3 with RWX Permissions (Read, write, execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 3. V bit is UnSet for the page at level 2 with RWX Permissions (Read, write, execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. V bit is UnSet for the page at level 1 with RWX Permissions (Read, write, execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 5. V bit is UnSet for the page at level 0 with RWX Permissions (Read, write, execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 15
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: V bit unset | Test in U-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: V bit unset | Test in U-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: V bit unset | Test in U-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: V bit unset | Test in U-Mode | RWX bit set | expected = RWX fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: V bit unset | Test in U-Mode | RWX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_misaligned_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_misaligned_S_mode.S
@@ -1,0 +1,269 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. A misaligned petapage is set up with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 2. A misaligned terapage is set up with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 3. A misaligned gigapage is set up with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. A misaligned megapage is set up with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 12
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000000				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x600008000039C
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | Misaligned petapage | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in S-Mode | Misaligned terapage | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in S-Mode | Misaligned gigapage | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in S-Mode | Misaligned megapage | expected = RWX Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGIONS FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+
+.align 12				// Misaligned (Peta/Tera/Giga/Mega) Page
+rvtest_data_1:
+	nop
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1				// Random word
+	.word 0xbeefcaf2				// Random word
+	jr ra	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_misaligned_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_misaligned_U_mode.S
@@ -1,0 +1,269 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. A misaligned petapage is set up with RWX Permissions (Read, write, execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 2. A misaligned terapage is set up with RWX Permissions (Read, write, execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 3. A misaligned gigapage is set up with RWX Permissions (Read, write, execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. A misaligned megapage is set up with RWX Permissions (Read, write, execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 12
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000000				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x600008000039C
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in U-Mode | Misaligned petapage | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in U-Mode | Misaligned terapage | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in U-Mode | Misaligned gigapage | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in U-Mode | Misaligned megapage | expected = RWX Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGIONS FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+
+.align 12				// Misaligned (Peta/Tera/Giga/Mega) Page
+rvtest_data_1:
+	nop
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1				// Random word
+	.word 0xbeefcaf2				// Random word
+	jr ra	
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mprv_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mprv_S_mode.S
@@ -1,0 +1,302 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------MPRV test in M Mode (with S bit perms)---------------------------------------------------
+// 1. PTE has RWX Permissions at Level 4 (Read, write, execute page) and MPRV bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 2. PTE has RWX Permissions at Level 3 (Read, write, execute page) and MPRV bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 3. PTE has RWX Permissions at Level 2 (Read, write, execute page) and MPRV bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 4. PTE has RWX Permissions at Level 1 (Read, write, execute page) and MPRV bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 5. PTE has RWX Permissions at Level 0 (Read, write, execute page) and MPRV bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+
+// Total Expected Faults :: 0
+//-------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+	LA(a5, rvtest_data_1)				// Using physical address for execution
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+.macro SET_REQ_MSTATUS_VAL
+	LI (s7, MSTATUS_MPRV)           
+	csrs mstatus,s7                 
+	LI (s7, 0x1800)	// Clear previous mode
+	csrc mstatus,s7                 
+	LI (s7, 0x800)	// Smode
+	csrs mstatus,s7
+.endm
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in M-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in M-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in M-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in M-Mode | RWX bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in M-Mode | RWX bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mprv_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mprv_U_mode.S
@@ -1,0 +1,300 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------MPRV test in M Mode (with U bit perms)---------------------------------------------------
+// 1. PTE has RWX Permissions at Level 4 (Read, write, execute page) and MPRV bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 2. PTE has RWX Permissions at Level 3 (Read, write, execute page) and MPRV bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 3. PTE has RWX Permissions at Level 2 (Read, write, execute page) and MPRV bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 4. PTE has RWX Permissions at Level 1 (Read, write, execute page) and MPRV bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 5. PTE has RWX Permissions at Level 0 (Read, write, execute page) and MPRV bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+
+// Total Expected Faults :: 0
+//-------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+	LA(a5, rvtest_data_1)				// Using physical address for execution
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+.macro SET_REQ_MSTATUS_VAL
+	LI (s7, MSTATUS_MPRV)           
+	csrs mstatus,s7                 
+	LI (s7, 0x1800) 	// Umode
+	csrc mstatus,s7                 
+.endm
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in M-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in M-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in M-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in M-Mode | RWX bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in M-Mode | RWX bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mprv_U_set_sum_set_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mprv_U_set_sum_set_S_mode.S
@@ -1,0 +1,309 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------MPRV test in M Mode (with S bit perms)---------------------------------------------------
+// 1. U-Page set up with RWX Permissions at Level 4 (Read, write, execute page) and SUM bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 2. U-Page set up with RWX Permissions at Level 3 (Read, write, execute page) and SUM bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 3. U-Page set up with RWX Permissions at Level 2 (Read, write, execute page) and SUM bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 4. U-Page set up with RWX Permissions at Level 1 (Read, write, execute page) and SUM bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+// 5. U-Page set up with RWX Permissions at Level 0 (Read, write, execute page) and SUM bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: if VA passed then Load, store successful and (PA) fetch without translation successful
+
+// Total Expected Faults :: 0
+//-------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+
+    // Test store permission
+	sfence.vma
+    sw  a2, 20(a5)               		// Store test data
+    nop
+	nop
+
+    // Test load permission
+    sfence.vma
+	lw  a4, 20(a5)        				// Load back data
+    nop
+	nop
+	
+	LA(a5, rvtest_data_1)				// Using physical address for execution
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+.macro SET_REQ_MSTATUS_VAL
+	LI (s7, MSTATUS_MPRV)           
+	csrs mstatus,s7                 
+	LI (s7, MSTATUS_SUM)	// Set mstatus SUM bit
+	csrs mstatus,s7                 
+	LI (s7, 0x1800)			
+	csrc mstatus,s7                 
+	LI (s7, 0x800)			// Smode
+	csrs mstatus,s7  
+.endm
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: MPRV bit set | Test in M-Mode | RWX set | expected = No Fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: MPRV bit set | Test in M-Mode | RWX set | expected = No Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: MPRV bit set | Test in M-Mode | RWX set | expected = No Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+	
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: MPRV bit set | Test in M-Mode | RWX set | expected = No Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: MPRV bit set | Test in M-Mode | RWX set | expected = No Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mprv_U_set_sum_unset_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mprv_U_set_sum_unset_S_mode.S
@@ -1,0 +1,308 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------MPRV test in M Mode (with S bit perms)---------------------------------------------------
+// 1. U-Page set up with RWX Permissions at Level 4 (Read, write, execute page) and SUM bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: Store & Load page faults; Instruction accesses should be successful
+// 2. U-Page set up with RWX Permissions at Level 3 (Read, write, execute page) and SUM bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: Store & Load page faults; Instruction accesses should be successful
+// 3. U-Page set up with RWX Permissions at Level 2 (Read, write, execute page) and SUM bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: Store & Load page faults; Instruction accesses should be successful
+// 4. U-Page set up with RWX Permissions at Level 1 (Read, write, execute page) and SUM bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: Store & Load page faults; Instruction accesses should be successful
+// 5. U-Page set up with RWX Permissions at Level 0 (Read, write, execute page) and SUM bit set in mstatus:
+//		Then, in M-Mode, the page is accessed --> required: Store & Load page faults; Instruction accesses should be successful
+
+// Total Expected Faults :: 10
+//-------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+	nop
+
+	// Reset the value as it gets changed due to trap
+	SET_REQ_MSTATUS_VAL	
+
+    // Test load permission
+	lw  a4, 20(a5)        				// Load back data
+	nop
+	
+	LA(a5, rvtest_data_1)				// Using physical address for execution
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+.macro SET_REQ_MSTATUS_VAL
+	LI (s7, MSTATUS_MPRV)           
+	csrw mstatus,s7                 
+	LI (s7, MSTATUS_SUM)	// Clear mstatus SUM bit
+	csrc mstatus,s7                 
+	LI (s7, 0x1800)
+	csrc mstatus,s7                 
+	LI (s7, 0x800)			// Smode
+	csrs mstatus,s7 
+.endm
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: MPRV bit set | Test in M-Mode | RWX set | expected = Store page fault, Load page fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: MPRV bit set | Test in M-Mode | RWX set | expected = Store page fault, Load page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: MPRV bit set | Test in M-Mode | RWX set | expected = Store page fault, Load page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+	
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: MPRV bit set | Test in M-Mode | RWX set | expected = Store page fault, Load page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: MPRV bit set | Test in M-Mode | RWX set | expected = Store page fault, Load page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Mmode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mstatus_sbe_set_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mstatus_sbe_set_S_mode.S
@@ -1,0 +1,324 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------- SBE in mstatus set -----------------------------------------------
+// 1. Level 4 page set up with RWX Permissions (Read, write, execute):
+//		Then, in S-Mode, the page is accessed --> required: No Fault
+// 2. Level 3 page set up with RWX Permissions (Read, write, execute):
+//		Then, in S-Mode, the page is accessed --> required: No Fault
+// 3. Level 2 page set up with RWX Permissions (Read, write, execute):
+//		Then, in S-Mode, the page is accessed --> required: No Fault
+// 4. Level 1 page set up with RWX Permissions (Read, write, execute):
+//		Then, in S-Mode, the page is accessed --> required: No Fault
+// 5. Level 0 page set up with RWX Permissions (Read, write, execute):
+//		Then, in S-Mode, the page is accessed --> required: No Fault
+
+// Total Expected Faults :: 0
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+    RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE					// Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)						// Record store attempt
+	nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)						// Record load attempt
+	nop
+	addi x13, x13, REGWIDTH
+.endm
+
+.macro CHANGE_PTE_TO_BE 
+	// After PTE_SETUP_SV57_New completes, a0 has the PTE (PPN and Permission bits) while t1 has the PTE address
+	add t2, zero, zero
+	add t4, zero, zero
+	addi t5, zero, 56
+	.rept(8)
+		srl  t3, a0, t4
+		andi t3, t3, 0xFF
+		sll  t3, t3, t5
+		or   t2, t2, t3
+		addi t4, t4, 8
+		addi t5, t5, -8
+	.endr
+	SREG t2, 0(t1)	
+.endm	
+
+main:
+#ifdef rvtest_mtrap_routine					                				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					                				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP          		                  	                      	// set the PMP permissions for the whole memory
+	csrw satp, zero  		                                        		// write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080005530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)											// Set SATP for virtualization
+	sfence.vma														// Flush the TLB
+
+	LI (s7, (1 << 36))
+	csrs mstatus, s7												// Set SBE (Supervisor Big Endian) bit
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in S-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in S-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in S-Mode | RWX bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in S-Mode | RWX bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mstatus_sbe_set_sum_set_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mstatus_sbe_set_sum_set_S_mode.S
@@ -1,0 +1,326 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------- SBE and SUM in mstatus set -----------------------------------------------
+// 1. U bit set for page at level 4 with RWX Permissions (Read, write, execute):
+//		Then, in S-Mode, the page is accessed --> required: No Fault
+// 2. U bit set for page at level 3 with RWX Permissions (Read, write, execute):
+//		Then, in S-Mode, the page is accessed --> required: No Fault
+// 3. U bit set for page at level 2 with RWX Permissions (Read, write, execute):
+//		Then, in S-Mode, the page is accessed --> required: No Fault
+// 4. U bit set for page at level 1 with RWX Permissions (Read, write, execute):
+//		Then, in S-Mode, the page is accessed --> required: No Fault
+// 5. U bit set for page at level 0 with RWX Permissions (Read, write, execute):
+//		Then, in S-Mode, the page is accessed --> required: No Fault
+
+// Total Expected Faults :: 0
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+    RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE					// Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)						// Record store attempt
+	nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)						// Record load attempt
+	nop
+	addi x13, x13, REGWIDTH
+.endm
+
+.macro CHANGE_PTE_TO_BE 
+	// After PTE_SETUP_SV57_New completes, a0 has the PTE (PPN and Permission bits) while t1 has the PTE address
+	add t2, zero, zero
+	add t4, zero, zero
+	addi t5, zero, 56
+	.rept(8)
+		srl  t3, a0, t4
+		andi t3, t3, 0xFF
+		sll  t3, t3, t5
+		or   t2, t2, t3
+		addi t4, t4, 8
+		addi t5, t5, -8
+	.endr
+	SREG t2, 0(t1)	
+.endm	
+
+main:
+#ifdef rvtest_mtrap_routine					                				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine					                				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP          		                  	                      	// set the PMP permissions for the whole memory
+	csrw satp, zero  		                                        		// write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080005530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)											// Set SATP for virtualization
+	sfence.vma														// Flush the TLB
+
+	LI (s7, (1 << 36))
+	csrs mstatus, s7												// Set SBE (Supervisor Big Endian) bit
+	LI (s7, MSTATUS_SUM)
+	csrs mstatus, s7												// Set SUM bit
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in S-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in S-Mode | RWX bit set | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in S-Mode | RWX bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in S-Mode | RWX bit set | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	CHANGE_PTE_TO_BE
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	CHANGE_PTE_TO_BE
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mxr_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mxr_S_mode.S
@@ -1,0 +1,384 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. X bit is set and MXR bit in mstatus is unset for the page at level 4 with X Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load Page Fault, store page fault 
+// 2. X bit is set and MXR bit in mstatus is set for the page at level 4 with X Permissions (execute page, read page --> MXR Bit):
+//      Then, in S-Mode, the page is accessed --> required: Store page fault
+// 3. X bit is set and MXR bit in mstatus is unset for the page at level 3 with X Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load Page Fault, store page fault 
+// 4. X bit is set and MXR bit in mstatus is set for the page at level 3 with X Permissions (execute page, read page --> MXR Bit):
+//      Then, in S-Mode, the page is accessed --> required: Store page fault
+// 5. X bit is set and MXR bit in mstatus is unset for the page at level 2 with X Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load Page Fault, store page fault 
+// 6. X bit is set and MXR bit in mstatus is set for the page at level 2 with X Permissions (execute page, read page --> MXR Bit):
+//      Then, in S-Mode, the page is accessed --> required: Store page fault
+// 7. X bit is set and MXR bit in mstatus is unset for the page at level 1 with X Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: Load Page Fault, store page fault 
+// 8. X bit is set and MXR bit in mstatus is set for the page at level 1 with X Permissions (execute page, read page --> MXR Bit):
+//		Then, in S-Mode, the page is accessed --> required: Store page fault
+// 9. X bit is set and MXR bit in mstatus is unset for the page at level 0 with X Permissions (execute page, read page --> MXR Bit):
+//		Then, in S-Mode, the page is accessed --> required: Load Page Fault, store page fault 
+// 10. X bit is set and MXR bit in mstatus is set for the page at level 0 with X Permissions (execute page, read page --> MXR Bit):
+//		Then, in S-Mode, the page is accessed --> required: Store page fault
+
+// Total Expected Faults :: 15
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080005530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: X bit set and MXR bit unset | Test in S-Mode | X bit set | expected = Store, load page fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_V ), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: X bit set and MXR bit set | Test in S-Mode | X bit set | expected = store page fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrs mstatus,s7							         						// Set mstatus.MXR = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: X bit set and MXR bit unset | Test in S-Mode | X bit set | expected = Store, load page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_V ), va_data_34, LEVEL3)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrc mstatus,s7							         						// Clear mstatus.MXR
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 4: X bit set and MXR bit set | Test in S-Mode | X bit set | expected = store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrs mstatus,s7							         						// Set mstatus.MXR = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: X bit set and MXR bit unset | Test in S-Mode | X bit set | expected = Store, load page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrc mstatus,s7							         						// Clear mstatus.MXR
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 6: X bit set and MXR bit set | Test in S-Mode | X bit set | expected = store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrs mstatus,s7							         						// Set mstatus.MXR = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2	
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: X bit set and MXR bit unset | Test in S-Mode | X bit set | expected = store, load page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrc mstatus,s7							         						// Clear mstatus.MXR
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 8: X bit set and MXR bit set | Test in S-Mode | X bit set | expected = store page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrs mstatus,s7							         						// Set mstatus.MXR = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1	
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 9: X bit set and MXR bit unset | Test in S-Mode | X bit set | expected = store, load page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrc mstatus,s7							         						// Clear mstatus.MXR
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 10: X bit set and MXR bit set | Test in S-Mode | X bit set | expected = store page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_V), va_data, LEVEL0)
+	sfence.vma
+    
+    li s7, MSTATUS_MXR
+	csrs mstatus,s7							         						// Set mstatus.MXR = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0	
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mxr_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_mxr_U_mode.S
@@ -1,0 +1,384 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. X bit is set and MXR bit in mstatus is unset for the page at level 4 with X Permissions (execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load Page Fault, store page fault 
+// 2. X bit is set and MXR bit in mstatus is set for the page at level 4 with X Permissions (execute page, read page --> MXR Bit):
+//      Then, in U-Mode, the page is accessed --> required: Store page fault
+// 3. X bit is set and MXR bit in mstatus is unset for the page at level 3 with X Permissions (execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load Page Fault, store page fault 
+// 4. X bit is set and MXR bit in mstatus is set for the page at level 3 with X Permissions (execute page, read page --> MXR Bit):
+//      Then, in U-Mode, the page is accessed --> required: Store page fault
+// 5. X bit is set and MXR bit in mstatus is unset for the page at level 2 with X Permissions (execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load Page Fault, store page fault 
+// 6. X bit is set and MXR bit in mstatus is set for the page at level 2 with X Permissions (execute page, read page --> MXR Bit):
+//      Then, in U-Mode, the page is accessed --> required: Store page fault
+// 7. X bit is set and MXR bit in mstatus is unset for the page at level 1 with X Permissions (execute page):
+//		Then, in U-Mode, the page is accessed --> required: Load Page Fault, store page fault 
+// 8. X bit is set and MXR bit in mstatus is set for the page at level 1 with X Permissions (execute page, read page --> MXR Bit):
+//		Then, in U-Mode, the page is accessed --> required: Store page fault
+// 9. X bit is set and MXR bit in mstatus is unset for the page at level 0 with X Permissions (execute page, read page --> MXR Bit):
+//		Then, in U-Mode, the page is accessed --> required: Load Page Fault, store page fault 
+// 10. X bit is set and MXR bit in mstatus is set for the page at level 0 with X Permissions (execute page, read page --> MXR Bit):
+//		Then, in U-Mode, the page is accessed --> required: Store page fault
+
+// Total Expected Faults :: 15
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080005530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: X bit set and MXR bit unset | Test in U-Mode | X bit set | expected = Store, load page fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V ), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: X bit set and MXR bit set | Test in U-Mode | X bit set | expected = store page fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrs mstatus,s7							         						// Set mstatus.MXR = 1
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: X bit set and MXR bit unset | Test in U-Mode | X bit set | expected = Store, load page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V ), va_data_34, LEVEL3)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrc mstatus,s7							         						// Clear mstatus.MXR
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 4: X bit set and MXR bit set | Test in U-Mode | X bit set | expected = store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrs mstatus,s7							         						// Set mstatus.MXR = 1
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: X bit set and MXR bit unset | Test in U-Mode | X bit set | expected = Store, load page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrc mstatus,s7							         						// Clear mstatus.MXR
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 6: X bit set and MXR bit set | Test in U-Mode | X bit set | expected = store page fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrs mstatus,s7							         						// Set mstatus.MXR = 1
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2	
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: X bit set and MXR bit unset | Test in U-Mode | X bit set | expected = store, load page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrc mstatus,s7							         						// Clear mstatus.MXR
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 8: X bit set and MXR bit set | Test in U-Mode | X bit set | expected = store page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrs mstatus,s7							         						// Set mstatus.MXR = 1
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1	
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 9: X bit set and MXR bit unset | Test in U-Mode | X bit set | expected = store, load page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	li s7, MSTATUS_MXR
+	csrc mstatus,s7							         						// Clear mstatus.MXR
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- X permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 10: X bit set and MXR bit set | Test in U-Mode | X bit set | expected = store page fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL0)
+	sfence.vma
+    
+    li s7, MSTATUS_MXR
+	csrs mstatus,s7							         						// Set mstatus.MXR = 1
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0	
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_nleaf_pte_level0_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_nleaf_pte_level0_S_mode.S
@@ -1,0 +1,226 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. No RWX, only V bit is set for the PTE at Level 0:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 3
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | Only V bit set at Level 0 | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_nleaf_pte_level0_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_nleaf_pte_level0_U_mode.S
@@ -1,0 +1,226 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. No RWX, only V bit is set for the PTE at Level 0:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 3
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in U-Mode | Only V bit set at Level 0 | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_U | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_pte_reserved_field_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_pte_reserved_field_S_mode.S
@@ -1,0 +1,281 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// --------------------------- Walking ones through the reserved bit field [63:54] of PTE -------------------------------
+//  1. Setting bit 54 of PTE, RWX permissions given (level 4):
+//		Then, in S-Mode, the page is accessed --> required: RWX Fault
+//  2. Setting bit 55 of PTE, RWX permissions given (level 4):
+//		Then, in S-Mode, the page is accessed --> required: RWX Fault
+//  3. Setting bit 56 of PTE, RWX permissions given (level 4):
+//		Then, in S-Mode, the page is accessed --> required: RWX Fault
+//  4. Setting bit 57 of PTE, RWX permissions given (level 4):
+//		Then, in S-Mode, the page is accessed --> required: RWX Fault
+//  5. Setting bit 58 of PTE, RWX permissions given (level 4):
+//		Then, in S-Mode, the page is accessed --> required: RWX Fault
+//  6. Setting bit 59 of PTE, RWX permissions given (level 4):
+//		Then, in S-Mode, the page is accessed --> required: RWX Fault
+//  7. Setting bit 60 of PTE, RWX permissions given (level 4):
+//		Then, in S-Mode, the page is accessed --> required: RWX Fault
+
+// Total Expected Faults :: 21
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | RWX bit set | Setting bit 54 of PTE | Expected = Store, Load and Fetch page faults
+	PTE_SETUP_SV57_New(pa_zero, ((1 << 54) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4	
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in S-Mode | RWX bit set | Setting bit 55 of PTE | Expected = Store, Load and Fetch page faults
+	PTE_SETUP_SV57_New(pa_zero, ((1 << 55) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4	
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in S-Mode | RWX bit set | Setting bit 56 of PTE | Expected = Store, Load and Fetch page faults
+	PTE_SETUP_SV57_New(pa_zero, ((1 << 56) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4	
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in S-Mode | RWX bit set | Setting bit 57 of PTE | Expected = Store, Load and Fetch page faults
+	PTE_SETUP_SV57_New(pa_zero, ((1 << 57) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4	
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in S-Mode | RWX bit set | Setting bit 58 of PTE | Expected = Store, Load and Fetch page faults
+	PTE_SETUP_SV57_New(pa_zero, ((1 << 58) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4	
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 6: Test in S-Mode | RWX bit set | Setting bit 59 of PTE | Expected = Store, Load and Fetch page faults
+	PTE_SETUP_SV57_New(pa_zero, ((1 << 59) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4	
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: Test in S-Mode | RWX bit set | Setting bit 60 of PTE | Expected = Store, Load and Fetch page faults
+	PTE_SETUP_SV57_New(pa_zero, ((1 << 60) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4	
+	
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 128*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_rsw_pte_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_rsw_pte_S_mode.S
@@ -1,0 +1,437 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. RSW bits are Set for the page at level 4 (01):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 2. RSW bits are Set for the page at level 4 (10):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 3. RSW bits are Set for the page at level 4 (11):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 4. RSW bits are Set for the page at level 3 (01):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 5. RSW bits are Set for the page at level 3 (10):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 6. RSW bits are Set for the page at level 3 (11):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 7. RSW bits are Set for the page at level 2 (01):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 8. RSW bits are Set for the page at level 2 (10):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 9. RSW bits are Set for the page at level 2 (11):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 10. RSW bits are Set for the page at level 1 (01):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 11. RSW bits are Set for the page at level 1 (10):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 12. RSW bits are Set for the page at level 1 (11):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 13. RSW bits are Set for the page at level 0 (01):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 14. RSW bits are Set for the page at level 0 (10):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 15. RSW bits are Set for the page at level 0 (11):
+//		Then, in S-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+
+// Total Expected Faults :: 0
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080006530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | RSW set to 1 | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 8)), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: Test in S-Mode | RSW set to 2 | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9)), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 3: Test in S-Mode | RSW set to 3 | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9) | (1 << 8)), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in S-Mode | RSW set to 1 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 8)), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 5: Test in S-Mode | RSW set to 2 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9)), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 6: Test in S-Mode | RSW set to 3 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9) | (1 << 8)), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: Test in S-Mode | RSW set to 1 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 8)), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 8: Test in S-Mode | RSW set to 2 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9)), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 9: Test in S-Mode | RSW set to 3 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9) | (1 << 8)), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 10: Test in S-Mode | RSW set to 1 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 8)), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 11: Test in S-Mode | RSW set to 2 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9)), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 12: Test in S-Mode | RSW set to 3 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9) | (1 << 8)), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 13: Test in S-Mode | RSW set to 1 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 8)), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 14: Test in S-Mode | RSW set to 2 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9)), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 15: Test in S-Mode | RSW set to 3 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9) | (1 << 8)), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 128*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_rsw_pte_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_rsw_pte_U_mode.S
@@ -1,0 +1,437 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. RSW bits are Set for the page at level 4 (01):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 2. RSW bits are Set for the page at level 4 (10):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 3. RSW bits are Set for the page at level 4 (11):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 4. RSW bits are Set for the page at level 3 (01):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 5. RSW bits are Set for the page at level 3 (10):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 6. RSW bits are Set for the page at level 3 (11):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 7. RSW bits are Set for the page at level 2 (01):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 8. RSW bits are Set for the page at level 2 (10):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 9. RSW bits are Set for the page at level 2 (11):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 10. RSW bits are Set for the page at level 1 (01):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 11. RSW bits are Set for the page at level 1 (10):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 12. RSW bits are Set for the page at level 1 (11):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 13. RSW bits are Set for the page at level 0 (01):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 14. RSW bits are Set for the page at level 0 (10):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+// 15. RSW bits are Set for the page at level 0 (11):
+//		Then, in U-Mode, the page is accessed --> required: No affect on these bits, successful page table walk 
+
+// Total Expected Faults :: 0
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080006530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in U-Mode | RSW set to 1 | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 8)), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: Test in U-Mode | RSW set to 2 | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9)), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 3: Test in U-Mode | RSW set to 3 | expected = successful page access
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9) | (1 << 8)), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in U-Mode | RSW set to 1 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 8)), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 5: Test in U-Mode | RSW set to 2 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9)), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 6: Test in U-Mode | RSW set to 3 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9) | (1 << 8)), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: Test in U-Mode | RSW set to 1 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 8)), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 8: Test in U-Mode | RSW set to 2 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9)), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 9: Test in U-Mode | RSW set to 3 | expected = successful page access
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9) | (1 << 8)), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 10: Test in U-Mode | RSW set to 1 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 8)), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 11: Test in U-Mode | RSW set to 2 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9)), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 12: Test in U-Mode | RSW set to 3 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9) | (1 << 8)), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 13: Test in U-Mode | RSW set to 1 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 8)), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 14: Test in U-Mode | RSW set to 2 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9)), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 15: Test in U-Mode | RSW set to 3 | expected = successful page access 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V | (1 << 9) | (1 << 8)), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 128*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_rwx_pte_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_rwx_pte_S_mode.S
@@ -1,0 +1,365 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. WX Permissions is Set for the page at level 4:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 2. W Permissions is Set for the page at level 4:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 3. WX Permissions is Set for the page at level 3:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. W Permissions is Set for the page at level 3:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 5. WX Permissions is Set for the page at level 2:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 6. W Permissions is Set for the page at level 2:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 7. WX Permissions is Set for the page at level 1:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 8. W Permissions is Set for the page at level 1:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 9. WX Permissions is Set for the page at level 0:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 10. W Permissions is Set for the page at level 0:
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 30
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080005530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | WX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: Test in S-Mode | W bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_W | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in S-Mode | WX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 4: Test in S-Mode | W bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_W | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- WX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in S-Mode | WX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- W permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 6: Test in S-Mode | W bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_W | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- WX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: Test in S-Mode | WX bit set | expected = RWX fault  
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- W permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 8: Test in S-Mode | W bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_W | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- WX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 9: Test in S-Mode | WX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- W permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 10: Test in S-Mode | W bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_W | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 128*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_rwx_pte_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_rwx_pte_U_mode.S
@@ -1,0 +1,365 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. WX Permissions is Set for the page at level 4:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 2. W Permissions is Set for the page at level 4:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 3. WX Permissions is Set for the page at level 3:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. W Permissions is Set for the page at level 3:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 5. WX Permissions is Set for the page at level 2:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 6. W Permissions is Set for the page at level 2:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 7. WX Permissions is Set for the page at level 1:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 8. W Permissions is Set for the page at level 1:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 9. WX Permissions is Set for the page at level 0:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 10. W Permissions is Set for the page at level 0:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 30
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080005530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in U-Mode | WX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: Test in U-Mode | W bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_W | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in U-Mode | WX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 4: Test in U-Mode | W bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_W | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- WX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in U-Mode | WX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- W permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 6: Test in U-Mode | W bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_W | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- WX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 7: Test in U-Mode | WX bit set | expected = RWX fault  
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- W permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 8: Test in U-Mode | W bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_W | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- WX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 9: Test in U-Mode | WX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- W permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 10: Test in U-Mode | W bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_W | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 128*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_svnapot_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_svnapot_S_mode.S
@@ -1,0 +1,223 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// ------------------------ NOTE: This test is for architectures that don't support SVNAPOT -----------------------------
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+//  1. Bit 63 Set (NAPOT indicator, but reserved as SVNAPOT is not supported), RWX permissions given (level 0):
+// 		Then, in S-Mode, the page is accessed --> required: Store, Load & Fetch page faults
+
+// Total Expected Faults :: 3
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000000				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x600008000039C
+	.set va_rvtest_data_begin,  0x7000080010530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					64KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | RWX bit set | Bit 63 (PTE.N) set | PTE.PPN[0][3:0] set to 4'b1000 (64KiB region encoding)
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, ((1 << 63) | (1 << 13) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0			
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGIONS FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0
+// Aligned to 64KiB 
+.align 16
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1								// Random word
+	.word 0xbeefcaf2								// Random word
+	.skip (1 << 16) - (7*4)							// Make a 64 KiB contiguous region
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_svpbmt_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_reserved_svpbmt_S_mode.S
@@ -1,0 +1,232 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+//  1. Set PTE.PBMT = 1 (reserved as SVPBMT is not supported/enabled), RWX permissions given (level 4):
+// 		Then, in S-Mode, the page is accessed --> required: Store, Load & Fetch page faults
+//  1. Set PTE.PBMT = 2 (reserved as SVPBMT is not supported/enabled), RWX permissions given (level 4):
+// 		Then, in S-Mode, the page is accessed --> required: Store, Load & Fetch page faults
+//  3. Set PTE.PBMT = 3 (reserved), RWX permissions given (level 4):
+// 		Then, in S-Mode, the page is accessed --> required: Store, Load & Fetch page faults
+
+// Total Expected Faults :: 9
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in S-Mode | RWX bit set | PTE.PBMT = 1 
+	PTE_SETUP_SV57_New(pa_zero, ((1 << 61) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4	
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in S-Mode | RWX bit set | PTE.PBMT = 2
+	PTE_SETUP_SV57_New(pa_zero, ((2 << 61) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4			
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in S-Mode | RWX bit set | PTE.PBMT = 3
+	PTE_SETUP_SV57_New(pa_zero, ((3 << 61) | PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4			
+
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_satp_access_tests.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_satp_access_tests.S
@@ -1,0 +1,160 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+//  1. Testing satp mode field (SV57 and Bare mode) -> Successful
+//  2. All zeroes, all ones and walking ones in the PPN bitfield of satp  -> Successful
+//	3. All zeroes and ones in satp[59:0] -> Successful
+//	4. Walking ones in the ASID bitfield of satp -> Successful
+
+// Total Expected Faults: 0
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------------------------------------------------
+// Test case 1:  							  Mode Supported --- SV48 and Bare
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	li t0, 0xA000000000000000  // Set t0 to have 1010 in [63:60] (SV57)
+    csrw satp, t0              // Write satp
+    csrr t1, satp              // Read back satp
+    RVTEST_SIGUPD(x13, t1)     // Store read value in signature
+
+    li t0, 0x0000000000000000  // Set t0 to have 0 in [63:60] (Bare mode)
+    csrw satp, t0              // Write satp
+    csrr t1, satp              // Read back satp
+    RVTEST_SIGUPD(x13, t1)     // Store read value in signature
+	
+	RVTEST_GOTO_MMODE
+
+//---------------------------------------------------------------------------------------------------------------------------------
+// Test case 2:				   PPN all zeros, all ones and walking ones in the PPN bitfield of satp
+//---------------------------------------------------------------------------------------------------------------------------------
+
+    li t0, 0xA000000000000000  // Ensure SV57 mode in [63:60]
+    mv t3, t0                  // Start with all_zero case                   
+    csrw satp, t3              // Write all_zero PPN to satp
+    csrr t2, satp              // Read back satp
+    RVTEST_SIGUPD(x13, t2)     // Store read value in signature
+
+    li t1, 0x1                 // Walking ones
+    li t4, 44                  // 43 shifts needed for full 44-bit walking 1 test
+
+loop_walking:
+    or t3, t0, t1              // Combine SV57 mode with PPN value
+    csrw satp, t3              // Write satp
+    csrr t2, satp              // Read back satp
+    RVTEST_SIGUPD(x13, t2)     // Store read value in signature
+    slli t1, t1, 1             // Shift left to prepare the next value
+    addi t4, t4, -1            // Decrement loop counter
+    bnez t4, loop_walking      // Repeat until all iterations are done
+
+    li t1, 0xFFFFFFFFFFF       // All ones case (44-bit max)
+    or t3, t0, t1              // Combine SV57 mode with all ones PPN
+    csrw satp, t3              // Write satp
+    csrr t2, satp              // Read back satp
+    RVTEST_SIGUPD(x13, t2)     // Store read value in signature
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+// Test case 3: 								 All zeros and ones in Satp[59:0]
+//---------------------------------------------------------------------------------------------------------------------------------
+
+    li t0, 0xA000000000000000  // Ensure SV57 mode in [63:60]
+
+    mv t3, t0                  // Keep lower 60 bits as zero                   
+    csrw satp, t3              // Write all_zero case to satp
+    csrr t2, satp              // Read back satp
+    RVTEST_SIGUPD(x13, t2)     // Store read value in signature
+
+    li t1, 0x0FFFFFFFFFFFFFFF  // Keep lower 60 bits as one
+    or t3, t0, t1              // Combine with mode field
+    csrw satp, t3              // Write to satp
+    csrr t2, satp              // Read back satp
+    RVTEST_SIGUPD(x13, t2)     // Store read value in signature
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+// Test case 4:                           	 Walking ones in the ASID bitfield of Satp
+//---------------------------------------------------------------------------------------------------------------------------------
+
+    li t0, 0x0000100000000000      // Start with satp.ASID[0] set
+    li t3, 0xA000000000000000      // Ensure SV57 mode in [63:60]
+    li t2, 16                      // Number of iterations (16 shifts)
+
+satp_test_loop:
+    or t4, t3, t0                  // Combine SV57 mode with current ASID value
+    csrw satp, t4                  // Write satp
+    csrr t1, satp                  // Read back the value
+    RVTEST_SIGUPD(x13, t1)         // Store the value in signature
+    slli t0, t0, 1                 // Shift ASID left to test the next value
+    addi t2, t2, -1                // Decrement loop counter
+    bnez t2, satp_test_loop        // Repeat until all iterations are done
+
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_spage_access_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_spage_access_U_mode.S
@@ -1,0 +1,292 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. S-Page at level 4, RWX permissions (read, write, execute page) given:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 2. S-Page at level 3, RWX permissions (read, write, execute page) given:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 3. S-Page at level 2, RWX permissions (read, write, execute page) given:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 4. S-Page at level 1, RWX permissions (read, write, execute page) given:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 5. S-Page at level 0, RWX permissions (read, write, execute page) given:
+//		Then, in U-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 15
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080004530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 1: Test in U-Mode | U bit unset | RWX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 2: Test in U-Mode | U bit unset | RWX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- WX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 3: Test in U-Mode | U bit unset | RWX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- WX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 4: Test in U-Mode | U bit unset | RWX bit set | expected = RWX fault  
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- WX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	// Test case 5: Test in U-Mode | U bit unset | RWX bit set | expected = RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Umode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 32*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_sum_set_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_sum_set_S_mode.S
@@ -1,0 +1,630 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. U bit is set and mstatus.SUM is set for the page at level 4 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault
+// 2. U bit is set and mstatus.SUM is set for the page at level 4 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 3. U bit is set and mstatus.SUM is set for the page at level 4 with R,X Permissions (Read, Execute page):
+//		Then, in S-Mode, the page is accessed --> required: Store-page-fault, Fetch-page-fault
+// 4. U bit is set and mstatus.SUM is set for the page at level 4 with R,W Permissions (Read, Store page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault
+// 5. U bit is set and mstatus.SUM is set for the page at level 4 with R Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: Store-page-fault, Fetch-page-fault
+
+// 6. U bit is set and mstatus.SUM is set for the page at level 3 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault
+// 7. U bit is set and mstatus.SUM is set for the page at level 3 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 8. U bit is set and mstatus.SUM is set for the page at level 3 with R,X Permissions (Read, Execute page):
+//		Then, in S-Mode, the page is accessed --> required: Store-page-fault, Fetch-page-fault
+// 9. U bit is set and mstatus.SUM is set for the page at level 3 with R,W Permissions (Read, Store page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault
+// 10. U bit is set and mstatus.SUM is set for the page at level 3 with R Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: Store-page-fault, Fetch-page-fault
+
+// 11. U bit is set and mstatus.SUM is set for the page at level 2 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault
+// 12. U bit is set and mstatus.SUM is set for the page at level 2 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 13. U bit is set and mstatus.SUM is set for the page at level 2 with R,X Permissions (Read, Execute page):
+//		Then, in S-Mode, the page is accessed --> required: Store-page-fault, Fetch-page-fault
+// 14. U bit is set and mstatus.SUM is set for the page at level 2 with R,W Permissions (Read, Store page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault
+// 15. U bit is set and mstatus.SUM is set for the page at level 2 with R Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: Store-page-fault, Fetch-page-fault
+
+// 16. U bit is set and mstatus.SUM is set for the page at level 1 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault
+// 17. U bit is set and mstatus.SUM is set for the page at level 1 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 18. U bit is set and mstatus.SUM is set for the page at level 1 with R,X Permissions (Read, Execute page):
+//		Then, in S-Mode, the page is accessed --> required: Store-page-fault, Fetch-page-fault
+// 19. U bit is set and mstatus.SUM is set for the page at level 1 with R,W Permissions (Read, Store page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault
+// 20. U bit is set and mstatus.SUM is set for the page at level 1 with R Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: Store-page-fault, Fetch-page-fault
+
+// 21. U bit is set and mstatus.SUM is set for the page at level 0 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault
+// 22. U bit is set and mstatus.SUM is set for the page at level 0 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault, Fetch-page-fault
+// 23. U bit is set and mstatus.SUM is set for the page at level 0 with R,X Permissions (Read, Execute page):
+//		Then, in S-Mode, the page is accessed --> required: Store-page-fault, Fetch-page-fault
+// 24. U bit is set and mstatus.SUM is set for the page at level 0 with R,W Permissions (Read, Store page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault
+// 25. U bit is set and mstatus.SUM is set for the page at level 0 with R Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: Store-page-fault, Fetch-page-fault
+
+// Total Expected Faults :: 45
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080007530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 1: U bit set | Test in S-Mode | RWX bit set | expected = fetch-page-fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: U bit set | Test in S-Mode | X bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 3: U bit set | Test in S-Mode | RX bit set | expected = store-page-fault, fetch-page-fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_X | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 4: U bit set | Test in S-Mode |  RW bit set | expected = fetch-page-fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 5: U bit set | Test in S-Mode | R bit set | expected = fetch-page-fault, store-page-fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 6: U bit set | Test in S-Mode | RWX bit set | expected = fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 7: U bit set | Test in S-Mode | X bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 8: U bit set | Test in S-Mode | RX bit set | expected = store-page-fault, fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_X | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 9: U bit set | Test in S-Mode |  RW bit set | expected = fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 10: U bit set | Test in S-Mode | R bit set | expected = fetch-page-fault, store-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 11: U bit set | Test in S-Mode | RWX bit set | expected = fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 12: U bit set | Test in S-Mode | X bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 13: U bit set | Test in S-Mode | RX bit set | expected = store-page-fault, fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_X | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 14: U bit set | Test in S-Mode |  RW bit set | expected = fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 15: U bit set | Test in S-Mode | R bit set | expected = fetch-page-fault, store-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 16: U bit set | Test in S-Mode | RWX bit set | expected = fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 17: U bit set | Test in S-Mode | X bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 18: U bit set | Test in S-Mode | RX bit set | expected = store-page-fault, fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_X | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 19: U bit set | Test in S-Mode |  RW bit set | expected = fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 20: U bit set | Test in S-Mode | R bit set | expected = fetch-page-fault, store-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 21: U bit set | Test in S-Mode | RWX bit set | expected = fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 22: U bit set | Test in S-Mode | X bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 23: U bit set | Test in S-Mode | RX bit set | expected = store-page-fault, fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_X | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 24: U bit set | Test in S-Mode | RW bit set | expected = fetch-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 25: U bit set | Test in S-Mode | R bit set | expected = load-page-fault, store-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7							         						// set mstatus.SUM = 1
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 128*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 256*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_sum_set_U_bit_unset_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_sum_set_U_bit_unset_S_mode.S
@@ -1,0 +1,443 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. U bit is UnSet and Sum bit in mstatus is set for the page at level 4 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: No fault
+// 2. U bit is UnSet and Sum bit in mstatus is set for the page at level 4 with R Permissions (Read only page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault, Store-page-fault
+// 3. U bit is UnSet and Sum bit in mstatus is set for the page at level 4 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault
+
+// 4. U bit is UnSet and Sum bit in mstatus is set for the page at level 3 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: No fault
+// 5. U bit is UnSet and Sum bit in mstatus is set for the page at level 3 with R Permissions (Read only page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault, Store-page-fault
+// 6. U bit is UnSet and Sum bit in mstatus is set for the page at level 3 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault
+
+// 7. U bit is UnSet and Sum bit in mstatus is set for the page at level 2 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: No fault
+// 8. U bit is UnSet and Sum bit in mstatus is set for the page at level 2 with R Permissions (Read only page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault, Store-page-fault
+// 9. U bit is UnSet and Sum bit in mstatus is set for the page at level 2 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault
+
+// 10. U bit is UnSet and Sum bit in mstatus is set for the page at level 1 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: No fault
+// 11. U bit is UnSet and Sum bit in mstatus is set for the page at level 1 with R Permissions (Read only page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault, Store-page-fault
+// 12. U bit is UnSet and Sum bit in mstatus is set for the page at level 1 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault
+
+// 13. U bit is UnSet and Sum bit in mstatus is set for the page at level 0 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: No fault
+// 14. U bit is UnSet and Sum bit in mstatus is set for the page at level 0 with R Permissions (Read only page):
+//		Then, in S-Mode, the page is accessed --> required: Fetch-page-fault, Store-page-fault
+// 15. U bit is UnSet and Sum bit in mstatus is set for the page at level 0 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: Load-page-fault, Store-page-fault
+
+// Total Expected Faults :: 20
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080006530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)												// Set SATP for virtualization
+	sfence.vma															// Flush the TLB
+
+	li s7, MSTATUS_SUM
+	csrs mstatus,s7														// Set mstatus.SUM = 1
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 1: U bit unset | Test in S-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: U bit unset | Test in S-Mode | R bit set | expected = fetch-page-fault, store-page-fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 3: U bit unset | Test in S-Mode | X bit set | expected = Load, Store Fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 4: U bit unset | Test in S-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 5: U bit unset | Test in S-Mode | R bit set | expected = fetch-page-fault, store-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 6: U bit unset | Test in S-Mode | X bit set | expected = Load, Store Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 7: U bit unset | Test in S-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 8: U bit unset | Test in S-Mode | R bit set | expected = fetch-page-fault, store-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 9: U bit unset | Test in S-Mode | X bit set | expected = Load, Store Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 10: U bit unset | Test in S-Mode | RWX bit set | expected = No Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 11: U bit unset | Test in S-Mode | R bit set | expected = fetch-page-fault, store-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 12: U bit unset | Test in S-Mode | X bit set | expected = Load, Store Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 13: U bit unset | Test in S-Mode | RWX bit set | expected = No RWX fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 14: U bit unset | Test in S-Mode | R bit set | expected = load-page-fault, store-page-fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 15: U bit unset | Test in S-Mode | X bit set | expected = Load, Store Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_X | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 128*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_sum_unset_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_sv57/src/sv57_sum_unset_S_mode.S
@@ -1,0 +1,580 @@
+// ----------------------------------------------------------------------------------------------------------------------
+// This test is part of the test plan for the SV57 based Virtual Memory System, available at:
+// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
+// Developed by: Umer Shahid & Muhammad Zain
+// ----------------------------------------------------------------------------------------------------------------------
+// Test cases are as follows:
+// ----------------------------------------------------------------------------------------------------------------------
+// 1. U bit is set and mstatus.SUM is unset for the page at level 4 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 2. U bit is set and mstatus.SUM is unset for the page at level 4 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 3. U bit is set and mstatus.SUM is unset for the page at level 4 with R,X Permissions (Read, Execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 4. U bit is set and mstatus.SUM is unset for the page at level 4 with R,W Permissions (Read, Store page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 5. U bit is set and mstatus.SUM is unset for the page at level 4 with X Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+
+// 6. U bit is set and mstatus.SUM is unset for the page at level 3 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 7. U bit is set and mstatus.SUM is unset for the page at level 3 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 8. U bit is set and mstatus.SUM is unset for the page at level 3 with R,X Permissions (Read, Execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 9. U bit is set and mstatus.SUM is unset for the page at level 3 with R,W Permissions (Read, Store page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 10. U bit is set and mstatus.SUM is unset for the page at level 3 with X Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+
+// 11. U bit is set and mstatus.SUM is unset for the page at level 2 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 12. U bit is set and mstatus.SUM is unset for the page at level 2 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 13. U bit is set and mstatus.SUM is unset for the page at level 2 with R,X Permissions (Read, Execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 14. U bit is set and mstatus.SUM is unset for the page at level 2 with R,W Permissions (Read, Store page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 15. U bit is set and mstatus.SUM is unset for the page at level 2 with X Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+
+// 16. U bit is set and mstatus.SUM is unset for the page at level 1 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 17. U bit is set and mstatus.SUM is unset for the page at level 1 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 18. U bit is set and mstatus.SUM is unset for the page at level 1 with R,X Permissions (Read, Execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 19. U bit is set and mstatus.SUM is unset for the page at level 1 with R,W Permissions (Read, Store page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 20. U bit is set and mstatus.SUM is unset for the page at level 1 with X Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+
+// 21. U bit is set and mstatus.SUM is unset for the page at level 0 with RWX Permissions (Read, write, execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 22. U bit is set and mstatus.SUM is unset for the page at level 0 with X Permissions (Execute only page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 23. U bit is set and mstatus.SUM is unset for the page at level 0 with R,X Permissions (Read, Execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 24. U bit is set and mstatus.SUM is unset for the page at level 0 with R,W Permissions (Read, Store page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+// 25. U bit is set and mstatus.SUM is unset for the page at level 0 with X Permissions (execute page):
+//		Then, in S-Mode, the page is accessed --> required: load-page-fault, store-page-fault, Fetch Page Fault
+
+// Total Expected Faults :: 75
+// ----------------------------------------------------------------------------------------------------------------------
+
+#define SKIP_MEPC
+#define SKIP_MTVAL
+
+#include "model_test.h"
+
+#include "arch_test.h"
+
+RVTEST_ISA("RV64I_Zicsr")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT												// This test supports max 255 words for RVMODEL_BOOT
+
+j starting_point											// Skip test region
+.align 10													// Aligning so that RVMODEL_BOOT doesn't change address of rvtest_data_1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//											PHYSICAL ADDRESS REGION FOR TESTING
+//---------------------------------------------------------------------------------------------------------------------------------
+// Physical Address region under testing for LEVEL 0, 1, 2, 3 and 4
+rvtest_data_1:
+	nop
+	addi ra, ra, REGWIDTH
+	jr ra
+	nop
+	.word 0xbeefcaf1					// Random word
+	.word 0xbeefcaf2					// Random word
+	nop
+	jr ra
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+
+starting_point:
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def TEST_CASE_1=True", sv57_tests)
+
+RVTEST_SIGBASE( x13,signature_x13_1)
+# ---------------------------------------------------------------------------------------------
+// Test the RWX permissions
+.macro VERIFICATION_RWX ADDRESS, level	
+   	LI(a5, \ADDRESS)                    // Load virtual address
+    addi a2, a2, 16                     // Test pattern initialization
+	
+    // Test store permission
+    sw  a2, 20(a5)               		// Store test data
+    nop
+
+    // Test load permission
+    lw  a4, 20(a5)        				// Load back data
+    nop
+
+    // Test Execute Permission
+    LI(x3, 0xACCE)						// Store a value which is to be checked in trap handler
+    LA(x4, 1f)							// Store the return Address in x4
+    jalr ra, a5, 0
+    nop
+    nop
+1:
+    nop
+.endm
+
+.macro TEST_CASES_RUNNER LOWER_MODE, VA, level
+	.if \LOWER_MODE == Mmode
+		SET_REQ_MSTATUS_VAL
+	.else
+		RVTEST_GOTO_LOWER_MODE \LOWER_MODE   // Switch to the specified lower mode
+	.endif
+	.align 2
+
+	//JUMP TO LOAD, STORE, EXECUTE CHECK MACRO (SEE ON TOP)
+	VERIFICATION_RWX	\VA, \level
+	nop
+	nop
+
+	RVTEST_GOTO_MMODE		            // Switching back to M mode
+	
+	// Signature Update
+   	SREG a2, 0(x13)                     // Record store attempt
+    nop
+	addi x13, x13, REGWIDTH
+
+   	SREG a4, 0(x13)                     // Record load attempt
+    nop
+	addi x13, x13, REGWIDTH
+.endm
+
+
+main:
+#ifdef rvtest_mtrap_routine				// Verification of existance of rvtest_mtrap_routine
+	LI a4, 0xceed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+#ifdef rvtest_strap_routine				// Verification of existance of rvtest_strap_routine
+	LI a4, 0xbeed
+	RVTEST_SIGUPD(x13,a4)
+#endif
+	
+	ALL_MEM_PMP							// set the PMP permissions for the whole memory
+	csrw satp, zero  		            // write satp with all zeros (bare mode)
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//								Virtual addresses definition section for the code, data & test sections
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Virtual Address of Test section 
+	.set va_data,          		0x5000000000400				// Virtual Address of rvtest_data_1
+
+	// Virtual Addresses for code & data regions
+	.set va_rvtest_code_begin,  0x60000800007BC
+	.set va_rvtest_data_begin,  0x7000080007530
+    
+	// PetaPage must have PA[47:0] == 0 and TeraPage must have PA[38:0] == 0, but our PA range starts from 0x8000_0000
+	// Therefore, we will setup these pages using a physical address of zero
+    .set pa_zero,				0x0000000000000				// Physical Address for Peta & TeraPages
+	.set va_data_34,			0x5000080000400				// Virtual Address of rvtest_data_1 (In case of Level 3 & 4)
+
+	// PTE setup for Code Region
+    PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL4)
+	sfence.vma
+
+	// PTE setup for Data Region
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V), va_rvtest_data_begin, LEVEL4)
+	sfence.vma
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//													Save area logic
+//---------------------------------------------------------------------------------------------------------------------------------
+	
+	LI (t0, va_rvtest_data_begin) 
+	LA (t1, rvtest_data_begin) 
+	sub t0, t0, t1         
+	addi t3, t0, sv_area_sz
+	csrr sp, mscratch      
+	add t1,sp,t3           
+	csrw sscratch, t1      
+	csrr sp, mscratch
+
+	//save area setup for code region
+	SAVE_AREA_SETUP(va_rvtest_code_begin, rvtest_code_begin, code)
+	//save area setup for data region
+	SAVE_AREA_SETUP(va_rvtest_data_begin, rvtest_data_begin, data)
+	
+//---------------------------------------------------------------------------------------------------------------------------------
+//												Test Cases Start from here
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	SATP_SETUP_RV64(sv57)                                                  // Set SATP for virtualization
+	sfence.vma                                                             // Flush the TLB
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 4
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 1: U bit set | Test in S-Mode | RWX bit set | expected = RWX Fault 
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 2: U bit set | Test in S-Mode | X bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 3: U bit set | Test in S-Mode | RX bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_X | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 4: U bit set | Test in S-Mode |  RW bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					256TB PAGE	Region 1 under test at level 4 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 5: U bit set | Test in S-Mode | R bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V), va_data_34, LEVEL4)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL4
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 3
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 6: U bit set | Test in S-Mode | RWX bit set | expected = RWX Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 7: U bit set | Test in S-Mode | X bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 8: U bit set | Test in S-Mode | RX bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_X | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 9: U bit set | Test in S-Mode |  RW bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					512GB PAGE	Region 1 under test at level 3 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 10: U bit set | Test in S-Mode | R bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data_34, LEVEL4)
+	PTE_SETUP_SV57_New(pa_zero, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V), va_data_34, LEVEL3)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data_34, LEVEL3
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 2
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 11: U bit set | Test in S-Mode | RWX bit set | expected = RWX Fault 
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 12: U bit set | Test in S-Mode | X bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 13: U bit set | Test in S-Mode | RX bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_X | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 14: U bit set | Test in S-Mode |  RW bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					1GB PAGE	Region 1 under test at level 2 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 15: U bit set | Test in S-Mode | R bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V), va_data, LEVEL2)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL2
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 1
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 16: U bit set | Test in S-Mode | RWX bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 17: U bit set | Test in S-Mode | X bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 18: U bit set | Test in S-Mode | RX bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_X | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 19: U bit set | Test in S-Mode |  RW bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					2MB PAGE	Region 1 under test at level 1 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 20: U bit set | Test in S-Mode | R bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V), va_data, LEVEL1)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL1
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------------------
+//													TESTS AT LEVEL 0
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 21: U bit set | Test in S-Mode | RWX bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 22: U bit set | Test in S-Mode | X bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 23: U bit set | Test in S-Mode | RX bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_X | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 24: U bit set | Test in S-Mode | RW bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_W | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+//---------------------------------------------------------------------------------------------------------------------------------
+//					4KB PAGE	Region 1 under test at level 0 -- RWX permissions given to the region
+//---------------------------------------------------------------------------------------------------------------------------------
+
+	// Test case 25: U bit set | Test in S-Mode | R bit set | expected = RWX Fault
+	PTE_SETUP_SV57_New(rvtest_slvl4_pg_tbl, (PTE_V), va_data, LEVEL4)
+	PTE_SETUP_SV57_New(rvtest_slvl3_pg_tbl, (PTE_V), va_data, LEVEL3)
+    PTE_SETUP_SV57_New(rvtest_slvl2_pg_tbl, (PTE_V), va_data, LEVEL2)
+	PTE_SETUP_SV57_New(rvtest_slvl1_pg_tbl, (PTE_V), va_data, LEVEL1)
+	PTE_SETUP_SV57_New(rvtest_data_1, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V), va_data, LEVEL0)
+	sfence.vma
+
+	TEST_CASES_RUNNER Smode, va_data, LEVEL0
+
+#endif
+//---------------------------------------------------------------------------------------------------------------------------------
+RVTEST_CODE_END
+RVMODEL_HALT
+RVTEST_DATA_BEGIN
+
+#ifdef rvtest_strap_routine
+.align 12
+rvtest_slvl1_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl2_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl3_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+.align 12
+rvtest_slvl4_pg_tbl:
+		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
+#endif
+
+RVTEST_DATA_END                               
+.align 12
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+
+// test signatures initialization
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xcafebeef
+
+// trap signatures initialization
+#ifdef rvtest_mtrap_routine
+mtrap_sigptr:
+    .fill 360*(XLEN/32),4,0xdeadbeef
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END


### PR DESCRIPTION
## Description

> Tests have been added to verify the functionality of SV57 virtual memory extension.

### Ratified/Unratified Extensions

- [x] Ratified
- [ ] Unratified

### List Extensions

> SV57

### Reference Model Used

- [x] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [x] All tests are compliant with the test-format spec present in this repo ?
  - [x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

  - [x] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
