### PR TITLE
[CTG] fix: ensure coverage data is assigned for the first 100 entries

### DIFF
--- a/riscv-isac/riscv_isac/cgf_normalize.py
+++ b/riscv-isac/riscv_isac/cgf_normalize.py
@@ -623,8 +623,7 @@ def expand_cgf(cgf_files, xlen,flen, log_redundant=False):
                                     # so only do it for the first 100 entries.
                                     if i < 100:
                                         cgf[labels][label].yaml_add_eol_comment(comment, key=cp)
-                                    else:
-                                        cgf[labels][label][cp] = coverage
 
+                                    cgf[labels][label][cp] = coverage
                                     i += 1
     return dict(cgf)


### PR DESCRIPTION
## Description

This PR fixes a bug in `cgf_normalize.py` where coverage values were missing for the first 100 entries.

**Problem:**
Previously, the `if-else` logic was mutually exclusive. If the index was `< 100`, the code added a comment but **skipped** the actual assignment of the coverage value.

**Solution:**
I removed the `else` branch to ensure that:
1. Coverage values are assigned for **all** entries.
2. EOL comments are still correctly added for the first 100 entries.

**Verification:**
Attached is a comparison of `amoadd` before and after this change.
[original_amoadd.w-01.txt](https://github.com/user-attachments/files/24067712/original_amoadd.w-01.txt)
[update_amoadd.w-01.txt](https://github.com/user-attachments/files/24067714/update_amoadd.w-01.txt)

Kindly review, thank you.

