### PR TITLE
Fix hypervisor exception delegation CSR

### DIFF
--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -1019,7 +1019,7 @@ init_\__MODE__\()scratch:
 init_\__MODE__\()edeleg:
         li      T2, 0                   // save and clear edeleg so we can exit to Mmode
 .ifc \__MODE__ , V
-        csrrw   T2, CSR_VEDELEG, T2     // special case: VS EDELEG available from Vmode
+        csrrw   T2, CSR_HEDELEG, T2     // special case: VS EDELEG available from Vmode
 .else
   .ifc \__MODE__ , M
     #ifdef rvtest_strap_routine
@@ -1805,7 +1805,7 @@ resto_\__MODE__\()edeleg:
         LREG    T2, xedeleg_sv_off(T1)          // get saved xedeleg at offset -32
 
 .ifc \__MODE__ , V
-        csrw    CSR_VEDELEG, T2 //special case: VS EDELEG available from Vmode
+        csrw    CSR_HEDELEG, T2 //special case: VS EDELEG available from Vmode
 .else
   .ifc \__MODE__ , M
 #ifdef rvtest_strap_routine


### PR DESCRIPTION


<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

The hypervisor exception delegation CSR is name hedeleg and not vedeleg as written in the code.

### Related Issues

N/A

### Ratified/Unratified Extensions

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [ ] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [ ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [x] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
