### PR TITLE
ExceptionsInstr

### DIFF
--- a/coverpoints/priv/ExceptionsInstr_coverage.svh
+++ b/coverpoints/priv/ExceptionsInstr_coverage.svh
@@ -1,0 +1,4 @@
+// ExceptionsInstr_coverage.svh
+// Reuse the ExceptionsM coverage model for this test.
+
+`include "ExceptionsM_coverage.svh"

--- a/coverpoints/priv/ExceptionsInstr_coverage_init.svh
+++ b/coverpoints/priv/ExceptionsInstr_coverage_init.svh
@@ -1,0 +1,4 @@
+// ExceptionsInstr_coverage_init.svh
+// If ExceptionsM has an init, reuse it too.
+
+`include "ExceptionsM_coverage_init.svh"

--- a/framework/src/act/fcov/coverage/RISCV_coverage_config.svh
+++ b/framework/src/act/fcov/coverage/RISCV_coverage_config.svh
@@ -260,6 +260,9 @@
 `ifdef EXCEPTIONSF_COVERAGE
   `include "ExceptionsF_coverage.svh"
 `endif
+`ifdef EXCEPTIONSINSTR_COVERAGE
+  `include "ExceptionsInstr_coverage.svh"
+`endif
 `ifdef ZICNTRU_COVERAGE
   `include "ZicntrU_coverage.svh"
 `endif

--- a/tests/priv/ExceptionsInstr/ExceptionsInstr.S
+++ b/tests/priv/ExceptionsInstr/ExceptionsInstr.S
@@ -9,6 +9,12 @@
 // SPDX-License-Identifier: Apache-2.0
 ///////////////////////////////////////////
 
+##### START_TEST_CONFIG #####
+# implemented_extensions: [I, Zicsr]
+# MARCH: rv${XLEN}i_zicsr
+# CONFIG_DEPENDENT: true
+##### END_TEST_CONFIG #####
+
 
 #include "WALLY-init-lib.h"
 


### PR DESCRIPTION
Getting ExceptionsInstr to run in the new framework. Current coverage is 60%. Did not have a coverage for this file, so I created by just including the ExceptionsM_coverage (this is bc the test states at the top that its a portion of the Exceptions_coverage.) 

also edited Makefile to run for both rv32 and rv64 configs.