### PR TITLE
Correct the definitions of interrupt clearing tables based on supported modes

### DIFF
--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -1627,7 +1627,7 @@ clrint_\__MODE__\()tbl:                 //this code should only touch T2..T6
         .dword  \__MODE__\()clr_Vext_int                // int cause  A  Vmode Ext int
         .dword  \__MODE__\()clr_Mext_int                // int cause  B  Mmode Ext int
 //****************************************************************
-#elseif rvtest_dtrap_routine  // M/S/U only
+#elif rvtest_strap_routine  // M/S/U only
         .dword  0                       // int cause  0 is reserved, error
         .dword  \__MODE__\()clr_Ssw_int         // int cause  1  Smode SW int
         .dword  1                       // int cause  2  no Vmode


### PR DESCRIPTION


<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

We have an interrupt clearing table with different definitions depending on the modes supported on the machine.  Due to a typographical error, we were mistakenly using the M/U table for M/S/U mode, and concatenating the M/S/U table to the M/S/V/U table.  Appending the two tables caused issues when trying to index the contiguously following exception handler table with `rvtest_vtrap_routine` defined.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist
NA

### Ratified/Unratified Extensions

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [ ] SAIL
- [X] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [ ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [X] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
