### PR TITLE
[ACT 4] Update `RVMODEL_IO_WRITE_STR` macro and add coverpoints to debug message

### DIFF
--- a/configs/duts/cvw/cvw-rv64gc/model_test.h
+++ b/configs/duts/cvw/cvw-rv64gc/model_test.h
@@ -1,15 +1,6 @@
 #ifndef _COMPLIANCE_MODEL_H
 #define _COMPLIANCE_MODEL_H
 
-# Expects a PC16550-compatible UART.
-# Change these addresses to match your memory map
-.EQU UART_ENABLED, 1                     # set to 0 to not print
-.EQU UART_BASE_ADDR, 0x10000000
-.EQU UART_THR, (UART_BASE_ADDR + 0)
-.EQU UART_RBR, (UART_BASE_ADDR + 0)
-.EQU UART_LCR, (UART_BASE_ADDR + 3)
-.EQU UART_LSR, (UART_BASE_ADDR + 5)
-
 #define RVMODEL_DATA_SECTION \
         .pushsection .tohost,"aw",@progbits;                \
         .align 8; .global tohost; tohost: .dword 0;         \
@@ -36,14 +27,19 @@
 
 #define RVMODEL_BOOT
 
+# Expects a PC16550-compatible UART.
+# Change these addresses to match your memory map
+.EQU UART_BASE_ADDR, 0x10000000
+.EQU UART_THR, (UART_BASE_ADDR + 0)
+.EQU UART_RBR, (UART_BASE_ADDR + 0)
+.EQU UART_LCR, (UART_BASE_ADDR + 3)
+.EQU UART_LSR, (UART_BASE_ADDR + 5)
+
 #define RVMODEL_IO_INIT    \
   uart_init:                ;\
-    LI(T1, UART_ENABLED)    ;\
-    beqz T1, 1f             ; /* skip if UART is not enabled */ \
     li T1, UART_LCR         ; /* Load address of UART LCR */    \
     li T2, 3                ; /* 8-bit characters, 1 stop bit, no parity */ \
-    sb T2, 0(T1)
-
+    sb T2, 0(T1)            ; \
 
 # Prints a null-terminated string using a DUT specific mechanism.
 # A pointer to the string is passed in _STR_PTR.
@@ -54,8 +50,6 @@
   lbu _R1, 0(_STR_PTR)        ;/* Load byte */        \
   beqz _R1, 3f                ;/* Exit if null */     \
 2: /* uart_putc */           ;                      \
-  li _R2, UART_ENABLED   ;\
-  beqz _R2, 3f        ;/* skip if UART is not enabled */ \
   li _R2, UART_LSR ;\
   4: /* uart_putc_wait_busy */ \
     lbu _R3, 0(_R2) ;\

--- a/configs/duts/cvw/cvw-rv64gc/model_test.h
+++ b/configs/duts/cvw/cvw-rv64gc/model_test.h
@@ -44,18 +44,29 @@
     li T2, 3                ; /* 8-bit characters, 1 stop bit, no parity */ \
     sb T2, 0(T1)
 
-# Prints a null-terminated string (_STR) using a DUT specific
-# mechanism. _R can be used as a temporary register if needed.
+
+# Prints a null-terminated string using a DUT specific mechanism.
+# A pointer to the string is passed in _STR_PTR.
+# _R1, _R2, and _R3 can be used as temporary registers if needed.
 # Do not modify any other registers (or make sure to restore them).
-#define RVMODEL_IO_WRITE_STR(_R, _STR)               \
-  la x30, _STR               ;/* Load string addr */ \
+#define RVMODEL_IO_WRITE_STR(_R1, _R2, _R3, _STR_PTR)               \
 1:                           ;                       \
-  lbu a0, 0(x30)             ; /* Load byte */       \
-  beqz a0, 2f                ; /* Exit if null */    \
-  call uart_putc             ; /* Print char */      \
-  addi x30, x30, 1           ; /* Next char */       \
-  j 1b                       ; /* Loop */            \
-2:
+  lbu _R1, 0(_STR_PTR)        ;/* Load byte */        \
+  beqz _R1, 3f                ;/* Exit if null */     \
+2: /* uart_putc */           ;                      \
+  li _R2, UART_ENABLED   ;\
+  beqz _R2, 3f        ;/* skip if UART is not enabled */ \
+  li _R2, UART_LSR ;\
+  4: /* uart_putc_wait_busy */ \
+    lbu _R3, 0(_R2) ;\
+    andi _R3, _R3, 0x20 ;/* check line status register bit 5 */ \
+    beqz _R3, 4b ;/* wait until Transmit Holding Register Empty is set */ \
+  /* uart_putc_send */ \
+    li _R2, UART_THR ; /* transmit character */ \
+    sb _R1, 0(_R2) ;\
+  addi _STR_PTR, _STR_PTR, 1 ;/* Next char */        \
+  j 1b                       ;/* Loop */             \
+3:
 
 #define RVMODEL_SET_MSW_INT
 
@@ -64,19 +75,5 @@
 #define RVMODEL_CLEAR_MTIMER_INT
 
 #define RVMODEL_CLEAR_MEXT_INT
-
-uart_putc:
-    li t1, UART_ENABLED
-    beqz t1, 1f             # skip if UART is not enabled
-    li t1, UART_LSR
-  uart_putc_wait_busy:
-    lbu t2, 0(t1)
-    andi t2, t2, 0x20 # check line status register bit 5
-    beqz t2, uart_putc_wait_busy # wait until Transmit Holding Register Empty is set
-  uart_putc_send:
-    li t1, UART_THR # transmit character
-    sb a0, 0(t1)
-  1:
-    ret
 
 #endif // _COMPLIANCE_MODEL_H

--- a/configs/ref/sail-rv64gc/model_test.h
+++ b/configs/ref/sail-rv64gc/model_test.h
@@ -27,18 +27,23 @@
 
 #define RVMODEL_IO_INIT
 
-# Prints a null-terminated string (_STR) using a DUT specific
-# mechanism. _R can be used as a temporary register if needed.
+# Prints a null-terminated string using a DUT specific mechanism.
+# A pointer to the string is passed in _STR_PTR.
+# _R1, _R2, and _R3 can be used as temporary registers if needed.
 # Do not modify any other registers (or make sure to restore them).
-#define RVMODEL_IO_WRITE_STR(_R, _STR)               \
-  la x30, _STR               ;/* Load string addr */ \
+#define RVMODEL_IO_WRITE_STR(_R1, _R2, _R3, _STR_PTR)               \
 1:                           ;                       \
-  lbu a0, 0(x30)             ;/* Load byte */        \
-  beqz a0, 2f                ;/* Exit if null */     \
-  call htif_putc             ;/* Print char */       \
-  addi x30, x30, 1           ;/* Next char */        \
+  lbu _R1, 0(_STR_PTR)        ;/* Load byte */        \
+  beqz _R1, 3f                ;/* Exit if null */     \
+2: /* htif_putc */           ;                      \
+  la _R2, tohost       ;   \
+  sw _R1, 0(_R2)     ; \
+  /* device=1 (terminal), cmd=1 (output) */ \
+  li _R1, 0x01010000 ;\
+  sw _R1, 4(_R2)   ;\
+  addi _STR_PTR, _STR_PTR, 1 ;/* Next char */        \
   j 1b                       ;/* Loop */             \
-2:
+3:
 
 #define RVMODEL_SET_MSW_INT
 
@@ -47,13 +52,5 @@
 #define RVMODEL_CLEAR_MTIMER_INT
 
 #define RVMODEL_CLEAR_MEXT_INT
-
-htif_putc:
-    la x31, tohost
-    sw a0, 0(x31)
-    // device=1 (terminal), cmd=1 (output)
-    li a0, 0x01010000
-    sw a0, 4(x31)
-    ret
 
 #endif // _COMPLIANCE_MODEL_H

--- a/ctp/src/trickbox.adoc
+++ b/ctp/src/trickbox.adoc
@@ -24,7 +24,7 @@ The trick box is implemented with DUT-specific macros in given in <<t-trickbox>>
 |RVMODEL_HALT_PASS|Terminate test with a pass indication.  When the test is run in simulation, this should end the simulation.
 |RVMODEL_HALT_FAIL|Terminate test with a fail indication.  When the test is run in simulation, this should end the simulation.
 |RVMODEL_IO_INIT|Initialization steps needed prior to writing to the console
-|RVMODEL_IO_WRITE_STR(_R, _STR)|Write a null-terminated ASCII string to the console, where _R is a temporary register that may be trashed by the macro and _STR is a register containing the address of the first byte of the string
+|RVMODEL_IO_WRITE_STR(_R1, _R2, _R3, _STR_PTR)|Write a null-terminated ASCII string to the console, where _R1, _R2, and _R3 are temporary registers that may be trashed by the macro and _STR_PTR is a register containing the address of the first byte of the string
 |RVMODEL_SET_MEXT_INT| Sets the Machine External Interrupt (mip.MEIP = 1, if supported)
 |RVMODEL_CLR_MEXT_INT|Clears the Machine External Interrupt (mip.MEIP = 0)
 |RVMODEL_SET_MTIMER_INT|Sets the Machine Timer Interrupt (mip.MTIP = 1, if supported)

--- a/generators/tests/testgen/src/testgen/coverpoints/compare.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/compare.py
@@ -30,6 +30,7 @@ def make_cmp_rd_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data
 
     # Generate tests
     for reg in regs:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rd=reg, rs1=reg)
         desc = f"{coverpoint} (Test rd = rs1 = x{reg})"
@@ -56,6 +57,7 @@ def make_cmp_rd_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data
 
     # Generate tests
     for reg in regs:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rd=reg, rs2=reg)
         desc = f"{coverpoint} (Test rd = rs2 = x{reg})"
@@ -82,6 +84,7 @@ def make_cmp_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_dat
 
     # Generate tests
     for reg in regs:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rs1=reg, rs2=reg)
         desc = f"{coverpoint} (Test rs1 = rs2 = x{reg})"
@@ -106,6 +109,7 @@ def make_cmp_rd_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_
 
     # Generate tests
     for reg in regs:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rd=reg, rs1=reg, rs2=reg)
         desc = f"{coverpoint} (Test rd = rs1 = rs2 = x{reg})"

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_bs.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_bs.py
@@ -24,6 +24,7 @@ def make_cp_bs(instr_name: str, instr_type: str, coverpoint: str, test_data: Tes
 
     test_lines: list[str] = []
     for bs in bs_vals:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append("")
         params = generate_random_params(test_data, instr_type, immval=bs)
         desc = f"{coverpoint}: bs={bs}"

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_custom.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_custom.py
@@ -15,6 +15,7 @@ from testgen.utils.templates import insert_test_template
 @add_coverpoint_generator("cp_custom")
 def make_custom(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests for custom coverpoints using a template file."""
+    test_data.add_testcase_string(coverpoint)
     test_lines, sigupd_count_increment = insert_test_template(f"{instr_name}.S", test_data.xlen, test_data)
     test_data.sigupd_count += sigupd_count_increment
     return [test_lines]

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_imm_edges.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_imm_edges.py
@@ -31,6 +31,7 @@ def make_cp_imm_edges(instr_name: str, instr_type: str, coverpoint: str, test_da
     test_lines: list[str] = []
 
     for edge_val in edges_imm:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append("")
         params = generate_random_params(test_data, instr_type, immval=edge_val)
         desc = f"{coverpoint} (imm = {edge_val})"
@@ -43,6 +44,7 @@ def make_cp_imm_edges(instr_name: str, instr_type: str, coverpoint: str, test_da
 @add_coverpoint_generator("cp_imm_edges_branch")
 def make_cp_imm_edges_branch(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests for branch immediate edge values."""
+    # TODO: Update coverpoint error message
     test_lines: list[str] = ["\n# Testcase cp_imm_edges_branch"]
     params = generate_random_params(test_data, instr_type)
     assert params.rs1 is not None and params.rs2 is not None

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_imm_mul.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_imm_mul.py
@@ -34,6 +34,7 @@ def make_cp_uimm(instr_name: str, instr_type: str, coverpoint: str, test_data: T
         raise ValueError(f"Unknown cp_uimm coverpoint variant: {coverpoint} for {instr_name}")
     test_lines: list[str] = []
     for imm in imm_mul:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append("")
         params = generate_random_params(test_data, instr_type, immval=imm, exclude_regs=exclude_regs)
         desc = f"{coverpoint}: imm={imm}"

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_memval.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_memval.py
@@ -30,6 +30,7 @@ def make_memval(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
 
     test_lines: list[str] = []
     for val in memvals:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append("")
         if instr_type == "S":
             params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs2val=val)

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_offset.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_offset.py
@@ -13,6 +13,7 @@ from testgen.utils.common import write_sigupd
 from testgen.utils.param_generator import generate_random_params
 
 
+# TODO: Update coverpoint error message
 @add_coverpoint_generator("cp_offset")
 def make_offset(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests for backward branch negative offsets."""

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_rbox.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_rbox.py
@@ -23,6 +23,7 @@ def make_cp_rnum(instr_name: str, instr_type: str, coverpoint: str, test_data: T
 
     test_lines: list[str] = []
     for rnum in rnum_vals:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append("")
         params = generate_random_params(test_data, instr_type, immval=rnum)
         desc = f"{coverpoint}: rnum={rnum}"

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_sbox.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_sbox.py
@@ -23,6 +23,7 @@ def make_cp_sbox(instr_name: str, instr_type: str, coverpoint: str, test_data: T
 
     test_lines: list[str] = []
     for sbox in sbox_vals:
+        test_data.add_testcase_string(coverpoint)
         # repeat sbox value in each byte
         if test_data.xlen == 32:
             s = sbox | sbox << 8 | sbox << 16 | sbox << 24

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_uimm.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_uimm.py
@@ -27,6 +27,7 @@ def make_cp_uimm(instr_name: str, instr_type: str, coverpoint: str, test_data: T
 
     test_lines: list[str] = []
     for uimm in uimm_vals:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append("")
         params = generate_random_params(test_data, instr_type, immval=uimm)
         desc = f"{coverpoint}: imm={uimm}"

--- a/generators/tests/testgen/src/testgen/coverpoints/cr_rs1_imm_edges.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cr_rs1_imm_edges.py
@@ -37,6 +37,7 @@ def make_cr_rs1_imm_edges(instr_name: str, instr_type: str, coverpoint: str, tes
 
     for reg_edge_val in edges_reg:
         for imm_edge_val in edges_imm:
+            test_data.add_testcase_string(coverpoint)
             test_lines.append("")
             params = generate_random_params(
                 test_data, instr_type, exclude_regs=[0], rs1val=reg_edge_val, immval=imm_edge_val

--- a/generators/tests/testgen/src/testgen/coverpoints/reg_edges.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/reg_edges.py
@@ -26,8 +26,8 @@ def make_rs1_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
         raise ValueError(f"Unknown cp_rs1_edges coverpoint variant: {coverpoint} for {instr_name}")
 
     test_lines: list[str] = []
-
     for edge_val in edges:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append("")
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs1val=edge_val)
         desc = f"{coverpoint} (Test source rs1 value = {test_data.xlen_format_str.format(edge_val)})"
@@ -46,8 +46,8 @@ def make_rs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
         raise ValueError(f"Unknown cp_rs2_edges coverpoint variant: {coverpoint} for {instr_name}")
 
     test_lines: list[str] = []
-
     for edge_val in edges:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append("")
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs2val=edge_val)
         desc = f"{coverpoint} (Test source rs2 value = {test_data.xlen_format_str.format(edge_val)})"
@@ -67,9 +67,9 @@ def make_cr_rs1_rs2_edges(instr_name: str, instr_type: str, coverpoint: str, tes
         raise ValueError(f"Unknown cr_rs1_rs2_edges coverpoint variant: {coverpoint} for {instr_name}")
 
     test_lines: list[str] = []
-
     for edge_val1 in edges1:
         for edge_val2 in edges2:
+            test_data.add_testcase_string(coverpoint)
             test_lines.append("")
             params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs1val=edge_val1, rs2val=edge_val2)
             desc = f"{coverpoint} (Test source rs1 = {test_data.xlen_format_str.format(edge_val1)} rs2 = {test_data.xlen_format_str.format(edge_val2)})"
@@ -92,6 +92,7 @@ def make_cr_rs1_rs2_edges_offset(instr_name: str, instr_type: str, coverpoint: s
             test_lines.append("")
             params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs1val=edge_val1, rs2val=edge_val2)
             assert params.rs1 is not None and params.rs2 is not None
+            test_data.add_testcase_string(coverpoint)
             test_lines.extend(
                 [
                     f"# {coverpoint} (Test source rs1 = {test_data.xlen_format_str.format(edge_val1)} rs2 = {test_data.xlen_format_str.format(edge_val2)})",

--- a/generators/tests/testgen/src/testgen/coverpoints/register.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/register.py
@@ -30,6 +30,7 @@ def make_rd(instr_name: str, instr_type: str, coverpoint: str, test_data: TestDa
 
     # Generate tests
     for rd in rd_regs:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append(test_data.int_regs.consume_registers([rd]))
         params = generate_random_params(test_data, instr_type, rd=rd)
         desc = f"{coverpoint} (Test destination rd = x{rd})"
@@ -59,6 +60,7 @@ def make_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
 
     # Generate tests
     for rs1 in rs1_regs:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append(test_data.int_regs.consume_registers([rs1]))
         params = generate_random_params(test_data, instr_type, rs1=rs1)
         desc = f"{coverpoint} (Test source rs1 = x{rs1})"
@@ -85,6 +87,7 @@ def make_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
 
     # Generate tests
     for rs2 in rs2_regs:
+        test_data.add_testcase_string(coverpoint)
         test_lines.append(test_data.int_regs.consume_registers([rs2]))
         params = generate_random_params(test_data, instr_type, rs2=rs2)
         desc = f"{coverpoint} (Test source rs2 = x{rs2})"

--- a/generators/tests/testgen/src/testgen/data/test_data.py
+++ b/generators/tests/testgen/src/testgen/data/test_data.py
@@ -26,7 +26,7 @@ class TestData:
         test_data_values: List of values to be stored in test_data section
     """
 
-    def __init__(self, test_config: TestConfig) -> None:
+    def __init__(self, test_config: TestConfig, extension: str, instr_name: str) -> None:
         """
         Initialize test data with configuration and empty state.
 
@@ -34,11 +34,15 @@ class TestData:
             test_config: Immutable test configuration
         """
         self._config = test_config
+        self._extension = extension
+        self._instr_name = instr_name
         self._int_regs = IntegerRegisterFile(test_config.e_register_file)
         self._float_regs = FloatRegisterFile()
         self._sigupd_count = 10  # Start with a margin of 10 spaces in signature
         self._sigupd_count_float = 0
+        self._test_count = 0
         self._test_data_values: list[int] = []  # List of integer values
+        self._test_data_strings: list[str] = []  # List of string values
 
     def __repr__(self) -> str:
         return f"TestData(config={self._config}, int_regs={self._int_regs}, float_regs={self._float_regs}, sigupd_count={self._sigupd_count}, sigupd_count_float={self._sigupd_count_float})"
@@ -48,6 +52,17 @@ class TestData:
     def config(self) -> TestConfig:
         """Get the immutable test configuration."""
         return self._config
+
+    # Extension and instruction name accessors
+    @property
+    def extension(self) -> str:
+        """Get the RISC-V extension this test is exercising."""
+        return self._extension
+
+    @property
+    def instr_name(self) -> str:
+        """Get the instruction name this test is exercising."""
+        return self._instr_name
 
     # Register file accessors
     @property
@@ -100,6 +115,16 @@ class TestData:
     def flen_format_str(self) -> str:
         return self._config.flen_format_str
 
+    # Test count management
+    @property
+    def test_count(self) -> int:
+        """Get the current test count."""
+        return self._test_count
+
+    def increment_test_count(self) -> None:
+        """Increment the test count by 1."""
+        self._test_count += 1
+
     @property
     def test_data_values(self) -> list[int]:
         """Get the list of test data values to be stored in .data section."""
@@ -113,6 +138,23 @@ class TestData:
             value: The integer value to store
         """
         self._test_data_values.append(value)
+
+    @property
+    def test_data_strings(self) -> list[str]:
+        """Get the list of test data strings to be stored in .data section."""
+        return self._test_data_strings
+
+    def add_testcase_string(self, cp: str) -> None:
+        """
+        Add a test data string to be stored in .data section.
+
+        Args:
+            value: The string value to store
+        """
+        self.increment_test_count()
+        self._test_data_strings.append(
+            f'test_{self.test_count}: .string "\\"test: {self.test_count}; cp: {self.extension}_{self.instr_name}_cg/{cp}\\""'
+        )
 
     def destroy(self) -> None:
         """Clean up resources used by TestData."""

--- a/generators/tests/testgen/src/testgen/templates/testgen_footer.S
+++ b/generators/tests/testgen/src/testgen/templates/testgen_footer.S
@@ -9,7 +9,7 @@ RVTEST_DATA_BEGIN
 @TEST_DATA@
 
     // Testcase strings
-// @TESTCASE_STRINGS@ TODO: Add strings for each testcase indicating number, cp, and normative rule
+@TESTCASE_STRINGS@
 
 // End of test data section and model specific data
 RVTEST_DATA_END

--- a/generators/tests/testgen/src/testgen/testgen.py
+++ b/generators/tests/testgen/src/testgen/testgen.py
@@ -20,7 +20,7 @@ from rich.progress import track
 from testgen.coverpoints import generate_tests_for_coverpoint
 from testgen.data.test_config import TestConfig
 from testgen.data.test_data import TestData
-from testgen.utils.common import generate_test_data_section, get_sig_space
+from testgen.utils.common import generate_test_data_section, generate_test_data_string_section, get_sig_space
 from testgen.utils.templates import insert_setup_template
 from testgen.utils.testplans import get_extensions, read_testplan
 
@@ -110,7 +110,7 @@ def generate_tests_for_extension(task: tuple[int, bool, str, Path, Path]) -> Non
         # Skip instructions not valid for this xlen
         if (xlen == 32 and not instr_data.rv32) or (xlen == 64 and not instr_data.rv64):
             continue
-        test_data = TestData(test_config)
+        test_data = TestData(test_config, extension, instr_name)
         test_file = output_dir / f"{extension}-{instr_name}.S"
         test_file_relative = test_file.relative_to(output_test_dir)
 
@@ -132,10 +132,12 @@ def generate_tests_for_extension(task: tuple[int, bool, str, Path, Path]) -> Non
         # Generate final test string with signature size and test data section
         sig_words = get_sig_space(test_data)
         test_data_section = generate_test_data_section(test_data)
+        test_data_string_section = generate_test_data_string_section(test_data)
         test_string = (
             "\n".join(test_lines)
             .replace("@SIGUPD_COUNT_FROM_TESTGEN@", str(sig_words))
             .replace("@TEST_DATA@", test_data_section)
+            .replace("@TESTCASE_STRINGS@", test_data_string_section)
         )
 
         # Clean up test data
@@ -144,7 +146,7 @@ def generate_tests_for_extension(task: tuple[int, bool, str, Path, Path]) -> Non
         # Write test file if different from existing file
         if not test_file.exists() or test_file.read_text() != test_string:
             test_file.write_text(test_string)
-            print(f"Updated {test_file}")
+            # print(f"Updated {test_file}")
 
 
 def generate_tests_for_instruction(

--- a/generators/tests/testgen/src/testgen/utils/common.py
+++ b/generators/tests/testgen/src/testgen/utils/common.py
@@ -82,7 +82,7 @@ def write_sigupd(rd: int, test_data: TestData, sig_type: Literal["int", "float"]
         test_data.sigupd_count += 1
         return (
             f"# Check if x{rd} contains the expected result. x{sig_reg} is the signature ptr, x{link_reg} is the link ptr, x{temp_reg} is a temp reg.\n"
-            + f"RVTEST_SIGUPD(x{sig_reg}, x{link_reg}, x{temp_reg}, x{rd})"
+            + f'RVTEST_SIGUPD(x{sig_reg}, x{link_reg}, x{temp_reg}, x{rd}, "test_{test_data.test_count}")'
         )
     elif sig_type == "float":
         raise NotImplementedError("Floating point signature updates are not yet implemented.")
@@ -143,5 +143,21 @@ def generate_test_data_section(test_data: TestData) -> str:
     for value in test_data.test_data_values:
         hex_value = to_hex(value, test_data.xlen)
         lines.append(f"    {directive} {hex_value}")
+
+    return "\n".join(lines)
+
+
+def generate_test_data_string_section(test_data: TestData) -> str:
+    """
+    Generate the .data section containing all test strings.
+
+    Args:
+        test_data: TestData object containing the strings to generate
+
+    Returns:
+        Assembly code for the .data section
+    """
+    lines: list[str] = ['canary_mismatch: .string "Testcase signature canary mismatch!"']
+    lines.extend(test_data.test_data_strings)
 
     return "\n".join(lines)

--- a/tests/env/failure_code.h
+++ b/tests/env/failure_code.h
@@ -118,46 +118,77 @@
         addi x6, x4, -16    # address of the failing instruction (possibly including half of previous instruction)
         SREG x6, 264(x5)
 
+        # Get pointer to failure string
+        # In SELFCHECK mode, after the jal instruction there is an XLEN-sized pointer to the test name string
+        # The jal returns to x4, which points to the instruction after jal (i.e., the pointer itself)
+        LREG x6, 0(x4)      # load the string pointer from memory
+        SREG x6, 288(x5)    # save the string pointer
+
     failedtest_report:
         # RVMODEL_IO_INIT
-        RVMODEL_IO_WRITE_STR(a0, failstr)
+      print_failstr:
+        LA(x9, failstr)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
+
+        # Print test name string
+      print_testnamestr:
+        LA(x9, testnamestr)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
+      print_failure_test_name_str:
+        LREG x9, failure_string_ptr
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
+      print_newline_str:
+        LA(x9, newlinestr)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
 
         # Print failing instruction (32-bit)
-        RVMODEL_IO_WRITE_STR(a0, inststr)
+        LA(x9, inststr)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
         lw a0, failing_instruction
         li a1, 32
         jal failedtest_hex_to_str
-        RVMODEL_IO_WRITE_STR(a0, ascii_buffer)
+        LA(x9, ascii_buffer)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
 
         # Print failing address (XLEN-bit)
-        RVMODEL_IO_WRITE_STR(a0, addrstr)
+        LA(x9, addrstr)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
         LREG a0, failing_addr
         li a1, __riscv_xlen
         jal failedtest_hex_to_str
-        RVMODEL_IO_WRITE_STR(a0, ascii_buffer)
+        LA(x9, ascii_buffer)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
 
         # Print failing register (32-bit)
-        RVMODEL_IO_WRITE_STR(a0, regstr)
+        LA(x9, regstr)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
         lw a0, failing_reg
         li a1, 32
         jal failedtest_hex_to_str
-        RVMODEL_IO_WRITE_STR(a0, ascii_buffer)
+        LA(x9, ascii_buffer)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
 
         # Print failing value (XLEN-bit)
-        RVMODEL_IO_WRITE_STR(a0, badvalstr)
+        LA(x9, badvalstr)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
         LREG a0, failing_value
         li a1, __riscv_xlen
         jal failedtest_hex_to_str
-        RVMODEL_IO_WRITE_STR(a0, ascii_buffer)
+        LA(x9, ascii_buffer)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
 
         # Print expected value (XLEN-bit)
-        RVMODEL_IO_WRITE_STR(a0, expvalstr)
+        LA(x9, expvalstr)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
         LREG a0, expected_value
         li a1, __riscv_xlen
         jal failedtest_hex_to_str
-        RVMODEL_IO_WRITE_STR(a0, ascii_buffer)
+        LA(x9, ascii_buffer)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
 
-        RVMODEL_IO_WRITE_STR(a0, endstr)
+        # Print end string
+        LA(x9, endstr)
+        RVMODEL_IO_WRITE_STR(x6, x7, x8, x9)
 
     failedtest_terminate:
         RVMODEL_HALT_FAIL
@@ -218,6 +249,8 @@
         .fill 1, 8, 0xfeedf00dbaaaaaad
     expected_value:
         .fill 1, 8, 0xfeedf00dbaaaaaad
+    failure_string_ptr:
+        .fill 1, 8, 0xfeedf00dbaaaaaad
     ascii_buffer:
         .fill 20, 1, 0          # Buffer for hex string conversion (max "0x" + 16 hex digits + "\n" + null)
     end_failure_scratch:
@@ -230,6 +263,10 @@
         #endif
     failstr:
         .string "\nRVCP-SUMMARY: Test File \"" TEST_FILE "\": FAILED\nRVCP: DEBUG INFORMATION FOLLOWS\n"
+    testnamestr:
+        .string "RVCP: Test Info: "
+    newlinestr:
+        .string "\n"
     inststr:
         .string "RVCP: Instruction: "
     addrstr:

--- a/tests/env/sail_test.h
+++ b/tests/env/sail_test.h
@@ -32,18 +32,23 @@
 
 #define RVMODEL_IO_INIT
 
-# Prints a null-terminated string (_STR) using a DUT specific
-# mechanism. _R can be used as a temporary register if needed.
+# Prints a null-terminated string using a DUT specific mechanism.
+# A pointer to the string is passed in _STR_PTR.
+# _R1, _R2, and _R3 can be used as temporary registers if needed.
 # Do not modify any other registers (or make sure to restore them).
-#define RVMODEL_IO_WRITE_STR(_R, _STR)               \
-  la x30, _STR                ;/* Load string addr */ \
-1:                           ;\
-  lbu a0, 0(x30)              ;/* Load byte */        \
-  beqz a0, 2f                ;/* Exit if null */     \
-  call htif_putc             ;/* Print char */       \
-  addi x30, x30, 1             ;/* Next char */        \
+#define RVMODEL_IO_WRITE_STR(_R1, _R2, _R3, _STR_PTR)               \
+1:                           ;                       \
+  lbu _R1, 0(_STR_PTR)        ;/* Load byte */        \
+  beqz _R1, 3f                ;/* Exit if null */     \
+2: /* htif_putc */           ;                      \
+  la _R2, tohost       ;   \
+  sw _R1, 0(_R2)     ; \
+  /* device=1 (terminal), cmd=1 (output) */ \
+  li _R1, 0x01010000 ;\
+  sw _R1, 4(_R2)   ;\
+  addi _STR_PTR, _STR_PTR, 1 ;/* Next char */        \
   j 1b                       ;/* Loop */             \
-2:
+3:
 
 #define RVMODEL_SET_MSW_INT
 

--- a/tests/env/signature.h
+++ b/tests/env/signature.h
@@ -3,6 +3,13 @@
 # Jordan Carlin jcarlin@hmc.edu October 2025
 # SPDX-License-Identifier: Apache-2.0
 
+// Define XLEN-sized pointer directive
+#if __riscv_xlen == 64
+  #define RVTEST_WORD_PTR .dword
+#else
+  #define RVTEST_WORD_PTR .word
+#endif
+
 // RVTEST_SIGBASE(sigbase, label) initializes the sigbase register to the
 // address of the signature region.
 // _SIG_BASE - Base register for signature region
@@ -19,18 +26,22 @@
 //  _LINK_REG - Link register to use for failure jump
 //  _TEMP_REG - Temporary register to use for loading signature
 //  _R - Register containing value to store/compare
+//  _STR_PTR - label to string describing the test
 #ifdef SELFCHECK
-  #define RVTEST_SIGUPD(_SIG_BASE, _LINK_REG, _TEMP_REG, _R)  \
-    LREG _TEMP_REG,0(_SIG_BASE)                            ;\
+  #define RVTEST_SIGUPD(_SIG_BASE, _LINK_REG, _TEMP_REG, _R, _STR_PTR)  \
+    LREG _TEMP_REG, 0(_SIG_BASE)                            ;\
     beq _TEMP_REG, _R, 1f                                  ;\
     jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+    RVTEST_WORD_PTR _STR_PTR                                ;\
     1:                                                     ;\
     addi _SIG_BASE, _SIG_BASE, REGWIDTH
 #else
-  #define RVTEST_SIGUPD(_SIG_BASE, _LINK_REG, _TEMP_REG, _R)  \
-    SREG _R,0(_SIG_BASE)                                   ;\
-    nop                                                    ;\
-    nop                                                    ;\
+  #define RVTEST_SIGUPD(_SIG_BASE, _LINK_REG, _TEMP_REG, _R, _STR_PTR)  \
+    SREG _R, 0(_SIG_BASE)                                   ;\
+    beq x0, x0, 1f                                         ;\
+    jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+    RVTEST_WORD_PTR _STR_PTR                                ;\
+    1:                                                     ;\
     addi _SIG_BASE, _SIG_BASE, REGWIDTH
 #endif
 

--- a/tests/env/test_setup.h
+++ b/tests/env/test_setup.h
@@ -41,7 +41,7 @@
     RVTEST_SIGBASE(x3, signature_base)
     LI(T1, CANARY_VALUE)
     #ifdef SELFCHECK
-      RVTEST_SIGUPD(x3, x4, x5, T1) # sig_begin_canary
+      RVTEST_SIGUPD(x3, x4, x5, T1, "canary_mismatch") # sig_begin_canary
     #else
       # nops to match selfchecking test length
       nop
@@ -108,8 +108,8 @@
 
   // Terminate test
   exit_cleanup:
-    LA(T1, successstr)
-    RVMODEL_IO_WRITE_STR(T1, successstr)
+    LA(T4, successstr)
+    RVMODEL_IO_WRITE_STR(T1, T2, T3, T4)
     RVMODEL_HALT_PASS
   .option pop
 .endm


### PR DESCRIPTION
- Add additional temporary registers to `RVMODEL_IO_WRITE_STR` macro
- Inline all printing code
- Add testcase number and coverpoint to debug messages in test data section