### PR TITLE
Bump RVVI-Trace version to 1.6

### DIFF
--- a/framework/src/act/fcov/rvviTrace.sv
+++ b/framework/src/act/fcov/rvviTrace.sv
@@ -20,7 +20,7 @@
  */
 
 `define RVVI_TRACE_VERSION_MAJOR 1
-`define RVVI_TRACE_VERSION_MINOR 5
+`define RVVI_TRACE_VERSION_MINOR 6
 
 /*
  * A single DTM (Debug Transport Module), connects
@@ -113,7 +113,7 @@ interface rvviTrace
   wire                      halt       [(NHART-1):0][(RETIRE-1):0];   // Halted  instruction
   wire [1:0]                ixl        [(NHART-1):0][(RETIRE-1):0];   // XLEN mode 32/64 bit
   wire [1:0]                mode       [(NHART-1):0][(RETIRE-1):0];   // Privilege mode of operation
-  wire                      mode_virt  [(NHART-1):0][(RETIRE-1):0];   // hypervisor bit
+  wire                      mode_virt  [(NHART-1):0][(RETIRE-1):0];   // Virtual mode
 
   // Virtual Memory signals for verification
   localparam PA_BITS = (XLEN==32 ? 32'd34 : 32'd56);


### PR DESCRIPTION
Bump RVVI Trace version to 1.6 after adding `virt_mode` to stay in line with upstream RVVI standard: https://github.com/riscv-verification/RVVI/blob/master/source/host/rvvi/rvviTrace.sv