### PR TITLE
Fix GOTO_LOWER_MODE to VS/VU mode

### DIFF
--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -828,7 +828,7 @@
 /**** the macro invocation. Legal params are VSmode,HSmode,VUmode,              ****/
 /**** HUmode,Smode & Umode.                                                     ****/
 /**** This macro will stay in Mmode, if requested lower mode doesn't exist.     ****/
-/****  This uses T1,T2&T4. The H,U variations leave V unchanged.                ****/
+/****  This uses T1,T2&T4. The S,U variations leave V unchanged.                ****/
 /**** NOTE: this MUST be executed in M-mode. Precede with GOTO_MMODE            ****/
 /**** FIXME - SATP & VSATP must point to the identity map page table            ****/
 
@@ -894,7 +894,7 @@
   csrr   T2, CSR_MSCRATCH       /* ensure GPR T2 points to Mmode datae area */
         /**** mstatus MPV and PP now set up to desired mode    ****/
         /**** set MEPC to mret+4; requires relocating the pc   ****/
-.if     (\LMODE\() == Vmode)     // get trapsig_ptr & init val up 2 save areas (M<-S<-V)
+.if     ((\LMODE\() == VSmode)||(\LMODE\() == VUmode))     // get trapsig_ptr & init val up 2 save areas (M<-S<-V)
         LREG    T1, code_bgn_off + 2*sv_area_sz(T2)
 #ifdef rvtest_strap_routine
 .elseif (\LMODE\() == Smode || \LMODE\() == Umode)     // get trapsig_ptr & init val up 1 save areas (M<-S)


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

When moving to a virtualized mode, we need to make sure we use the guest save area.  The if statements incorrectly checks for a non-existent Vmode, instead of the two virtualized modes VSmode and VUmode.  This fixes the condition of the original code.

This also fixes the code comment to reflect the code, which explicitly sets V=0 for HS/HU modes, sets V=1 for VS/VU modes, and leaves V the same for S/U modes.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist

### Ratified/Unratified Extensions

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [ ] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [ ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
