### PR TITLE
Fix save area delta calculation with virtualization

### DIFF
--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -1337,7 +1337,7 @@ common_\__MODE__\()excpt_handler:
   // can use T3, T6 because relocation will overwrite them
   //********************************************************************************
         
-        // create an index from these values: vMPP, x.GVA , H-ext
+        // create an index from these values: vMPP, H-ext, x.GVA
         // where vMPP = m.PRV ? svedMPP : m.MPP
         
   .ifc \__MODE__ ,  M
@@ -1348,12 +1348,16 @@ common_\__MODE__\()excpt_handler:
         LREG    T6, mpp_sv_off(sp)      /* saved MPP, overwritten if MPRV=1     */
 1:
 // create a mask in T4[2:0] with (xMPP==3, H-ext, GVA)        
+// extract vMPP into bit 2
         srli    T4, T6, MPP_LSB         /* now cvt MPP (in its natural position)*/
         andi    T4, T4, 3               /* to a single bit in bit2 iff ==3      */
         addi    T4, T4, 1
         andi    T4, T4, 4               
+    #ifdef rvtest_vtrap_routine
+// put H-extension implemented into bit 1
+        ori     T4, T4, 2               /* set bit 1 if H-ext is present        */
+        //****FIXME: this doesn't work if misa.H is RW but set to zero ****/
 // extract GVA into bit 0
-    #if (rvtest_vtrap_routine)
       #if (XLEN==32)
         csrr    T3, CSR_MSTATUSH        /* get CSR with GVA bit, but only H-ext */
         srli    T3, T3, GVA_LSB         /* reposition RV32 mstatush into bit1   */
@@ -1361,13 +1365,10 @@ common_\__MODE__\()excpt_handler:
         srli    T3, T4, GVA_LSB+32      /* reposition RV32 mstatus  into bit1   */
       #endif
         andi    T3, T3, 1
-        or      T4, T4, T3              /* extract GVA in bit1, insert into msk */
-// put H-extension implemented into bit 0       
-        ori     T4, T4, 1               /* set LSB if H-ext present             */
-        //****FIXME: this doesn't work if misa.H is RW but set to zero ****/
+        or      T4, T4, T3              /* extract GVA in bit0, insert into msk */
     #endif
 // chk for illegal combination
-        LI(     T6, 0x5D)               /*lglmsk(vMPP,H,GVA)=(1x1,011,0x0)=0x5D */
+        LI(     T6, 0x5D)               /*lglmsk(vMPP,H,GVA)=(1x1,0x1)=0x5D */
         srl     T6, T6, T4
         andi    T6, T6, 1               /* extract lgl bit val & end test if 0  */
         beq     T6, x0, rvtest_\__MODE__\()endtest 
@@ -1385,11 +1386,11 @@ common_\__MODE__\()excpt_handler:
 // vMPP cannot be 11 because you it cannot handle at a lower mode than trap mode
 // MPRV cannot be 1  because that only applies to Mmode
 // GVA can only exist if there is H-ext
-      #if rvtest_vtrap_routine
+      #ifdef rvtest_vtrap_routine
         LI(     T6, sv_area_sz)
         csrr    T3, CSR_HSTATUS         /* get CSR with GVA bit, but only H-ext */
         slli    T3, T3, XLEN-1-GVA_LSB  /* sign extend rt justified GVA bit     */
-        slri    T3, T3, XLEN-1
+        srli    T3, T3, XLEN-1
         and     T4, T3, T6              /* clr delta if GVA=0                   */
       #else
         li      T4,0                    /* clr delta if no H-ext                */


### PR DESCRIPTION

<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

When calculating the save area offset, the code tries to determine the illegal flag combinations according to the table in the comments above. To do this, it is supposed to form a 3 bit number from the (vMPP,H,GVA) flags.  This code had several problems which are now fixed:

1. The H flag, which indicates if the hypervisor is enabled, was incorrectly stored in bit 0 instead of bit 1, overwriting the GVA flag.
3. Incorrectly using `#if` instead of `#ifdef` to check for the `rvtest_vtrap_routine` macro, causing the code to be permanently disabled.
4. Incorrect comment explaining the illegal bit patterns, although an earlier comment in the code had the correct patterns. The constant 0x5D is actually the correct constant to use.
5. Typographic error spelling the instruction `srli` as `slri`.

### Related Issues

N/A

### Ratified/Unratified Extensions

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [ ] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [ ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [x] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
