### PR TITLE
Updated VM_PMP ACTs to support any value of G

### DIFF
--- a/riscv-test-suite/rv32i_m/vm_pmp/src/sv32_pmp_on_pa_S_mode.S
+++ b/riscv-test-suite/rv32i_m/vm_pmp/src/sv32_pmp_on_pa_S_mode.S
@@ -25,6 +25,10 @@
 
 #include "arch_test.h"
 
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
+
 RVTEST_ISA("RV32I_Zicsr")
 
 # Test code region
@@ -47,14 +51,15 @@ rvtest_data_1:
 	nop
 	.word 0xbeefcaf1					// Random word
 	.word 0xbeefcaf2					// Random word
-	.rept(8)
-		nop
-	.endr
+	nop
 	jr ra
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
+.align 11
+// The preceding test region is 2KB by default. If G increases, adjusting alignment to expand the test region accordingly.
+.align (RVMODEL_PMP_GRAIN+2)
 starting_point:
 RVTEST_CODE_BEGIN
 
@@ -139,9 +144,16 @@ main:
 	li t2, -1
 	csrw pmpaddr3, t2
 
-	LI (t2, 0x80000400)					// Configure test region as NAPOT, Start = 0x8000_0400
+	LI (t2, 0x80000000)					// Configure test region as NAPOT, Start = 0x8000_0000
 	srl t2, t2, 2
-	ori t2, t2, 0x7						// Range = 2^(3+3) = 64 bytes
+
+	.if (RVMODEL_PMP_GRAIN < 10)
+		LI (t1, 0xFF)								// Range = 2^(8+3) = 2048 Bytes
+	.else
+		LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)		// Range = 2^(G+3) Bytes
+	.endif
+
+	or t2, t2, t1						
 	csrw pmpaddr1, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------
@@ -152,11 +164,21 @@ main:
 	.set va_data,          		0x91400400
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x900007ac
+	// If G increases more than 9, size of test region increases. Therefore, adjust address of rvtest_code_begin accordingly
+	.if (RVMODEL_PMP_GRAIN < 10)
+		.set va_rvtest_code_begin,  0x90000B6C
+	.else
+		.set va_rvtest_code_begin,  0x9000036C | (1<<(RVMODEL_PMP_GRAIN+2))
+	.endif
 	.set va_rvtest_data_begin,  0x910003f0	
 
 //	PTE setup for Code Region
     PTE_SETUP_RV32_New(rvtest_code_begin, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL1)
+	// As address of rvtest_code_begin can change, therefore zero out PPN[0] from PTE to keep it aligned
+	LI (t0, 0xFFC00)
+	not t0, t0
+	and a0, a0, t0
+	sw  a0, 0(t1)
 	sfence.vma
 
 //	PTE setup for Data Region

--- a/riscv-test-suite/rv32i_m/vm_pmp/src/sv32_pmp_on_pa_U_mode.S
+++ b/riscv-test-suite/rv32i_m/vm_pmp/src/sv32_pmp_on_pa_U_mode.S
@@ -25,6 +25,10 @@
 
 #include "arch_test.h"
 
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
+
 RVTEST_ISA("RV32I_Zicsr")
 
 # Test code region
@@ -47,14 +51,15 @@ rvtest_data_1:
 	nop
 	.word 0xbeefcaf1					// Random word
 	.word 0xbeefcaf2					// Random word
-	.rept(8)
-		nop
-	.endr
+	nop
 	jr ra
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
+.align 11
+// The preceding test region is 2KB by default. If G increases, adjusting alignment to expand the test region accordingly.
+.align (RVMODEL_PMP_GRAIN+2)
 starting_point:
 RVTEST_CODE_BEGIN
 
@@ -139,9 +144,16 @@ main:
 	li t2, -1
 	csrw pmpaddr3, t2
 
-	LI (t2, 0x80000400)					// Configure test region as NAPOT, Start = 0x8000_0400
+	LI (t2, 0x80000000)					// Configure test region as NAPOT, Start = 0x8000_0000
 	srl t2, t2, 2
-	ori t2, t2, 0x7						// Range = 2^(3+3) = 64 bytes
+
+	.if (RVMODEL_PMP_GRAIN < 10)
+		LI (t1, 0xFF)								// Range = 2^(8+3) = 2048 Bytes
+	.else
+		LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)		// Range = 2^(G+3) Bytes
+	.endif
+
+	or t2, t2, t1						
 	csrw pmpaddr1, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------
@@ -152,11 +164,21 @@ main:
 	.set va_data,          		0x91400400
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x900007ac
+	// If G increases more than 9, size of test region increases. Therefore, adjust address of rvtest_code_begin accordingly
+	.if (RVMODEL_PMP_GRAIN < 10)
+		.set va_rvtest_code_begin,  0x90000B6C
+	.else
+		.set va_rvtest_code_begin,  0x9000036C | (1<<(RVMODEL_PMP_GRAIN+2))
+	.endif
 	.set va_rvtest_data_begin,  0x910003f0	
 
 //	PTE setup for Code Region
     PTE_SETUP_RV32_New(rvtest_code_begin, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL1)
+	// As address of rvtest_code_begin can change, therefore zero out PPN[0] from PTE to keep it aligned
+	LI (t0, 0xFFC00)
+	not t0, t0
+	and a0, a0, t0
+	sw  a0, 0(t1)
 	sfence.vma
 
 //	PTE setup for Data Region

--- a/riscv-test-suite/rv32i_m/vm_pmp/src/sv32_pmp_on_pte_S_mode.S
+++ b/riscv-test-suite/rv32i_m/vm_pmp/src/sv32_pmp_on_pte_S_mode.S
@@ -1,19 +1,23 @@
 // ----------------------------------------------------------------------------------------------------------------------
-// This test is part of the test plan for the SV-48-based Virtual Memory System, available at:
-// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
 // Developed by: Umer Shahid & Muhammad Zain
 // ----------------------------------------------------------------------------------------------------------------------
 // Test cases are as follows:
 // ----------------------------------------------------------------------------------------------------------------------
+// .if (RVMODEL_PMP_GRAIN < 10)
 // Configure level 1 PTE as NAPOT with X permission (pmp0cfg0)
 // 1. Setup a PTE at Level 1 with RWX permissions
 //      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 // Configure level 0 PTE as NAPOT with X permission (pmp0cfg0)
 // 2. Setup a PTE at Level 0 with RWX permissions
 //      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
-
-// Total Expected Faults :: 6
+//
+// .if (RVMODEL_PMP_GRAIN < 10)
+// 		Total Expected Faults :: 6
+// .else
+// 		Total Expected Faults :: 3
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 
 #define SKIP_MEPC
@@ -22,6 +26,10 @@
 #include "model_test.h"
 
 #include "arch_test.h"
+
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
 
 RVTEST_ISA("RV32I_Zicsr")
 
@@ -138,11 +146,11 @@ main:
 //---------------------------------------------------------------------------------------------------------------------------------
 
 	// Virtual Address of Test section 
-	.set va_data,          		0x01400400
+	.set va_data,          		0x00000400
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x9000078c
-	.set va_rvtest_data_begin,  0x910003f0	
+	.set va_rvtest_code_begin,  0xFF80078C
+	.set va_rvtest_data_begin,  0xFFC003F0	
 
 //	PTE setup for Code Region
     PTE_SETUP_RV32_New(rvtest_code_begin, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL1)
@@ -177,15 +185,19 @@ main:
 	SATP_SETUP_SV32                                                         // Set SATP for virtualization
 	sfence.vma                                                              // Flush the TLB
 
+// This test case for root page table is skipped if G >= 10, because with PMP granularity ≥ 4KB,
+// the entire root page table will lose its read/write permissions, preventing entry into S-Mode.
+.if (RVMODEL_PMP_GRAIN < 10)
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 1 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_Sroot_pg_tbl)			// Configure first 16 (level 1) PTEs as NAPOT region
+	LA (t2, rvtest_Sroot_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -203,15 +215,17 @@ main:
 
 	TEST_CASES_RUNNER Smode, va_data
 
+.endif
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 0 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl1_pg_tbl)			// Configure first 16 (level 0) PTEs as NAPOT region
+	LA (t2, rvtest_slvl1_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -239,12 +253,15 @@ RVTEST_DATA_BEGIN
 
 #ifdef rvtest_strap_routine
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl1_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
 #endif
 
+.align (RVMODEL_PMP_GRAIN+2)
 RVTEST_DATA_END                               
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 sig_begin_canary:

--- a/riscv-test-suite/rv32i_m/vm_pmp/src/sv32_pmp_on_pte_U_mode.S
+++ b/riscv-test-suite/rv32i_m/vm_pmp/src/sv32_pmp_on_pte_U_mode.S
@@ -1,19 +1,23 @@
 // ----------------------------------------------------------------------------------------------------------------------
-// This test is part of the test plan for the SV-48-based Virtual Memory System, available at:
-// https://docs.google.com/spreadsheets/d/1rZQbz8gJc3RRbTG4rbw9SoEGYkArA8ileVldBX_gxUc/edit?gid=1688601426#gid=1688601426
 // Developed by: Umer Shahid & Muhammad Zain
 // ----------------------------------------------------------------------------------------------------------------------
 // Test cases are as follows:
 // ----------------------------------------------------------------------------------------------------------------------
+// .if (RVMODEL_PMP_GRAIN < 10)
 // Configure level 1 PTE as NAPOT with X permission (pmp0cfg0)
 // 1. Setup a PTE at Level 1 with RWX permissions
 //      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 // Configure level 0 PTE as NAPOT with X permission (pmp0cfg0)
 // 2. Setup a PTE at Level 0 with RWX permissions
 //      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
-
-// Total Expected Faults :: 6
+//
+// .if (RVMODEL_PMP_GRAIN < 10)
+// 		Total Expected Faults :: 6
+// .else
+// 		Total Expected Faults :: 3
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 
 #define SKIP_MEPC
@@ -22,6 +26,10 @@
 #include "model_test.h"
 
 #include "arch_test.h"
+
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
 
 RVTEST_ISA("RV32I_Zicsr")
 
@@ -138,11 +146,11 @@ main:
 //---------------------------------------------------------------------------------------------------------------------------------
 
 	// Virtual Address of Test section 
-	.set va_data,          		0x01400400
+	.set va_data,          		0x00000400
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x9000078c
-	.set va_rvtest_data_begin,  0x910003f0	
+	.set va_rvtest_code_begin,  0xFF80078C
+	.set va_rvtest_data_begin,  0xFFC003F0	
 
 //	PTE setup for Code Region
     PTE_SETUP_RV32_New(rvtest_code_begin, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL1)
@@ -177,15 +185,19 @@ main:
 	SATP_SETUP_SV32                                                         // Set SATP for virtualization
 	sfence.vma                                                              // Flush the TLB
 
+// This test case for root page table is skipped if G >= 10, because with PMP granularity ≥ 4KB,
+// the entire root page table will lose its read/write permissions, preventing entry into U-Mode.
+.if (RVMODEL_PMP_GRAIN < 10)
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 1 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_Sroot_pg_tbl)			// Configure first 16 (level 1) PTEs as NAPOT region
+	LA (t2, rvtest_Sroot_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -203,15 +215,17 @@ main:
 
 	TEST_CASES_RUNNER Umode, va_data
 
+.endif
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 0 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl1_pg_tbl)			// Configure first 16 (level 0) PTEs as NAPOT region
+	LA (t2, rvtest_slvl1_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -239,12 +253,15 @@ RVTEST_DATA_BEGIN
 
 #ifdef rvtest_strap_routine
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl1_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
 #endif
 
+.align (RVMODEL_PMP_GRAIN+2)
 RVTEST_DATA_END                               
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 sig_begin_canary:

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv39/sv39_pmp_on_pa_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv39/sv39_pmp_on_pa_S_mode.S
@@ -27,6 +27,10 @@
 
 #include "arch_test.h"
 
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
+
 RVTEST_ISA("RV64I_Zicsr")
 
 # Test code region
@@ -49,14 +53,15 @@ rvtest_data_1:
 	nop
 	.word 0xbeefcaf1					// Random word
 	.word 0xbeefcaf2					// Random word
-	.rept(9)
-		nop
-	.endr
+	nop
 	jr ra
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
+.align 11
+// The preceding test region is 2KB by default. If G increases, adjusting alignment to expand the test region accordingly.
+.align (RVMODEL_PMP_GRAIN+2)
 starting_point:
 RVTEST_CODE_BEGIN
 
@@ -141,9 +146,16 @@ main:
 	li t2, -1
 	csrw pmpaddr3, t2
 
-	LI (t2, 0x80000400)					// Configure test region as NAPOT, Start = 0x8000_0400
+	LI (t2, 0x80000000)					// Configure test region as NAPOT, Start = 0x8000_0000
 	srl t2, t2, 2
-	ori t2, t2, 0x7						// Range = 2^(3+3) = 64 bytes
+
+	.if (RVMODEL_PMP_GRAIN < 10)
+		LI (t1, 0xFF)								// Range = 2^(8+3) = 2048 Bytes
+	.else
+		LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)		// Range = 2^(G+3) Bytes
+	.endif
+
+	or t2, t2, t1	
 	csrw pmpaddr1, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------
@@ -154,11 +166,21 @@ main:
 	.set va_data,          		0x140000400
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x1800007dc
+	// If G increases more than 9, size of test region increases. Therefore, adjust address of rvtest_code_begin accordingly
+	.if (RVMODEL_PMP_GRAIN < 10)
+		.set va_rvtest_code_begin,  0x180000B9C
+	.else
+		.set va_rvtest_code_begin,  0x18000039C | (1<<(RVMODEL_PMP_GRAIN+2))
+	.endif
 	.set va_rvtest_data_begin,  0x1c0000530	
 
 //	PTE setup for Code Region
     PTE_SETUP_RV39_New(rvtest_code_begin, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL2)
+	// As address of rvtest_code_begin can change, therefore zero out PPN[1] & PPN[0] from PTE to keep it aligned
+	LI (t0, 0xFFFFC00)
+	not t0, t0
+	and a0, a0, t0
+	sd  a0, 0(t1)
 	sfence.vma
 
 //	PTE setup for Data Region

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv39/sv39_pmp_on_pa_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv39/sv39_pmp_on_pa_U_mode.S
@@ -27,6 +27,10 @@
 
 #include "arch_test.h"
 
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
+
 RVTEST_ISA("RV64I_Zicsr")
 
 # Test code region
@@ -49,14 +53,15 @@ rvtest_data_1:
 	nop
 	.word 0xbeefcaf1					// Random word
 	.word 0xbeefcaf2					// Random word
-	.rept(9)
-		nop
-	.endr
+	nop
 	jr ra
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
+.align 11
+// The preceding test region is 2KB by default. If G increases, adjusting alignment to expand the test region accordingly.
+.align (RVMODEL_PMP_GRAIN+2)
 starting_point:
 RVTEST_CODE_BEGIN
 
@@ -141,9 +146,16 @@ main:
 	li t2, -1
 	csrw pmpaddr3, t2
 
-	LI (t2, 0x80000400)					// Configure test region as NAPOT, Start = 0x8000_0400
+	LI (t2, 0x80000000)					// Configure test region as NAPOT, Start = 0x8000_0000
 	srl t2, t2, 2
-	ori t2, t2, 0x7						// Range = 2^(3+3) = 64 bytes
+
+	.if (RVMODEL_PMP_GRAIN < 10)
+		LI (t1, 0xFF)								// Range = 2^(8+3) = 2048 Bytes
+	.else
+		LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)		// Range = 2^(G+3) Bytes
+	.endif
+
+	or t2, t2, t1	
 	csrw pmpaddr1, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------
@@ -154,11 +166,21 @@ main:
 	.set va_data,          		0x140000400
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x1800007dc
+	// If G increases more than 9, size of test region increases. Therefore, adjust address of rvtest_code_begin accordingly
+	.if (RVMODEL_PMP_GRAIN < 10)
+		.set va_rvtest_code_begin,  0x180000B9C
+	.else
+		.set va_rvtest_code_begin,  0x18000039C | (1<<(RVMODEL_PMP_GRAIN+2))
+	.endif
 	.set va_rvtest_data_begin,  0x1c0000530	
 
 //	PTE setup for Code Region
     PTE_SETUP_RV39_New(rvtest_code_begin, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL2)
+	// As address of rvtest_code_begin can change, therefore zero out PPN[1] & PPN[0] from PTE to keep it aligned
+	LI (t0, 0xFFFFC00)
+	not t0, t0
+	and a0, a0, t0
+	sd  a0, 0(t1)
 	sfence.vma
 
 //	PTE setup for Data Region

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv39/sv39_pmp_on_pte_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv39/sv39_pmp_on_pte_S_mode.S
@@ -5,9 +5,11 @@
 // ----------------------------------------------------------------------------------------------------------------------
 // Test cases are as follows:
 // ----------------------------------------------------------------------------------------------------------------------
+// .if (RVMODEL_PMP_GRAIN < 10)
 // Configure level 2 PTE as NAPOT with X permission (pmp0cfg0)
 // 1. Setup a PTE at Level 2 with RWX permissions
 //      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 // Configure level 1 PTE as NAPOT with X permission (pmp0cfg0)
 // 2. Setup a PTE at Level 1 with RWX permissions
@@ -16,8 +18,12 @@
 // Configure level 0 PTE as NAPOT with X permission (pmp0cfg0)
 // 3. Setup a PTE at Level 0 with RWX permissions
 //      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
-
-// Total Expected Faults :: 9
+//
+// .if (RVMODEL_PMP_GRAIN < 10)
+// 		Total Expected Faults :: 9
+// .else
+// 		Total Expected Faults :: 6
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 
 #define SKIP_MEPC
@@ -26,6 +32,10 @@
 #include "model_test.h"
 
 #include "arch_test.h"
+
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
 
 RVTEST_ISA("RV64I_Zicsr")
 
@@ -143,11 +153,11 @@ main:
 
 
 	// Virtual Address of Test section 
-	.set va_data,          		0x140000400
+	.set va_data,          		0x000000400
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x2800007bc                  
-	.set va_rvtest_data_begin,  0x2c0000530	    
+	.set va_rvtest_code_begin,  0xFFFFFFFF800007BC                  
+	.set va_rvtest_data_begin,  0xFFFFFFFFC0000530	    
 
 
 //	PTE setup for Code Region
@@ -183,15 +193,19 @@ main:
 	SATP_SETUP_RV64(sv39)                                                  	// Set SATP for virtualization
 	sfence.vma                                                            	// Flush the TLB
 
+// This test case for root page table is skipped if G >= 10, because with PMP granularity ≥ 4KB,
+// the entire root page table will lose its read/write permissions, preventing entry into S-Mode.
+.if (RVMODEL_PMP_GRAIN < 10)
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 2 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_Sroot_pg_tbl)			// Configure first 8 (level 2) PTEs as NAPOT region
+	LA (t2, rvtest_Sroot_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -209,15 +223,17 @@ main:
 
 	TEST_CASES_RUNNER Smode, va_data
 
+.endif
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 1 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl2_pg_tbl)			// Configure first 8 (level 1) PTEs as NAPOT region
+	LA (t2, rvtest_slvl2_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -242,9 +258,10 @@ main:
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl1_pg_tbl)			// Configure first 8 (level 0) PTEs as NAPOT region
+	LA (t2, rvtest_slvl1_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -273,15 +290,19 @@ RVTEST_DATA_BEGIN
 
 #ifdef rvtest_strap_routine
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl1_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl2_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
 #endif
 
+.align (RVMODEL_PMP_GRAIN+2)
 RVTEST_DATA_END                               
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 sig_begin_canary:

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv39/sv39_pmp_on_pte_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv39/sv39_pmp_on_pte_U_mode.S
@@ -5,9 +5,11 @@
 // ----------------------------------------------------------------------------------------------------------------------
 // Test cases are as follows:
 // ----------------------------------------------------------------------------------------------------------------------
+// .if (RVMODEL_PMP_GRAIN < 10)
 // Configure level 2 PTE as NAPOT with X permission (pmp0cfg0)
 // 1. Setup a PTE at Level 2 with RWX permissions
 //      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 // Configure level 1 PTE as NAPOT with X permission (pmp0cfg0)
 // 2. Setup a PTE at Level 1 with RWX permissions
@@ -16,8 +18,12 @@
 // Configure level 0 PTE as NAPOT with X permission (pmp0cfg0)
 // 3. Setup a PTE at Level 0 with RWX permissions
 //      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
-
-// Total Expected Faults :: 9
+//
+// .if (RVMODEL_PMP_GRAIN < 10)
+// 		Total Expected Faults :: 9
+// .else
+// 		Total Expected Faults :: 6
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 
 #define SKIP_MEPC
@@ -26,6 +32,10 @@
 #include "model_test.h"
 
 #include "arch_test.h"
+
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
 
 RVTEST_ISA("RV64I_Zicsr")
 
@@ -143,11 +153,11 @@ main:
 
 
 	// Virtual Address of Test section 
-	.set va_data,          		0x140000400
+	.set va_data,          		0x000000400
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x2800007bc                  
-	.set va_rvtest_data_begin,  0x2c0000530	    
+	.set va_rvtest_code_begin,  0xFFFFFFFF800007BC                  
+	.set va_rvtest_data_begin,  0xFFFFFFFFC0000530	    
 
 
 //	PTE setup for Code Region
@@ -183,15 +193,19 @@ main:
 	SATP_SETUP_RV64(sv39)                                                  	// Set SATP for virtualization
 	sfence.vma                                                            	// Flush the TLB
 
+// This test case for root page table is skipped if G >= 10, because with PMP granularity ≥ 4KB,
+// the entire root page table will lose its read/write permissions, preventing entry into U-Mode.
+.if (RVMODEL_PMP_GRAIN < 10)
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 2 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_Sroot_pg_tbl)			// Configure first 8 (level 2) PTEs as NAPOT region
+	LA (t2, rvtest_Sroot_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -209,15 +223,17 @@ main:
 
 	TEST_CASES_RUNNER Umode, va_data
 
+.endif
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 1 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl2_pg_tbl)			// Configure first 8 (level 1) PTEs as NAPOT region
+	LA (t2, rvtest_slvl2_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -242,9 +258,10 @@ main:
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl1_pg_tbl)			// Configure first 8 (level 0) PTEs as NAPOT region
+	LA (t2, rvtest_slvl1_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -273,15 +290,19 @@ RVTEST_DATA_BEGIN
 
 #ifdef rvtest_strap_routine
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl1_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl2_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
 #endif
 
+.align (RVMODEL_PMP_GRAIN+2)
 RVTEST_DATA_END                               
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 sig_begin_canary:

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv48/sv48_pmp_on_pa_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv48/sv48_pmp_on_pa_S_mode.S
@@ -27,6 +27,10 @@
 
 #include "arch_test.h"
 
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
+
 RVTEST_ISA("RV64I_Zicsr")
 
 # Test code region
@@ -49,14 +53,15 @@ rvtest_data_1:
 	nop
 	.word 0xbeefcaf1					// Random word
 	.word 0xbeefcaf2					// Random word
-	.rept(8)
-		nop
-	.endr
+	nop
 	jr ra
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
+.align 11
+// The preceding test region is 2KB by default. If G increases, adjusting alignment to expand the test region accordingly.
+.align (RVMODEL_PMP_GRAIN+2)
 starting_point:
 RVTEST_CODE_BEGIN
 
@@ -141,9 +146,16 @@ main:
 	li t2, -1
 	csrw pmpaddr3, t2
 
-	LI (t2, 0x80000400)					// Configure test region as NAPOT, Start = 0x8000_0400
+	LI (t2, 0x80000000)					// Configure test region as NAPOT, Start = 0x8000_0000
 	srl t2, t2, 2
-	ori t2, t2, 0x7						// Range = 2^(3+3) = 64 bytes
+
+	.if (RVMODEL_PMP_GRAIN < 10)
+		LI (t1, 0xFF)								// Range = 2^(8+3) = 2048 Bytes
+	.else
+		LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)		// Range = 2^(G+3) Bytes
+	.endif
+
+	or t2, t2, t1						
 	csrw pmpaddr1, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------
@@ -154,7 +166,12 @@ main:
 	.set va_data,          		0x028000000400              	// Virtual Address of rvtest_data_1
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x0300800007DC
+	// If G increases more than 9, size of test region increases. Therefore, adjust address of rvtest_code_begin accordingly
+	.if (RVMODEL_PMP_GRAIN < 10)
+		.set va_rvtest_code_begin,  0x030080000B9C
+	.else
+		.set va_rvtest_code_begin,  0x03008000039C | (1<<(RVMODEL_PMP_GRAIN+2))
+	.endif
 	.set va_rvtest_data_begin,  0x038080005530	
     
 	// TeraPage must have PA bits [38:0] equal to zero, but our PA range starts from 0x8000_0000

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv48/sv48_pmp_on_pa_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv48/sv48_pmp_on_pa_U_mode.S
@@ -27,6 +27,10 @@
 
 #include "arch_test.h"
 
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
+
 RVTEST_ISA("RV64I_Zicsr")
 
 # Test code region
@@ -49,14 +53,15 @@ rvtest_data_1:
 	nop
 	.word 0xbeefcaf1					// Random word
 	.word 0xbeefcaf2					// Random word
-	.rept(8)
-		nop
-	.endr
+	nop
 	jr ra
 
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
+.align 11
+// The preceding test region is aligned to 2KB by default. If G increases, adjusting alignment to expand the test region accordingly.
+.align (RVMODEL_PMP_GRAIN+2)
 starting_point:
 RVTEST_CODE_BEGIN
 
@@ -141,9 +146,16 @@ main:
 	li t2, -1
 	csrw pmpaddr3, t2
 
-	LI (t2, 0x80000400)					// Configure test region as NAPOT, Start = 0x8000_0400
+	LI (t2, 0x80000000)					// Configure test region as NAPOT, Start = 0x8000_0000
 	srl t2, t2, 2
-	ori t2, t2, 0x7						// Range = 2^(3+3) = 64 bytes
+
+	.if (RVMODEL_PMP_GRAIN < 10)
+		LI (t1, 0xFF)								// Range = 2^(8+3) = 2048 Bytes
+	.else
+		LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)		// Range = 2^(G+3) Bytes
+	.endif
+
+	or t2, t2, t1						
 	csrw pmpaddr1, t2
 
 //---------------------------------------------------------------------------------------------------------------------------------
@@ -154,7 +166,12 @@ main:
 	.set va_data,          		0x028000000400              	// Virtual Address of rvtest_data_1
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x0300800007DC
+	// If G increases more than 9, size of test region increases. Therefore, adjust address of rvtest_code_begin accordingly
+	.if (RVMODEL_PMP_GRAIN < 10)
+		.set va_rvtest_code_begin,  0x030080000B9C
+	.else
+		.set va_rvtest_code_begin,  0x03008000039C | (1<<(RVMODEL_PMP_GRAIN+2))
+	.endif
 	.set va_rvtest_data_begin,  0x038080005530	
     
 	// TeraPage must have PA bits [38:0] equal to zero, but our PA range starts from 0x8000_0000

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv48/sv48_pmp_on_pte_S_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv48/sv48_pmp_on_pte_S_mode.S
@@ -5,9 +5,11 @@
 // ----------------------------------------------------------------------------------------------------------------------
 // Test cases are as follows:
 // ----------------------------------------------------------------------------------------------------------------------
+// .if (RVMODEL_PMP_GRAIN < 10)
 // Configure level 3 PTE as NAPOT with X permission (pmp0cfg0)
 // 1. Setup a PTE at Level 3 with RWX permissions
 //      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 // Configure level 2 PTE as NAPOT with X permission (pmp0cfg0)
 // 2. Setup a PTE at Level 2 with RWX permissions
@@ -20,8 +22,12 @@
 // Configure level 0 PTE as NAPOT with X permission (pmp0cfg0)
 // 4. Setup a PTE at Level 0 with RWX permissions
 //      → Then, in S-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
-
-// Total Expected Faults :: 12
+//
+// .if (RVMODEL_PMP_GRAIN < 10)
+// 		Total Expected Faults :: 12
+// .else
+// 		Total Expected Faults :: 9
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 
 #define SKIP_MEPC
@@ -30,6 +36,10 @@
 #include "model_test.h"
 
 #include "arch_test.h"
+
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
 
 RVTEST_ISA("RV64I_Zicsr")
 
@@ -146,16 +156,16 @@ main:
 //---------------------------------------------------------------------------------------------------------------------------------
 
 	// Virtual Address of Test section 
-	.set va_data,          		0x028000000400              	// Virtual Address of rvtest_data_1
+	.set va_data,          		0x000000000400              	// Virtual Address of rvtest_data_1
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x0500800007BC
-	.set va_rvtest_data_begin,  0x058080004530	
+	.set va_rvtest_code_begin,  0xFFFFFF00800007BC
+	.set va_rvtest_data_begin,  0xFFFFFF8080004530	
     
 	// TeraPage must have PA bits [38:0] equal to zero, but our PA range starts from 0x8000_0000
 	// Therefore, we will setup TeraPage using this imm value
     .set terapage_pa,           0x000000000000    				// Physical Address for TeraPage
-	.set va_data_l3,			0x028080000400					// Virtual Address of rvtest_data_1 (In case of Level3)
+	.set va_data_l3,			0x000080000400					// Virtual Address of rvtest_data_1 (In case of Level3)
 
 //	PTE setup for Code Region
     PTE_SETUP_SV48_New(terapage_pa, (PTE_D | PTE_A | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL3)
@@ -190,15 +200,19 @@ main:
 	SATP_SETUP_RV64(sv48)                                                  	// Set SATP for virtualization
 	sfence.vma                                                            	// Flush the TLB
 
+// This test case for root page table is skipped if G >= 10, because with PMP granularity ≥ 4KB,
+// the entire root page table will lose its read/write permissions, preventing entry into S-Mode.
+.if (RVMODEL_PMP_GRAIN < 10)
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 3 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_Sroot_pg_tbl)			// Configure first 8 (level 3) PTEs as NAPOT region
+	LA (t2, rvtest_Sroot_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -216,16 +230,17 @@ main:
 
 	TEST_CASES_RUNNER Smode, va_data_l3
 
-		
+.endif	
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 2 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl3_pg_tbl)			// Configure first 8 (level 2) PTEs as NAPOT region
+	LA (t2, rvtest_slvl3_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -250,9 +265,10 @@ main:
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl2_pg_tbl)			// Configure first 8 (level 1) PTEs as NAPOT region
+	LA (t2, rvtest_slvl2_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -278,9 +294,10 @@ main:
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl1_pg_tbl)			// Configure first 8 (level 0) PTEs as NAPOT region
+	LA (t2, rvtest_slvl1_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -310,18 +327,23 @@ RVTEST_DATA_BEGIN
 
 #ifdef rvtest_strap_routine
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl1_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl2_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl3_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
 #endif
 
+.align (RVMODEL_PMP_GRAIN+2)
 RVTEST_DATA_END                               
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 sig_begin_canary:

--- a/riscv-test-suite/rv64i_m/vm_pmp/src/sv48/sv48_pmp_on_pte_U_mode.S
+++ b/riscv-test-suite/rv64i_m/vm_pmp/src/sv48/sv48_pmp_on_pte_U_mode.S
@@ -5,9 +5,11 @@
 // ----------------------------------------------------------------------------------------------------------------------
 // Test cases are as follows:
 // ----------------------------------------------------------------------------------------------------------------------
+// .if (RVMODEL_PMP_GRAIN < 10)
 // Configure level 3 PTE as NAPOT with X permission (pmp0cfg0)
 // 1. Setup a PTE at Level 3 with RWX permissions
 //      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 // Configure level 2 PTE as NAPOT with X permission (pmp0cfg0)
 // 2. Setup a PTE at Level 2 with RWX permissions
@@ -20,8 +22,12 @@
 // Configure level 0 PTE as NAPOT with X permission (pmp0cfg0)
 // 4. Setup a PTE at Level 0 with RWX permissions
 //      → Then, in U-Mode, the page is accessed --> required: Store access fault, Load access fault, Instruction access fault
-
-// Total Expected Faults :: 12
+//
+// .if (RVMODEL_PMP_GRAIN < 10)
+// 		Total Expected Faults :: 12
+// .else
+// 		Total Expected Faults :: 9
+// .endif
 // ----------------------------------------------------------------------------------------------------------------------
 
 #define SKIP_MEPC
@@ -30,6 +36,10 @@
 #include "model_test.h"
 
 #include "arch_test.h"
+
+#ifndef RVMODEL_PMP_GRAIN
+	#define RVMODEL_PMP_GRAIN 0
+#endif
 
 RVTEST_ISA("RV64I_Zicsr")
 
@@ -146,16 +156,16 @@ main:
 //---------------------------------------------------------------------------------------------------------------------------------
 
 	// Virtual Address of Test section 
-	.set va_data,          		0x028000000400              	// Virtual Address of rvtest_data_1
+	.set va_data,          		0x000000000400              	// Virtual Address of rvtest_data_1
 
 	// Virtual Addresses for code & data regions
-	.set va_rvtest_code_begin,  0x0500800007BC
-	.set va_rvtest_data_begin,  0x058080004530	
+	.set va_rvtest_code_begin,  0xFFFFFF00800007BC
+	.set va_rvtest_data_begin,  0xFFFFFF8080004530	
     
 	// TeraPage must have PA bits [38:0] equal to zero, but our PA range starts from 0x8000_0000
 	// Therefore, we will setup TeraPage using this imm value
     .set terapage_pa,           0x000000000000    				// Physical Address for TeraPage
-	.set va_data_l3,			0x028080000400					// Virtual Address of rvtest_data_1 (In case of Level3)
+	.set va_data_l3,			0x000080000400					// Virtual Address of rvtest_data_1 (In case of Level3)
 
 //	PTE setup for Code Region
     PTE_SETUP_SV48_New(terapage_pa, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V), va_rvtest_code_begin, LEVEL3)
@@ -190,15 +200,19 @@ main:
 	SATP_SETUP_RV64(sv48)                                                  	// Set SATP for virtualization
 	sfence.vma                                                            	// Flush the TLB
 
+// This test case for root page table is skipped if G >= 10, because with PMP granularity ≥ 4KB,
+// the entire root page table will lose its read/write permissions, preventing entry into U-Mode.
+.if (RVMODEL_PMP_GRAIN < 10)
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 3 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_Sroot_pg_tbl)			// Configure first 8 (level 3) PTEs as NAPOT region
+	LA (t2, rvtest_Sroot_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -216,16 +230,17 @@ main:
 
 	TEST_CASES_RUNNER Umode, va_data_l3
 
-		
+.endif	
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 // 								Configure level 2 PTE as NAPOT region with X permission
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl3_pg_tbl)			// Configure first 8 (level 2) PTEs as NAPOT region
+	LA (t2, rvtest_slvl3_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -250,9 +265,10 @@ main:
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl2_pg_tbl)			// Configure first 8 (level 1) PTEs as NAPOT region
+	LA (t2, rvtest_slvl2_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -278,9 +294,10 @@ main:
 //---------------------------------------------------------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------------------------------------------------------
 
-	LA (t2, rvtest_slvl1_pg_tbl)			// Configure first 8 (level 0) PTEs as NAPOT region
+	LA (t2, rvtest_slvl1_pg_tbl)
 	srl t2, t2, 2
-	ori t2, t2, 0x7							// Range = 2^(3+3) = 64 bytes
+	LI (t1, ((1<<RVMODEL_PMP_GRAIN)-1)>>1)	// Minimum range is 8 Bytes (1 PTE). Increases as G increases
+	or t2, t2, t1
 	csrw pmpaddr0, t2
 
 	LI (t2, PMP_GLOBAL_RWX | PMP0CFG_X)							
@@ -310,18 +327,23 @@ RVTEST_DATA_BEGIN
 
 #ifdef rvtest_strap_routine
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl1_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 1, PTE_V | PTE_A | PTE_D | PTE_G)
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl2_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 2, PTE_V | PTE_A | PTE_D | PTE_G)
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 rvtest_slvl3_pg_tbl:
 		RVTEST_PTE_IDENT_MAP(0, 3, PTE_V | PTE_A | PTE_D | PTE_G)
 #endif
 
+.align (RVMODEL_PMP_GRAIN+2)
 RVTEST_DATA_END                               
 .align 12
+.align (RVMODEL_PMP_GRAIN+2)
 RVMODEL_DATA_BEGIN
 rvtest_sig_begin:
 sig_begin_canary:


### PR DESCRIPTION

### Description

These tests initially worked for DUTs having PMP grain <= 4. I have updated them to support any value of G. The ones for SV57 have been pushed to the SV57 PR.