### PR TITLE
Update priv_mode coverpoints

### DIFF
--- a/coverpoints/general/RISCV_coverage_standard_coverpoints.svh
+++ b/coverpoints/general/RISCV_coverage_standard_coverpoints.svh
@@ -13,36 +13,194 @@
   // Privilege mode coverpoints
   // Uses ins.prev to check mode at end of previous instruction,
   // which is the mode the current instruction begins execution in
-  priv_mode_m: coverpoint ins.prev.mode {
+  priv_mode_m: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
     type_option.weight = 0;
-    bins M_mode = {2'b11};
+    bins M_mode = {3'b011};
   }
-  priv_mode_s: coverpoint ins.prev.mode {
+  // priv_mode_s and priv_mode_hs are the same, both names are available for clarity when writing crosses
+  priv_mode_s: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
     type_option.weight = 0;
-    bins S_mode = {2'b01};
+    bins S_mode = {3'b001};
   }
-  priv_mode_u: coverpoint ins.prev.mode {
+  priv_mode_hs: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
     type_option.weight = 0;
-    bins U_mode = {2'b00};
+    bins HS_mode = {3'b001};
   }
-  priv_mode_ms: coverpoint ins.prev.mode {
+  priv_mode_vs: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
     type_option.weight = 0;
-    bins M_mode = {2'b11};
-    bins S_mode = {2'b01};
+    bins VS_mode = {3'b101};
   }
-  priv_mode_mu: coverpoint ins.prev.mode {
+  priv_mode_u: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
     type_option.weight = 0;
-    bins M_mode = {2'b11};
-    bins U_mode = {2'b00};
+    bins U_mode = {3'b000};
   }
-  priv_mode_su: coverpoint ins.prev.mode {
+  priv_mode_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
     type_option.weight = 0;
-    bins S_mode = {2'b01};
-    bins U_mode = {2'b00};
+    bins VU_mode = {3'b100};
   }
-  priv_mode_msu: coverpoint ins.prev.mode {
+
+
+  priv_mode_m_s: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
     type_option.weight = 0;
-    bins M_mode = {2'b11};
-    bins S_mode = {2'b01};
-    bins U_mode = {2'b00};
+    bins M_mode = {3'b011};
+    bins S_mode = {3'b001};
+  }
+  priv_mode_m_vs: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins VS_mode = {3'b101};
+  }
+  priv_mode_m_u: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins U_mode = {3'b000};
+  }
+  priv_mode_m_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins VU_mode = {3'b100};
+  }
+
+  priv_mode_hs_vs: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins HS_mode = {3'b001};
+    bins VS_mode = {3'b101};
+  }
+  priv_mode_s_u: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins S_mode = {3'b001};
+    bins U_mode = {3'b000};
+  }
+  priv_mode_hs_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins HS_mode = {3'b001};
+    bins VU_mode = {3'b100};
+  }
+
+  priv_mode_vs_u: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins VS_mode = {3'b101};
+    bins U_mode = {3'b000};
+  }
+  priv_mode_vs_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins VS_mode = {3'b101};
+    bins VU_mode = {3'b100};
+  }
+
+  priv_mode_u_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins U_mode = {3'b000};
+    bins VU_mode = {3'b100};
+  }
+
+
+  priv_mode_m_s_u: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins S_mode = {3'b001};
+    bins U_mode = {3'b000};
+  }
+  priv_mode_m_hs_vs: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins HS_mode = {3'b001};
+    bins VS_mode = {3'b101};
+  }
+  priv_mode_m_hs_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins HS_mode = {3'b001};
+    bins VU_mode = {3'b100};
+  }
+  priv_mode_m_vs_u: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins VS_mode = {3'b101};
+    bins U_mode = {3'b000};
+  }
+  priv_mode_m_vs_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins VS_mode = {3'b101};
+    bins VU_mode = {3'b100};
+  }
+  priv_mode_m_u_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins U_mode = {3'b000};
+    bins VU_mode = {3'b100};
+  }
+
+  priv_mode_hs_vs_u: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins HS_mode = {3'b001};
+    bins VS_mode = {3'b101};
+    bins U_mode = {3'b000};
+  }
+  priv_mode_hs_vs_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins HS_mode = {3'b001};
+    bins VS_mode = {3'b101};
+    bins VU_mode = {3'b100};
+  }
+  priv_mode_hs_u_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins HS_mode = {3'b001};
+    bins U_mode = {3'b000};
+    bins VU_mode = {3'b100};
+  }
+
+  priv_mode_vs_u_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins VS_mode = {3'b101};
+    bins U_mode = {3'b000};
+    bins VU_mode = {3'b100};
+  }
+
+
+  priv_mode_m_hs_vs_u: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins HS_mode = {3'b001};
+    bins VS_mode = {3'b101};
+    bins U_mode = {3'b000};
+  }
+  priv_mode_m_hs_vs_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins HS_mode = {3'b001};
+    bins VS_mode = {3'b101};
+    bins VU_mode = {3'b100};
+  }
+  priv_mode_m_hs_u_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins HS_mode = {3'b001};
+    bins U_mode = {3'b000};
+    bins VU_mode = {3'b100};
+  }
+  priv_mode_m_vs_u_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins VS_mode = {3'b101};
+    bins U_mode = {3'b000};
+    bins VU_mode = {3'b100};
+  }
+  priv_mode_hs_vs_u_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins HS_mode = {3'b001};
+    bins VS_mode = {3'b101};
+    bins U_mode = {3'b000};
+    bins VU_mode = {3'b100};
+  }
+
+
+  priv_mode_m_hs_vs_u_vu: coverpoint {ins.prev.mode_virt, ins.prev.mode} {
+    type_option.weight = 0;
+    bins M_mode = {3'b011};
+    bins HS_mode = {3'b001};
+    bins VS_mode = {3'b101};
+    bins U_mode = {3'b000};
+    bins VU_mode = {3'b100};
   }

--- a/coverpoints/priv/EndianH_coverage.svh
+++ b/coverpoints/priv/EndianH_coverage.svh
@@ -103,14 +103,6 @@ covergroup EndianH_endian_cg with function sample(ins_t ins);
     vsstatus_ube: coverpoint ins.current.csr[12'h200][6] { // ube is vsstatus[6]
     }
 
-    // VS and VU modes
-    priv_mode_vs: coverpoint {ins.current.mode_virt, ins.current.mode} {
-        bins VS_mode = {3'b101};
-    }
-
-    priv_mode_vu: coverpoint {ins.current.mode_virt, ins.current.mode} {
-        bins VU_mode = {3'b100};
-    }
 
 
     // main coverpoints

--- a/coverpoints/priv/ExceptionsS_coverage.svh
+++ b/coverpoints/priv/ExceptionsS_coverage.svh
@@ -169,17 +169,17 @@ covergroup ExceptionsS_exceptions_cg with function sample(ins_t ins);
     cp_store_access_fault:                   cross storeops, illegal_address, priv_mode_s;
     cp_ecall_s:                              cross ecall, priv_mode_s;
     cp_misaligned_priority:                  cross sw_lw, illegal_address_misaligned, priv_mode_s;
-    cp_medeleg_msu_instrmisaligned:          cross jalr,     rs1_1_0, offset, priv_mode_msu, medeleg_walk;
-    cp_medeleg_msu_loadmisaligned:           cross loadops,    adr_LSBs,         priv_mode_msu, medeleg_walk;
-    cp_medeleg_msu_storemisaligned:          cross storeops,   adr_LSBs,         priv_mode_msu, medeleg_walk;
-    cp_medeleg_msu_instraccessfault:         cross jalr,       illegal_address,  priv_mode_msu, medeleg_walk;
-    cp_medeleg_msu_loadaccessfault:          cross loadops,    illegal_address,  priv_mode_msu, medeleg_walk;
-    cp_medeleg_msu_storeaccessfault:         cross storeops,   illegal_address,  priv_mode_msu, medeleg_walk;
-    cp_medeleg_msu_illegalinstruction:       cross illegalops,                   priv_mode_msu, medeleg_walk;
-    cp_medeleg_msu_ecall:                    cross ecall,                        priv_mode_msu, medeleg_walk;
-    cp_medeleg_msu_ebreak:                   cross ebreak,                       priv_mode_msu, medeleg_walk;
-    cp_stvec:                                cross jalr, illegal_address, priv_mode_su, medeleg_instraccessfault_enabled, mtvec_stvec_ne; // Testplan was not specific, I chose instr access fault for the delegated exception
-    cp_xstatus_ie:                           cross ecall, priv_mode_su, mstatus_MIE, sstatus_SIE, medeleg_b8;
+    cp_medeleg_msu_instrmisaligned:          cross jalr,     rs1_1_0, offset, priv_mode_m_s_u, medeleg_walk;
+    cp_medeleg_msu_loadmisaligned:           cross loadops,    adr_LSBs,         priv_mode_m_s_u, medeleg_walk;
+    cp_medeleg_msu_storemisaligned:          cross storeops,   adr_LSBs,         priv_mode_m_s_u, medeleg_walk;
+    cp_medeleg_msu_instraccessfault:         cross jalr,       illegal_address,  priv_mode_m_s_u, medeleg_walk;
+    cp_medeleg_msu_loadaccessfault:          cross loadops,    illegal_address,  priv_mode_m_s_u, medeleg_walk;
+    cp_medeleg_msu_storeaccessfault:         cross storeops,   illegal_address,  priv_mode_m_s_u, medeleg_walk;
+    cp_medeleg_msu_illegalinstruction:       cross illegalops,                   priv_mode_m_s_u, medeleg_walk;
+    cp_medeleg_msu_ecall:                    cross ecall,                        priv_mode_m_s_u, medeleg_walk;
+    cp_medeleg_msu_ebreak:                   cross ebreak,                       priv_mode_m_s_u, medeleg_walk;
+    cp_stvec:                                cross jalr, illegal_address, priv_mode_s_u, medeleg_instraccessfault_enabled, mtvec_stvec_ne; // Testplan was not specific, I chose instr access fault for the delegated exception
+    cp_xstatus_ie:                           cross ecall, priv_mode_s_u, mstatus_MIE, sstatus_SIE, medeleg_b8;
 
 endgroup
 

--- a/coverpoints/priv/ExceptionsZicboS_coverage.svh
+++ b/coverpoints/priv/ExceptionsZicboS_coverage.svh
@@ -42,9 +42,9 @@ covergroup ExceptionsZicboS_exceptions_cg with function sample(ins_t ins);
     }
 
     // main coverpoints
-    cp_cbie:  cross cbo_inval,      menvcfg_cbie,  senvcfg_cbie,  priv_mode_msu;
-    cp_cbcfe: cross cbo_flushclean, menvcfg_cbcfe, senvcfg_cbcfe, priv_mode_msu;
-    cp_cbze:  cross cbo_zero,       menvcfg_cbze,  senvcfg_cbze,  priv_mode_msu;
+    cp_cbie:  cross cbo_inval,      menvcfg_cbie,  senvcfg_cbie,  priv_mode_m_s_u;
+    cp_cbcfe: cross cbo_flushclean, menvcfg_cbcfe, senvcfg_cbcfe, priv_mode_m_s_u;
+    cp_cbze:  cross cbo_zero,       menvcfg_cbze,  senvcfg_cbze,  priv_mode_m_s_u;
 
 endgroup
 

--- a/coverpoints/priv/ExceptionsZicboU_coverage.svh
+++ b/coverpoints/priv/ExceptionsZicboU_coverage.svh
@@ -35,9 +35,9 @@ covergroup ExceptionsZicboU_exceptions_cg with function sample(ins_t ins);
     }
 
     // main coverpoints
-    cp_cbie:  cross cbo_inval,      menvcfg_cbie,  priv_mode_mu;
-    cp_cbcfe: cross cbo_flushclean, menvcfg_cbcfe, priv_mode_mu;
-    cp_cbze:  cross cbo_zero,       menvcfg_cbze,  priv_mode_mu;
+    cp_cbie:  cross cbo_inval,      menvcfg_cbie,  priv_mode_m_u;
+    cp_cbcfe: cross cbo_flushclean, menvcfg_cbcfe, priv_mode_m_u;
+    cp_cbze:  cross cbo_zero,       menvcfg_cbze,  priv_mode_m_u;
 
 endgroup
 

--- a/coverpoints/priv/SsstrictS_coverage.svh
+++ b/coverpoints/priv/SsstrictS_coverage.svh
@@ -81,14 +81,13 @@ covergroup SsstrictS_scsr_cg with function sample(ins_t ins);
     }
 
     // main coverpoints
-    cp_csrr:         cross csrr,    csr,         priv_mode_s, nonzerord;
-    cp_csrw_edges: cross csrrw,   csr, priv_mode_s, rs1_edges {
+    cp_csrr:       cross csrr,  csr,   priv_mode_s, nonzerord;
+    cp_csrw_edges: cross csrrw, csr,   priv_mode_s, rs1_edges {
     }
-
-    cp_csrcs:        cross csrop,   csr, priv_mode_s, rs1_ones {
+    cp_csrcs:      cross csrop, csr,   priv_mode_s, rs1_ones {
     }
-    cp_shadow_m:     cross csrrw,   mcsrs,       priv_mode_m, rs1_edges;  // write 1s/0s to mstatus, mie, mip in m mode
-    cp_shadow_s:     cross csrrw,   scsrs,       priv_mode_s, rs1_edges;  // write 1s/0s to sstatus, sie, sip in s mode
+    cp_shadow_m:   cross csrrw, mcsrs, priv_mode_m, rs1_edges;  // write 1s/0s to mstatus, mie, mip in m mode
+    cp_shadow_s:   cross csrrw, scsrs, priv_mode_s, rs1_edges;  // write 1s/0s to sstatus, sie, sip in s mode
 endgroup
 
 covergroup SsstrictS_instr_cg with function sample(ins_t ins);

--- a/coverpoints/priv/VM_CBO_coverage.svh
+++ b/coverpoints/priv/VM_CBO_coverage.svh
@@ -270,13 +270,13 @@ covergroup VM_CBO_exceptions_cg with function sample(ins_t ins);
 
     // Non leaf PTE points to a non existatant phys addr instead of next page table. Store access fault required during walk
     // Example: Setup a giga page in sv48, lvl 3 pte (tera) should point to lvl2 page table, but it points to non existent PA
-    nonleaf_PTE_to_nonexistent_pa_cbo: cross pointer_PTE_d, d_phys_address_nonexistent, PageType_d, store_acc_fault, cbo_ins, priv_mode_su {
+    nonleaf_PTE_to_nonexistent_pa_cbo: cross pointer_PTE_d, d_phys_address_nonexistent, PageType_d, store_acc_fault, cbo_ins, priv_mode_s_u {
         `ifdef SV48     ignore_bins ig1 = binsof(PageType_d.sv48_tera); `endif     // Here PageType_d will be the page being pointed towards
         `ifdef SV39     ignore_bins ig2 = binsof(PageType_d.sv39_giga); `endif
         `ifdef XLEN32   ignore_bins ig3 = binsof(PageType_d.sv32_mega); `endif
     }
 
-    PTE_nonleaf_DAU_cbo: cross PTE_DAU_d, PageType_d, store_page_fault, cbo_ins, priv_mode_su {
+    PTE_nonleaf_DAU_cbo: cross PTE_DAU_d, PageType_d, store_page_fault, cbo_ins, priv_mode_s_u {
         `ifdef SV48     ignore_bins ig1 = binsof(PageType_d.sv48_kilo); `endif
         `ifdef SV39     ignore_bins ig2 = binsof(PageType_d.sv39_kilo); `endif
         `ifdef XLEN32   ignore_bins ig3 = binsof(PageType_d.sv32_kilo); `endif

--- a/coverpoints/priv/VM_coverage.svh
+++ b/coverpoints/priv/VM_coverage.svh
@@ -158,7 +158,7 @@ covergroup VM_satp_cg with function sample(ins_t ins);
     access_u: cross priv_mode_u, Mcause, tvm_mstatus { //sat.1
         ignore_bins ig1 = binsof(Mcause.no_exception);
     }
-    access_m_s: cross priv_mode_ms, ins, Mcause, tvm_mstatus { //sat.1
+    access_m_s: cross priv_mode_m_s, ins, Mcause, tvm_mstatus { //sat.1
         ignore_bins ig1 = binsof(Mcause.illegal_ins);
     }
 endgroup

--- a/coverpoints/priv/ZicntrH_coverage.svh
+++ b/coverpoints/priv/ZicntrH_coverage.svh
@@ -463,20 +463,6 @@ covergroup ZicntrH_counters_cg with function sample(ins_t ins);
     `endif
 
 
-    // new hypervisor priv modes
-
-    priv_mode_hs: coverpoint {ins.current.mode_virt, ins.current.mode} {
-        bins HS_mode = {3'b001};
-    }
-
-    priv_mode_vs: coverpoint {ins.current.mode_virt, ins.current.mode} {
-        bins VS_mode = {3'b101};
-    }
-
-    priv_mode_vu: coverpoint {ins.current.mode_virt, ins.current.mode} {
-        bins VU_mode = {3'b100};
-    }
-
     `ifdef XLEN64
     cp_htimedelta: coverpoint {ins.current.csr[12'h605][63:0]} {
         bins htimedelta_zero  = {64'h0};


### PR DESCRIPTION
- Add `mode_virt` to all `priv_mode` coverpoints
- Add new `priv_mode` coverpoints based on vs and vu mode
- Rename `priv_mode` coverpoints to separate modes with an underscore because the names were getting unwieldy.