### PR TITLE
covergroupgen fix for Zvfhmin

### DIFF
--- a/generators/coverage/covergroupgen.py
+++ b/generators/coverage/covergroupgen.py
@@ -252,6 +252,8 @@ def get_effew(arch: str) -> str:
     match = re.search(r"(\d+)$", arch)
     if match:
         effew = match.group(1)
+    elif (arch == "Zvfhmin"):
+        effew = "16"
     else:
         raise ValueError(f"Arch does not contain an expected integer: '{arch}'")
     return effew


### PR DESCRIPTION
Covergroupgen now working. Getting errors on ExceptionsM when running make coverage, but don't think that is a vector issue.

```
/home/gtai/cvw/addins/riscv-arch-test-cvw/tests/priv/ExceptionsM/ExceptionsM.S: Assembler messages:
/home/gtai/cvw/addins/riscv-arch-test-cvw/tests/priv/ExceptionsM/ExceptionsM.S:202: Error: illegal operands `li t1,ACCESS_FAULT_ADDRESS'
/home/gtai/cvw/addins/riscv-arch-test-cvw/tests/priv/ExceptionsM/ExceptionsM.S:288: Error: illegal operands `li t0,ACCESS_FAULT_ADDRESS'
make[2]: *** [Makefile:11: /home/gtai/cvw/addins/riscv-arch-test-cvw/work-ref/sail-rv32gc/build/priv/ExceptionsM/ExceptionsM.sig.elf] Error 1
make[2]: Leaving directory '/home/gtai/cvw/addins/riscv-arch-test-cvw/work-ref/sail-rv32gc'
make[1]: *** [Makefile:7: sail-rv32gc-compile] Error 2
make[1]: Leaving directory '/home/gtai/cvw/addins/riscv-arch-test-cvw/work-ref'
make: *** [Makefile:98: coverage] Error 2
```