### PR TITLE
replace addi with li+add for large PMP grain values

### DIFF
--- a/riscv-test-suite/rv32i_m/pmp/src/pmpm_cfg_A_tor_bot.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpm_cfg_A_tor_bot.S
@@ -167,7 +167,8 @@ main:
 	csrw pmpcfg3, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-	addi    x5, x4, g
+	LI(x5, g)
+	add    x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
     

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpm_cfg_napot_all.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpm_cfg_napot_all.S
@@ -75,7 +75,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-	addi a5, a5, (g+4)
+	LI(t0, (g+4))
+	add a5, a5, t0
     lw a4, 0(a5)
     nop
     nop

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpm_cfg_tor_check-02.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpm_cfg_tor_check-02.S
@@ -159,7 +159,8 @@ main:
 
 	//addresses for a default TOR region 
     LA(x4, TEST_FOR_EXECUTION)
-	addi    x5, x4, g
+	LI(x5, g)
+	add    x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpm_cfg_tor_check-03.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpm_cfg_tor_check-03.S
@@ -159,7 +159,8 @@ main:
 
 	//addresses for a default TOR region 
     LA(x4, TEST_FOR_EXECUTION)
-	addi    x5, x4, g
+	LI(x5, g)
+	add    x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpm_misaligned_tor.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpm_misaligned_tor.S
@@ -139,7 +139,8 @@ main:
 	csrw pmpcfg3, x4
 
 	LA(x4, TEST_FOR_EXECUTION)
-	addi    x5, x4, g
+	LI(x5, g)
+	add    x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
     
@@ -153,6 +154,7 @@ main:
 	csrw pmpcfg0, x4
 
 	VERIFICATION_RWX	TEST_FOR_EXECUTION
+
 
 // Test Case: 2 -- LXWR Permissions given to the PMP Region.
 

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpm_napot_legal_lwxr.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpm_napot_legal_lwxr.S
@@ -95,7 +95,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 	nop
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -136,7 +137,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
     nop
@@ -180,7 +182,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     nop

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpm_priority.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpm_priority.S
@@ -124,7 +124,8 @@ main:
 
     LA(x4, TEST_FOR_EXECUTION)
     srl x4, x4, PMP_SHIFT
-    addi x5, x0, g
+    LI(t0, g)
+    add x5, x0, t0
 
     // REGIONSTART in even PMPADDR
     .set pmpaddri, CSR_PMPADDR0
@@ -137,7 +138,8 @@ main:
     LA(x5, TEST_FOR_EXECUTION)
     .set pmpaddri, CSR_PMPADDR0+1
     .rept 7
-    addi x5, x5, g
+    LI(t0, g)
+    add x5, x5, t0
     srl x6, x5, PMP_SHIFT
     csrw pmpaddri, x6
     .set pmpaddri, pmpaddri+2

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpm_priority_off.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpm_priority_off.S
@@ -120,7 +120,8 @@ main:
 	csrw pmpcfg3, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-    addi x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     csrw pmpaddr0, x4
     csrw pmpaddr2, x4

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpm_tor_legal_lwxr.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpm_tor_legal_lwxr.S
@@ -87,7 +87,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 	nop
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -122,7 +123,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
     nop
@@ -150,7 +152,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     nop
@@ -204,7 +207,8 @@ main:
 	csrw pmpcfg3, x4
 
 	LA(x4, TEST_FOR_EXECUTION)
-    addi x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
 	srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/riscv-test-suite/rv32i_m/pmp/src/pmps_napot_legal_lxwr.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmps_napot_legal_lxwr.S
@@ -88,7 +88,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 3:
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -120,7 +121,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     sw a4, 0(a5)
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
 
@@ -155,7 +157,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update

--- a/riscv-test-suite/rv32i_m/pmp/src/pmps_tor_legal_lxwr.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmps_tor_legal_lxwr.S
@@ -81,7 +81,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 3:
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -109,7 +110,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     sw a4, 0(a5)
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
 
@@ -132,7 +134,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpu_napot_legal_lxwr.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpu_napot_legal_lxwr.S
@@ -89,7 +89,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 3:
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -121,7 +122,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     sw a4, 0(a5)
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
 
@@ -156,7 +158,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update

--- a/riscv-test-suite/rv32i_m/pmp/src/pmpu_tor_legal_lxwr.S
+++ b/riscv-test-suite/rv32i_m/pmp/src/pmpu_tor_legal_lxwr.S
@@ -82,7 +82,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 3:
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -110,7 +111,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     sw a4, 0(a5)
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
 
@@ -133,7 +135,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpm_cfg_A_tor_bot.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpm_cfg_A_tor_bot.S
@@ -167,7 +167,8 @@ main:
 	csrw pmpcfg2, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-	addi    x5, x4, g
+	LI(x5, g)
+	add    x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
     

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpm_cfg_napot_all.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpm_cfg_napot_all.S
@@ -75,7 +75,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-	addi a5, a5, (g+4)
+	LI(t0, g)
+	add a5, a5, t0
     lw a4, 0(a5)
     nop
     nop

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpm_cfg_tor_check-02.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpm_cfg_tor_check-02.S
@@ -159,7 +159,8 @@ main:
 
 	//addresses for a default TOR region 
     LA(x4, TEST_FOR_EXECUTION)
-	addi    x5, x4, g
+	LI(x5, g)
+	add    x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpm_cfg_tor_check-03.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpm_cfg_tor_check-03.S
@@ -159,7 +159,8 @@ main:
 
 	//addresses for a default TOR region 
     LA(x4, TEST_FOR_EXECUTION)
-	addi    x5, x4, g
+	LI(x5, g)
+	add    x5, x4, x5
     srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpm_napot_legal_lxwr.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpm_napot_legal_lxwr.S
@@ -89,7 +89,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 3:
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -123,7 +124,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     sw a4, 0(a5)
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
 
@@ -164,7 +166,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpm_priority.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpm_priority.S
@@ -124,7 +124,8 @@ main:
 
     LA(x4, TEST_FOR_EXECUTION)
     srl x4, x4, PMP_SHIFT
-    addi x5, x0, g
+    LI(x5, g)
+    add x5, x0, x5
 
     // REGIONSTART in even PMPADDR
     .set pmpaddri, CSR_PMPADDR0
@@ -137,7 +138,8 @@ main:
     LA(x5, TEST_FOR_EXECUTION)
     .set pmpaddri, CSR_PMPADDR0+1
     .rept 7
-    addi x5, x5, g
+    LI(t0, g)
+    add x5, x5, t0
     srl x6, x5, PMP_SHIFT
     csrw pmpaddri, x6
     .set pmpaddri, pmpaddri+2

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpm_priority_off.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpm_priority_off.S
@@ -120,7 +120,8 @@ main:
 	csrw pmpcfg3, x4
 
     LA(x4, TEST_FOR_EXECUTION)
-    addi x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
     srl x4, x4, PMP_SHIFT
     csrw pmpaddr0, x4
     csrw pmpaddr2, x4

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpm_tor_legal_lxwr.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpm_tor_legal_lxwr.S
@@ -87,7 +87,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 	nop
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -122,7 +123,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
     nop
@@ -150,7 +152,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     nop
@@ -204,7 +207,8 @@ main:
 	csrw pmpcfg2, x4
 
 	LA(x4, TEST_FOR_EXECUTION)
-    addi x5, x4, g
+    LI(x5, g)
+    add x5, x4, x5
 	srl x4, x4, PMP_SHIFT
     srl x5, x5, PMP_SHIFT
 

--- a/riscv-test-suite/rv64i_m/pmp/src/pmps_napot_legal_lxwr.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmps_napot_legal_lxwr.S
@@ -88,7 +88,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 3:
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -122,7 +123,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     sw a4, 0(a5)
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
 
@@ -163,7 +165,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update

--- a/riscv-test-suite/rv64i_m/pmp/src/pmps_tor_legal_lxwr.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmps_tor_legal_lxwr.S
@@ -81,7 +81,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 3:
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -109,7 +110,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     sw a4, 0(a5)
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
 
@@ -132,7 +134,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpu_napot_legal_lxwr.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpu_napot_legal_lxwr.S
@@ -89,7 +89,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 3:
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -123,7 +124,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     sw a4, 0(a5)
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     sw a4, 0(a5)
     nop
 
@@ -164,7 +166,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update

--- a/riscv-test-suite/rv64i_m/pmp/src/pmpu_tor_legal_lxwr.S
+++ b/riscv-test-suite/rv64i_m/pmp/src/pmpu_tor_legal_lxwr.S
@@ -82,7 +82,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
 3:
 	nop
 
-    addi a4, a4, (g-8)                  // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a4, a4, t0                      // REGIONSTART + g - 4
 	LA(x4, 4f)							// Store the return Address in x4
 	jalr ra, 0(a4)
 	nop
@@ -110,7 +111,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     sw a4, 0(a5)
     nop
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    li x0, (g-8)
+    add a5, a5, t0                                          // REGIONSTART + g - 4ls
     sw a4, 0(a5)
     nop
 
@@ -133,7 +135,8 @@ RVTEST_SIGBASE( x13,signature_x13_1)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update
 
-    addi a5, a5, (g-8)                                      // REGIONSTART + g - 4
+    LI(t0, (g-8))
+    add a5, a5, t0                                          // REGIONSTART + g - 4
     lw a4, 0(a5)
     nop
     RVTEST_SIGUPD(x13, a4)       							// Signature update


### PR DESCRIPTION
- Replace problematic 'addi a5, a5, (g+4)' instructions
- Use 'li t0, (g+4)' + 'add a5, a5, t0' sequence instead
- Fixes compilation error when RVMODEL_PMP_GRAIN>=10
- Resolves the 12-bit immediate value range limitation issue

<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> 
<img width="701" height="487" alt="image" src="https://github.com/user-attachments/assets/727ef43d-9a79-4110-b7e7-c28cdf0fb6dc" />
<img width="1814" height="133" alt="image" src="https://github.com/user-attachments/assets/4637979c-2cb3-4711-9b7d-8d3c50816f24" />

During testing of PMP-related test cases with pmp_grain and RVMODEL_PMP_GRAIN set to 10, a compilation error ("illegal operands") occurred. The issue was traced to instructions like addi a5, a5, (g+4)in the test code. When RVMODEL_PMP_GRAIN=10, the value of g(defined as 1 << (RVMODEL_PMP_GRAIN + 2)) exceeds the 12-bit immediate operand limit of the addiinstruction, making g+4 invalid.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist

### Ratified/Unratified Extensions

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [x] SAIL
- [x] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
