### PR TITLE
Fix resto_Vtrtn implementation

### DIFF
--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -1556,7 +1556,11 @@ resto_\__MODE__\()rtn:                  // restore and return
         LREG    T6, trap_sv_off+6*REGWIDTH(sp)
         LREG    sp, trap_sv_off+7*REGWIDTH(sp)      // restore temporaries
 
-        \__MODE__\()RET                 // return to test, after padding adjustment (macro to handle case)
+.ifc \__MODE__ , V
+       sret                            // V-mode handler uses standard sret.
+.else
+       \__MODE__\()ret                 // return to test, after padding adjustment (macro to handle case)
+.endif
 
  /***************************************************/
  /**** This is the interrupt specific code. It   ****/


### PR DESCRIPTION


<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

When returning from the guest supervisor trap handler, the macros expand to calling a non-existent vret instruction.  We should be using the same instruction as the hypervisor supervisor, which is sret.

### Related Issues

N/A

### Ratified/Unratified Extensions

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [ ] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [ ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [x] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
