### PR TITLE
[ACT 4] F extension at nearly 100% coverage

### DIFF
--- a/generators/coverage/templates/cp_csr_frm.txt
+++ b/generators/coverage/templates/cp_csr_frm.txt
@@ -1,4 +1,4 @@
-    cp_csr_frm : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "fcsr", "frm")  iff (ins.trap == 0 & ins.current.insn[14:12] == 3'b111)  {
+    cp_csr_frm : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "fcsr", "frm")  iff (ins.trap == 0 & ins.current.insn[14:12] == 3'b111)  {
         // Value of FCSR.frm during dynamic rounding
         bins rne  = {3'b000};
         bins rtz  = {3'b001};

--- a/generators/coverage/templates/cp_csr_frm.txt
+++ b/generators/coverage/templates/cp_csr_frm.txt
@@ -1,4 +1,4 @@
-    cp_csr_frm : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "fcsr", "frm")  iff (ins.trap == 0 & ins.current.insn[14:12] == 3'b111)  {
+    cp_csr_frm : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "frm", "frm")  iff (ins.trap == 0 & ins.current.insn[14:12] == 3'b111)  {
         // Value of FCSR.frm during dynamic rounding
         bins rne  = {3'b000};
         bins rtz  = {3'b001};

--- a/generators/coverage/templates/cp_csr_frm_v.txt
+++ b/generators/coverage/templates/cp_csr_frm_v.txt
@@ -1,4 +1,4 @@
-    cp_csr_frm_v : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_AFTER, "fcsr", "frm")  iff (ins.trap == 0 )  {
+    cp_csr_frm_v : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "fcsr", "frm")  iff (ins.trap == 0 )  {
         // Value of FCSR.frm for vector FP instructions, which do not specify dynamic rounding mode in opcode
         bins rne  = {3'b000};
         bins rtz  = {3'b001};

--- a/generators/coverage/templates/cp_csr_frm_v.txt
+++ b/generators/coverage/templates/cp_csr_frm_v.txt
@@ -1,4 +1,4 @@
-    cp_csr_frm_v : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "fcsr", "frm")  iff (ins.trap == 0 )  {
+    cp_csr_frm_v : coverpoint get_csr_val(ins.hart, ins.issue, `SAMPLE_BEFORE, "frm", "frm")  iff (ins.trap == 0 )  {
         // Value of FCSR.frm for vector FP instructions, which do not specify dynamic rounding mode in opcode
         bins rne  = {3'b000};
         bins rtz  = {3'b001};

--- a/generators/tests/testgen/src/testgen/coverpoints/cmp_fp_regs.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cmp_fp_regs.py
@@ -74,6 +74,36 @@ def make_cmp_fd_fs2(instr_name: str, instr_type: str, coverpoint: str, test_data
     return test_lines
 
 
+@add_coverpoint_generator("cmp_fd_fs3")
+def make_cmp_fd_fs3(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
+    """Generate tests where fd = fs3."""
+    # Determine which fd registers to test based on coverpoint variant
+    if coverpoint == "cmp_fd_fs3":
+        regs = range(test_data.float_regs.reg_count)
+    elif coverpoint.endswith("_c"):
+        regs = range(8, 16)  # x8-x15 for compressed instructions
+    else:
+        raise ValueError(f"Unknown cmp_fd_fs3 coverpoint variant: {coverpoint} for {instr_name}")
+
+    test_lines: list[str] = []
+
+    # Generate tests
+    for reg in regs:
+        test_data.add_testcase_string(coverpoint)
+        test_data.float_regs.consume_registers([reg])
+        params = generate_random_params(test_data, instr_type, fd=reg, fs3=reg)
+        desc = f"{coverpoint} (Test fd = fs3 = f{reg})"
+        test_lines.extend(
+            [
+                "",
+                format_single_test(instr_name, instr_type, test_data, params, desc),
+            ]
+        )
+        return_test_regs(test_data, params)
+
+    return test_lines
+
+
 @add_coverpoint_generator("cmp_fs1_fs2")
 def make_cmp_fs1_fs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests where fd = fs2."""

--- a/generators/tests/testgen/src/testgen/coverpoints/cmp_fp_regs.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cmp_fp_regs.py
@@ -5,11 +5,12 @@
 # SPDX-License-Identifier: Apache-2.0
 ##################################
 
-"""Compare floating register coverpoint generators (cmp_fd_rs1, cmp_fd_rs2, cmp_fs1_fs2, cmp_fd_fs1_fs2)."""
+"""Compare floating register coverpoint generators (cmp_fd_fs1, cmp_fd_fs2, cmp_fs1_fs2, cmp_fd_fs1_fs2)."""
 
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -32,9 +33,13 @@ def make_cmp_fd_fs1(instr_name: str, instr_type: str, coverpoint: str, test_data
         test_data.float_regs.consume_registers([reg])
         params = generate_random_params(test_data, instr_type, fd=reg, fs1=reg)
         desc = f"{coverpoint} (Test fd = fs1 = f{reg})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
-        test_data.float_regs.return_registers(params.used_float_regs)
+        test_lines.extend(
+            [
+                "",
+                format_single_test(instr_name, instr_type, test_data, params, desc),
+            ]
+        )
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -58,9 +63,13 @@ def make_cmp_fd_fs2(instr_name: str, instr_type: str, coverpoint: str, test_data
         test_data.float_regs.consume_registers([reg])
         params = generate_random_params(test_data, instr_type, fd=reg, fs2=reg)
         desc = f"{coverpoint} (Test fd = fs2 = f{reg})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
-        test_data.float_regs.return_registers(params.used_float_regs)
+        test_lines.extend(
+            [
+                "",
+                format_single_test(instr_name, instr_type, test_data, params, desc),
+            ]
+        )
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -84,9 +93,13 @@ def make_cmp_fs1_fs2(instr_name: str, instr_type: str, coverpoint: str, test_dat
         test_data.float_regs.consume_registers([reg])
         params = generate_random_params(test_data, instr_type, fs1=reg, fs2=reg)
         desc = f"{coverpoint} (Test fs1 = fs2 = f{reg})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
-        test_data.float_regs.return_registers(params.used_float_regs)
+        test_lines.extend(
+            [
+                "",
+                format_single_test(instr_name, instr_type, test_data, params, desc),
+            ]
+        )
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -110,8 +123,12 @@ def make_cmp_fd_fs1_fs2(instr_name: str, instr_type: str, coverpoint: str, test_
         test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, fd=reg, fs1=reg, fs2=reg)
         desc = f"{coverpoint} (Test fd = fs1 = fs2 = f{reg})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
-        test_data.float_regs.return_registers(params.used_float_regs)
+        test_lines.extend(
+            [
+                "",
+                format_single_test(instr_name, instr_type, test_data, params, desc),
+            ]
+        )
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cmp_regs.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cmp_regs.py
@@ -10,6 +10,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -35,7 +36,7 @@ def make_cmp_rd_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data
         params = generate_random_params(test_data, instr_type, rd=reg, rs1=reg)
         desc = f"{coverpoint} (Test rd = rs1 = x{reg})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -62,7 +63,7 @@ def make_cmp_rd_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data
         params = generate_random_params(test_data, instr_type, rd=reg, rs2=reg)
         desc = f"{coverpoint} (Test rd = rs2 = x{reg})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -89,7 +90,7 @@ def make_cmp_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_dat
         params = generate_random_params(test_data, instr_type, rs1=reg, rs2=reg)
         desc = f"{coverpoint} (Test rs1 = rs2 = x{reg})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -114,6 +115,6 @@ def make_cmp_rd_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_
         params = generate_random_params(test_data, instr_type, rd=reg, rs1=reg, rs2=reg)
         desc = f"{coverpoint} (Test rd = rs1 = rs2 = x{reg})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/coverpoints.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/coverpoints.py
@@ -81,6 +81,18 @@ SKIP_COVERPOINTS = frozenset(
         "cp_rd_sign",  # Already covered by rd_edges
         "cmp_rd_rs1_eqval",  # Already covered by cr_rs1_rs2_edges
         "cmp_rd_rs2_eqval",  # Already covered by cr_rs1_rs2_edges
+        # Covered by edge tests
+        "cp_csr_fflags_n",
+        "cp_csr_fflags_on",
+        "cp_csr_fflags_v",
+        "cp_csr_fflags_vd",
+        "cp_csr_fflags_vdon",
+        "cp_csr_fflags_vdoun",
+        "cp_csr_fflags_vn",
+        "cp_csr_fflags_von",
+        "cp_csr_fflags_voun",
+        "cp_csr_fflags_vun",
+        "cp_fclass",
     }
 )
 

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_align.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_align.py
@@ -9,7 +9,7 @@
 
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
-from testgen.utils.common import load_int_reg, write_sigupd
+from testgen.utils.common import load_int_reg, return_test_regs, write_sigupd
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -90,6 +90,6 @@ def make_align(instr_name: str, instr_type: str, coverpoint: str, test_data: Tes
         else:
             raise ValueError(f"Unknown instruction type: {instr_type} for cp_align.")
 
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_bs.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_bs.py
@@ -11,6 +11,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -29,6 +30,6 @@ def make_cp_bs(instr_name: str, instr_type: str, coverpoint: str, test_data: Tes
         params = generate_random_params(test_data, instr_type, immval=bs)
         desc = f"{coverpoint}: bs={bs}"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_csr_frm.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_csr_frm.py
@@ -1,0 +1,33 @@
+##################################
+# cp_fp_reg_edges.py
+#
+# jcarlin@hmc.edu Dec 2025
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+"""Floating point register edge value coverpoint generators (cp_fs1_edges, cp_fs2_edges, cp_fs3_edges)."""
+
+from testgen.coverpoints.coverpoints import add_coverpoint_generator
+from testgen.data.test_data import TestData
+from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
+from testgen.utils.param_generator import generate_random_params
+
+
+@add_coverpoint_generator("cp_csr_frm")
+def make_frm(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
+    """Generate tests for frm values."""
+    if coverpoint != "cp_csr_frm":
+        raise ValueError(f"Unknown cp_csr_frm coverpoint variant: {coverpoint} for {instr_name}")
+
+    frm_modes = (4, 3, 2, 1, 0)  # csr frm modes 0-4, end at 0 so the rest of the test continues in rne
+    test_lines: list[str] = []
+    for frm_mode in frm_modes:
+        test_data.add_testcase_string(coverpoint)
+        test_lines.append(f"\nfsrmi 0x{frm_mode:x} # set fcsr.frm to mode {frm_mode}\n")
+        params = generate_random_params(test_data, instr_type, exclude_regs=[0])
+        desc = f"{coverpoint} (Test dynamic frm, fcsr.frm = {frm_mode})"
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        return_test_regs(test_data, params)
+
+    return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
@@ -10,12 +10,13 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.edges import FLOAT_EDGES
 from testgen.utils.param_generator import generate_random_params
 
 
 @add_coverpoint_generator("cp_fs1_edges")
-def make_rs1_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
+def make_fs1_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests for fs1 edge values."""
     if coverpoint == "cp_fs1_edges":
         edges = FLOAT_EDGES.single
@@ -29,8 +30,7 @@ def make_rs1_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs1val=edge_val)
         desc = f"{coverpoint} (Test source fs1 value = {test_data.flen_format_str.format(edge_val)})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
-        test_data.float_regs.return_registers(params.used_float_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -50,8 +50,7 @@ def make_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs2val=edge_val)
         desc = f"{coverpoint} (Test source fs2 value = {test_data.flen_format_str.format(edge_val)})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
-        test_data.float_regs.return_registers(params.used_float_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -63,7 +62,7 @@ def make_cr_fs1_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, tes
         edges1 = FLOAT_EDGES.single
         edges2 = FLOAT_EDGES.single
     else:
-        raise ValueError(f"Unknown cr_rs1_rs2_edges coverpoint variant: {coverpoint} for {instr_name}")
+        raise ValueError(f"Unknown cr_fs1_fs2_edges coverpoint variant: {coverpoint} for {instr_name}")
 
     test_lines: list[str] = []
     for edge_val1 in edges1:
@@ -73,7 +72,6 @@ def make_cr_fs1_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, tes
             params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs1val=edge_val1, fs2val=edge_val2)
             desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs2 = {test_data.flen_format_str.format(edge_val2)})"
             test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-            test_data.int_regs.return_registers(params.used_int_regs)
-            test_data.float_regs.return_registers(params.used_float_regs)
+            return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
@@ -18,19 +18,26 @@ from testgen.utils.param_generator import generate_random_params
 @add_coverpoint_generator("cp_fs1_edges")
 def make_fs1_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests for fs1 edge values."""
+    cross_frm = False
     if coverpoint == "cp_fs1_edges":
         edges = FLOAT_EDGES.single
+    elif coverpoint == "cp_fs1_edges_frm":
+        edges = FLOAT_EDGES.single
+        cross_frm = True
     else:
         raise ValueError(f"Unknown cp_fs1_edges coverpoint variant: {coverpoint} for {instr_name}")
 
+    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
+
     test_lines: list[str] = []
     for edge_val in edges:
-        test_data.add_testcase_string(coverpoint)
-        test_lines.append("")
-        params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs1val=edge_val)
-        desc = f"{coverpoint} (Test source fs1 value = {test_data.flen_format_str.format(edge_val)})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        return_test_regs(test_data, params)
+        for frm_mode in frm_modes:
+            test_data.add_testcase_string(coverpoint)
+            test_lines.append("")
+            params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs1val=edge_val, frm=frm_mode)
+            desc = f"{coverpoint} (Test source fs1 value = {test_data.flen_format_str.format(edge_val)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+            test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+            return_test_regs(test_data, params)
 
     return test_lines
 
@@ -55,23 +62,21 @@ def make_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
     return test_lines
 
 
-@add_coverpoint_generator("cr_fs1_fs2_edges")
-def make_cr_fs1_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
-    """Generate tests for cross-product of rs1 and rs2 edge values."""
-    if coverpoint == "cr_fs1_fs2_edges":
-        edges1 = FLOAT_EDGES.single
-        edges2 = FLOAT_EDGES.single
+@add_coverpoint_generator("cp_fs3_edges")
+def make_fs3_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
+    """Generate tests for fs3 edge values."""
+    if coverpoint == "cp_fs3_edges":
+        edges = FLOAT_EDGES.single
     else:
-        raise ValueError(f"Unknown cr_fs1_fs2_edges coverpoint variant: {coverpoint} for {instr_name}")
+        raise ValueError(f"Unknown cp_fs3_edges coverpoint variant: {coverpoint} for {instr_name}")
 
     test_lines: list[str] = []
-    for edge_val1 in edges1:
-        for edge_val2 in edges2:
-            test_data.add_testcase_string(coverpoint)
-            test_lines.append("")
-            params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs1val=edge_val1, fs2val=edge_val2)
-            desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs2 = {test_data.flen_format_str.format(edge_val2)})"
-            test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-            return_test_regs(test_data, params)
+    for edge_val in edges:
+        test_data.add_testcase_string(coverpoint)
+        test_lines.append("")
+        params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs3val=edge_val)
+        desc = f"{coverpoint} (Test source fs3 value = {test_data.flen_format_str.format(edge_val)})"
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_fp_regs.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_fp_regs.py
@@ -10,6 +10,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -38,8 +39,7 @@ def make_fd(instr_name: str, instr_type: str, coverpoint: str, test_data: TestDa
                 format_single_test(instr_name, instr_type, test_data, params, desc),
             ]
         )
-        test_data.int_regs.return_registers(params.used_int_regs)
-        test_data.float_regs.return_registers(params.used_float_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -69,8 +69,7 @@ def make_fs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
                 format_single_test(instr_name, instr_type, test_data, params, desc),
             ]
         )
-        test_data.int_regs.return_registers(params.used_int_regs)
-        test_data.float_regs.return_registers(params.used_float_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -100,8 +99,7 @@ def make_fs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
                 format_single_test(instr_name, instr_type, test_data, params, desc),
             ]
         )
-        test_data.int_regs.return_registers(params.used_int_regs)
-        test_data.float_regs.return_registers(params.used_float_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -131,7 +129,6 @@ def make_fs3(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
                 format_single_test(instr_name, instr_type, test_data, params, desc),
             ]
         )
-        test_data.int_regs.return_registers(params.used_int_regs)
-        test_data.float_regs.return_registers(params.used_float_regs)
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_frm.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_frm.py
@@ -1,0 +1,33 @@
+##################################
+# cp_fp_reg_edges.py
+#
+# jcarlin@hmc.edu Dec 2025
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+"""Floating point register edge value coverpoint generators (cp_fs1_edges, cp_fs2_edges, cp_fs3_edges)."""
+
+from testgen.coverpoints.coverpoints import add_coverpoint_generator
+from testgen.data.test_data import TestData
+from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
+from testgen.utils.param_generator import generate_random_params
+
+
+@add_coverpoint_generator("cp_frm")
+def make_frm(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
+    """Generate tests for frm values."""
+    if coverpoint not in ["cp_frm_3"]:
+        raise ValueError(f"Unknown cp_frm coverpoint variant: {coverpoint} for {instr_name}")
+
+    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup")
+    test_lines: list[str] = []
+    for frm_mode in frm_modes:
+        test_data.add_testcase_string(coverpoint)
+        test_lines.append("")
+        params = generate_random_params(test_data, instr_type, exclude_regs=[0], frm=frm_mode)
+        desc = f"{coverpoint} (Test frm, mode = {frm_mode})"
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        return_test_regs(test_data, params)
+
+    return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_frm.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_frm.py
@@ -17,7 +17,7 @@ from testgen.utils.param_generator import generate_random_params
 @add_coverpoint_generator("cp_frm")
 def make_frm(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests for frm values."""
-    if coverpoint not in ["cp_frm_3"]:
+    if coverpoint not in ["cp_frm_2", "cp_frm_3", "cp_frm_4"]:  # TODO: Why are these variants needed?
         raise ValueError(f"Unknown cp_frm coverpoint variant: {coverpoint} for {instr_name}")
 
     frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup")

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_imm_edges.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_imm_edges.py
@@ -11,7 +11,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
-from testgen.utils.common import load_int_reg, write_sigupd
+from testgen.utils.common import load_int_reg, return_test_regs, write_sigupd
 from testgen.utils.edges import IMMEDIATE_EDGES
 from testgen.utils.param_generator import generate_random_params
 
@@ -38,7 +38,7 @@ def make_cp_imm_edges(instr_name: str, instr_type: str, coverpoint: str, test_da
         params = generate_random_params(test_data, instr_type, immval=edge_val, exclude_regs=[0])
         desc = f"{coverpoint} (imm = {edge_val})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -91,7 +91,7 @@ def make_cp_imm_edges_branch(instr_name: str, instr_type: str, coverpoint: str, 
             write_sigupd(params.rs1, test_data),  # success code
         ]
     )
-    test_data.int_regs.return_registers(params.used_int_regs)
+    return_test_regs(test_data, params)
     return test_lines
 
 
@@ -234,5 +234,5 @@ def make_cp_imm_edges_jal(instr_name: str, instr_type: str, coverpoint: str, tes
         ]
     )
 
-    test_data.int_regs.return_registers(params.used_int_regs)
+    return_test_regs(test_data, params)
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_imm_mul.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_imm_mul.py
@@ -10,6 +10,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -39,6 +40,6 @@ def make_cp_uimm(instr_name: str, instr_type: str, coverpoint: str, test_data: T
         params = generate_random_params(test_data, instr_type, immval=imm, exclude_regs=exclude_regs)
         desc = f"{coverpoint}: imm={imm}"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_memval.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_memval.py
@@ -10,6 +10,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.edges import MEMORY_EDGES
 from testgen.utils.param_generator import generate_random_params
 
@@ -40,6 +41,6 @@ def make_memval(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
             raise ValueError(f"cp_memval coverpoint not supported for instruction type: {instr_type} in {instr_name}")
         desc = f"{coverpoint} (memory value = {val:#x})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_offset.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_offset.py
@@ -9,7 +9,7 @@
 
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
-from testgen.utils.common import write_sigupd
+from testgen.utils.common import return_test_regs, write_sigupd
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -84,7 +84,7 @@ def make_offset(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
         test_data.int_regs.return_register(temp_reg)
 
     test_data.int_regs.return_register(check_reg)
-    test_data.int_regs.return_registers(params.used_int_regs)
+    return_test_regs(test_data, params)
 
     if coverpoint == "cp_offset_jalr":
         test_lines.extend(make_offset_lsbs(instr_name, instr_type, coverpoint, test_data))
@@ -119,7 +119,7 @@ def make_offset_j(instr_name: str, instr_type: str, coverpoint: str, test_data: 
         write_sigupd(check_reg, test_data),
     ]
     test_data.int_regs.return_register(check_reg)
-    test_data.int_regs.return_registers(params.used_int_regs)
+    return_test_regs(test_data, params)
     return test_lines
 
 
@@ -189,6 +189,6 @@ def make_offset_lsbs(instr_name: str, instr_type: str, coverpoint: str, test_dat
             ]
         )
 
-    test_data.int_regs.return_registers(params.used_int_regs)
+    return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_rbox.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_rbox.py
@@ -10,6 +10,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -28,6 +29,6 @@ def make_cp_rnum(instr_name: str, instr_type: str, coverpoint: str, test_data: T
         params = generate_random_params(test_data, instr_type, immval=rnum)
         desc = f"{coverpoint}: rnum={rnum}"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_reg_edges.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_reg_edges.py
@@ -10,7 +10,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
-from testgen.utils.common import load_int_reg, write_sigupd
+from testgen.utils.common import load_int_reg, return_test_regs, write_sigupd
 from testgen.utils.edges import get_general_edges, get_orcb_edges
 from testgen.utils.param_generator import generate_random_params
 
@@ -32,7 +32,7 @@ def make_rs1_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs1val=edge_val)
         desc = f"{coverpoint} (Test source rs1 value = {test_data.xlen_format_str.format(edge_val)})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -52,7 +52,7 @@ def make_rs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs2val=edge_val)
         desc = f"{coverpoint} (Test source rs2 value = {test_data.xlen_format_str.format(edge_val)})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -74,7 +74,7 @@ def make_cr_rs1_rs2_edges(instr_name: str, instr_type: str, coverpoint: str, tes
             params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs1val=edge_val1, rs2val=edge_val2)
             desc = f"{coverpoint} (Test source rs1 = {test_data.xlen_format_str.format(edge_val1)} rs2 = {test_data.xlen_format_str.format(edge_val2)})"
             test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-            test_data.int_regs.return_registers(params.used_int_regs)
+            return_test_regs(test_data, params)
 
     return test_lines
 
@@ -113,6 +113,6 @@ def make_cr_rs1_rs2_edges_offset(instr_name: str, instr_type: str, coverpoint: s
                     "4: # done with test",
                 ]
             )
-            test_data.int_regs.return_registers(params.used_int_regs)
+            return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_regs.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_regs.py
@@ -10,6 +10,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -35,7 +36,7 @@ def make_rd(instr_name: str, instr_type: str, coverpoint: str, test_data: TestDa
         params = generate_random_params(test_data, instr_type, rd=rd)
         desc = f"{coverpoint} (Test destination rd = x{rd})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -65,7 +66,7 @@ def make_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
         params = generate_random_params(test_data, instr_type, rs1=rs1)
         desc = f"{coverpoint} (Test source rs1 = x{rs1})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines
 
@@ -92,6 +93,6 @@ def make_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
         params = generate_random_params(test_data, instr_type, rs2=rs2)
         desc = f"{coverpoint} (Test source rs2 = x{rs2})"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_sbox.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_sbox.py
@@ -10,6 +10,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -34,6 +35,6 @@ def make_cp_sbox(instr_name: str, instr_type: str, coverpoint: str, test_data: T
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs1val=s, rs2val=s)
         desc = f"{coverpoint} = {sbox}"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cp_uimm.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cp_uimm.py
@@ -10,6 +10,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.param_generator import generate_random_params
 
 
@@ -32,6 +33,6 @@ def make_cp_uimm(instr_name: str, instr_type: str, coverpoint: str, test_data: T
         params = generate_random_params(test_data, instr_type, immval=uimm)
         desc = f"{coverpoint}: imm={uimm}"
         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-        test_data.int_regs.return_registers(params.used_int_regs)
+        return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cr_fp_reg_edges.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cr_fp_reg_edges.py
@@ -1,0 +1,57 @@
+##################################
+# cp_fp_reg_edges.py
+#
+# jcarlin@hmc.edu Dec 2025
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+"""Floating point cross-product register edge value coverpoint generators (cr_fs1_fs2_edges, cr_fs1_fs2_edges_frm, etc.)."""
+
+from testgen.coverpoints.coverpoints import add_coverpoint_generator
+from testgen.data.test_data import TestData
+from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
+from testgen.utils.edges import FLOAT_EDGES
+from testgen.utils.param_generator import generate_random_params
+
+
+@add_coverpoint_generator("cr_fs1_fs2_edges")
+def make_cr_fs1_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
+    """Generate tests for cross-product of fs1 and fs2 edge values."""
+    cross_frm = False
+    if coverpoint == "cr_fs1_fs2_edges":
+        edges1 = FLOAT_EDGES.single
+        edges2 = FLOAT_EDGES.single
+    elif coverpoint == "cr_fs1_fs2_edges_frm":
+        edges1 = FLOAT_EDGES.single
+        edges2 = FLOAT_EDGES.single
+        cross_frm = True
+    else:
+        raise ValueError(f"Unknown cr_fs1_fs2_edges coverpoint variant: {coverpoint} for {instr_name}")
+
+    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
+
+    test_lines: list[str] = []
+    for edge_val1 in edges1:
+        for edge_val2 in edges2:
+            # Explicit rounding modes (if needed)
+            for frm_mode in frm_modes:
+                test_data.add_testcase_string(coverpoint)
+                test_lines.append("")
+                params = generate_random_params(
+                    test_data, instr_type, exclude_regs=[0], fs1val=edge_val1, fs2val=edge_val2, frm=frm_mode
+                )
+                desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs2 = {test_data.flen_format_str.format(edge_val2)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+                test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+                return_test_regs(test_data, params)
+            # Dynamic rounding modes
+            # if cross_frm:
+            #     for frm_mode in (4, 3, 2, 1, 0):  # csr frm modes 0-4, end at 0 so the rest of the test continues in rne
+            #         test_data.add_testcase_string(coverpoint)
+            #         test_lines.append(f"\nfsrmi 0x{frm_mode:x} # set fcsr.frm to mode {frm_mode}\n")
+            #         params = generate_random_params(test_data, instr_type, exclude_regs=[0])
+            #         desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs2 = {test_data.flen_format_str.format(edge_val2)}, fcsr.frm = {frm_mode})"
+            #         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+            #         return_test_regs(test_data, params)
+
+    return test_lines

--- a/generators/tests/testgen/src/testgen/coverpoints/cr_fp_reg_edges.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cr_fp_reg_edges.py
@@ -22,7 +22,7 @@ def make_cr_fs1_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, tes
     if coverpoint == "cr_fs1_fs2_edges":
         edges1 = FLOAT_EDGES.single
         edges2 = FLOAT_EDGES.single
-    elif coverpoint == "cr_fs1_fs2_edges_frm":
+    elif coverpoint == "cr_fs1_fs2_edges_frm" or coverpoint == "cr_fs1_fs2_edges_frm4":
         edges1 = FLOAT_EDGES.single
         edges2 = FLOAT_EDGES.single
         cross_frm = True
@@ -51,6 +51,52 @@ def make_cr_fs1_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, tes
             #         test_lines.append(f"\nfsrmi 0x{frm_mode:x} # set fcsr.frm to mode {frm_mode}\n")
             #         params = generate_random_params(test_data, instr_type, exclude_regs=[0])
             #         desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs2 = {test_data.flen_format_str.format(edge_val2)}, fcsr.frm = {frm_mode})"
+            #         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+            #         return_test_regs(test_data, params)
+
+    return test_lines
+
+
+@add_coverpoint_generator("cr_fs1_fs3_edges")
+def make_cr_fs1_fs3_edges(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
+    """Generate tests for cross-product of fs1 and fs3 edge values."""
+    cross_frm = False
+    if coverpoint == "cr_fs1_fs3_edges":
+        edges1 = FLOAT_EDGES.single
+        edges2 = FLOAT_EDGES.single
+    elif coverpoint == "cr_fs1_fs3_edges_frm" or coverpoint == "cr_fs1_fs3_edges_frm4":
+        edges1 = FLOAT_EDGES.single
+        edges2 = FLOAT_EDGES.single
+        cross_frm = True
+    else:
+        raise ValueError(f"Unknown cr_fs1_fs3_edges coverpoint variant: {coverpoint} for {instr_name}")
+
+    return [
+        "# TODO: Including this coverpoint makes the test too long for the linker. Need to split the test into multiple files."
+    ]
+
+    frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup") if cross_frm else [None]
+
+    test_lines: list[str] = []
+    for edge_val1 in edges1:
+        for edge_val2 in edges2:
+            # Explicit rounding modes (if needed)
+            for frm_mode in frm_modes:
+                test_data.add_testcase_string(coverpoint)
+                test_lines.append("")
+                params = generate_random_params(
+                    test_data, instr_type, exclude_regs=[0], fs1val=edge_val1, fs3val=edge_val2, frm=frm_mode
+                )
+                desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs3 = {test_data.flen_format_str.format(edge_val2)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
+                test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+                return_test_regs(test_data, params)
+            # Dynamic rounding modes
+            # if cross_frm:
+            #     for frm_mode in (4, 3, 2, 1, 0):  # csr frm modes 0-4, end at 0 so the rest of the test continues in rne
+            #         test_data.add_testcase_string(coverpoint)
+            #         test_lines.append(f"\nfsrmi 0x{frm_mode:x} # set fcsr.frm to mode {frm_mode}\n")
+            #         params = generate_random_params(test_data, instr_type, exclude_regs=[0])
+            #         desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs3 = {test_data.flen_format_str.format(edge_val2)}, fcsr.frm = {frm_mode})"
             #         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
             #         return_test_regs(test_data, params)
 

--- a/generators/tests/testgen/src/testgen/coverpoints/cr_rs1_imm_edges.py
+++ b/generators/tests/testgen/src/testgen/coverpoints/cr_rs1_imm_edges.py
@@ -10,6 +10,7 @@
 from testgen.coverpoints.coverpoints import add_coverpoint_generator
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters import format_single_test
+from testgen.utils.common import return_test_regs
 from testgen.utils.edges import IMMEDIATE_EDGES, get_general_edges
 from testgen.utils.param_generator import generate_random_params
 
@@ -44,6 +45,6 @@ def make_cr_rs1_imm_edges(instr_name: str, instr_type: str, coverpoint: str, tes
             )
             desc = f"{coverpoint} (rs1 = {test_data.xlen_format_str.format(reg_edge_val)}, imm = {imm_edge_val})"
             test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-            test_data.int_regs.return_registers(params.used_int_regs)
+            return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/tests/testgen/src/testgen/data/params.py
+++ b/generators/tests/testgen/src/testgen/data/params.py
@@ -51,7 +51,7 @@ class InstructionParams:
     immval: int | None = None
 
     # Flags
-    frm: bool = False  # Floating-point rounding mode tests
+    frm: str | None = None  # Floating-point rounding mode tests
     aqrl: str = ""  # Acquire/Release for atomic operations
 
     @property

--- a/generators/tests/testgen/src/testgen/data/params.py
+++ b/generators/tests/testgen/src/testgen/data/params.py
@@ -46,6 +46,7 @@ class InstructionParams:
     fs2val: int | None = None
     fs3val: int | None = None
     fdval: int | None = None
+    temp_fval: int | None = None
 
     # Immediate value
     immval: int | None = None

--- a/generators/tests/testgen/src/testgen/instruction_formatters/f2x_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/f2x_type.py
@@ -1,5 +1,5 @@
 ##################################
-# fr_type.py
+# f2x_type.py
 #
 # jcarlin@hmc.edu Dec 2025
 # SPDX-License-Identifier: Apache-2.0
@@ -11,22 +11,20 @@ from testgen.instruction_formatters.instruction_formatters import add_instructio
 from testgen.utils.common import load_float_reg, write_sigupd
 
 
-@add_instruction_formatter("FR", required_params={"fd", "fs1", "fs1val", "fs2", "fs2val"})
-def format_fr_type(
+@add_instruction_formatter("F2X", required_params={"rd", "fs1", "fs1val"})
+def format_f2x_type(
     instr_name: str, test_data: TestData, params: InstructionParams
 ) -> tuple[list[str], list[str], list[str]]:
-    """Format FR-type instruction."""
+    """Format F2X-type instruction."""
     assert params.fs1 is not None and params.fs1val is not None
-    assert params.fs2 is not None and params.fs2val is not None
-    assert params.fd is not None
+    assert params.rd is not None
     frm = f", {params.frm}" if params.frm is not None else ""
     setup = [
         load_float_reg("fs1", params.fs1, params.fs1val, test_data),
-        load_float_reg("fs2", params.fs2, params.fs2val, test_data),
         "fsflagsi 0b00000 # clear all fflags",
     ]
     test = [
-        f"{instr_name} f{params.fd}, f{params.fs1}, f{params.fs2}{frm} # perform operation",
+        f"{instr_name} x{params.rd}, f{params.fs1}{frm} # perform operation",
     ]
-    check = [write_sigupd(params.fd, test_data, "float")]
+    check = [write_sigupd(params.rd, test_data)]
     return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/instruction_formatters/fc_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/fc_type.py
@@ -1,5 +1,5 @@
 ##################################
-# fr_type.py
+# fc_type.py
 #
 # jcarlin@hmc.edu Dec 2025
 # SPDX-License-Identifier: Apache-2.0
@@ -11,22 +11,21 @@ from testgen.instruction_formatters.instruction_formatters import add_instructio
 from testgen.utils.common import load_float_reg, write_sigupd
 
 
-@add_instruction_formatter("FR", required_params={"fd", "fs1", "fs1val", "fs2", "fs2val"})
-def format_fr_type(
+@add_instruction_formatter("FC", required_params={"rd", "fs1", "fs1val", "fs2", "fs2val"})
+def format_fc_type(
     instr_name: str, test_data: TestData, params: InstructionParams
 ) -> tuple[list[str], list[str], list[str]]:
-    """Format FR-type instruction."""
+    """Format FC-type instruction."""
     assert params.fs1 is not None and params.fs1val is not None
     assert params.fs2 is not None and params.fs2val is not None
-    assert params.fd is not None
-    frm = f", {params.frm}" if params.frm is not None else ""
+    assert params.rd is not None
     setup = [
         load_float_reg("fs1", params.fs1, params.fs1val, test_data),
         load_float_reg("fs2", params.fs2, params.fs2val, test_data),
         "fsflagsi 0b00000 # clear all fflags",
     ]
     test = [
-        f"{instr_name} f{params.fd}, f{params.fs1}, f{params.fs2}{frm} # perform operation",
+        f"{instr_name} x{params.rd}, f{params.fs1}, f{params.fs2} # perform operation",
     ]
-    check = [write_sigupd(params.fd, test_data, "float")]
+    check = [write_sigupd(params.rd, test_data)]
     return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/instruction_formatters/fi_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/fi_type.py
@@ -1,5 +1,5 @@
 ##################################
-# fr_type.py
+# fi_type.py
 #
 # jcarlin@hmc.edu Dec 2025
 # SPDX-License-Identifier: Apache-2.0
@@ -11,22 +11,20 @@ from testgen.instruction_formatters.instruction_formatters import add_instructio
 from testgen.utils.common import load_float_reg, write_sigupd
 
 
-@add_instruction_formatter("FR", required_params={"fd", "fs1", "fs1val", "fs2", "fs2val"})
-def format_fr_type(
+@add_instruction_formatter("FI", required_params={"fd", "fs1", "fs1val"})
+def format_fi_type(
     instr_name: str, test_data: TestData, params: InstructionParams
 ) -> tuple[list[str], list[str], list[str]]:
-    """Format FR-type instruction."""
+    """Format FI-type instruction."""
     assert params.fs1 is not None and params.fs1val is not None
-    assert params.fs2 is not None and params.fs2val is not None
     assert params.fd is not None
     frm = f", {params.frm}" if params.frm is not None else ""
     setup = [
         load_float_reg("fs1", params.fs1, params.fs1val, test_data),
-        load_float_reg("fs2", params.fs2, params.fs2val, test_data),
         "fsflagsi 0b00000 # clear all fflags",
     ]
     test = [
-        f"{instr_name} f{params.fd}, f{params.fs1}, f{params.fs2}{frm} # perform operation",
+        f"{instr_name} f{params.fd}, f{params.fs1}{frm} # perform operation",
     ]
     check = [write_sigupd(params.fd, test_data, "float")]
     return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/instruction_formatters/fix_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/fix_type.py
@@ -1,7 +1,7 @@
 ##################################
-# fr_type.py
+# fix_type.py
 #
-# jcarlin@hmc.edu Oct 2025
+# jcarlin@hmc.edu Dec 2025
 # SPDX-License-Identifier: Apache-2.0
 ##################################
 
@@ -11,22 +11,19 @@ from testgen.instruction_formatters.instruction_formatters import add_instructio
 from testgen.utils.common import load_float_reg, write_sigupd
 
 
-@add_instruction_formatter("FR", required_params={"fd", "fs1", "fs1val", "fs2", "fs2val"})
-def format_fr_type(
+@add_instruction_formatter("FIX", required_params={"rd", "fs1", "fs1val"})
+def format_fix_type(
     instr_name: str, test_data: TestData, params: InstructionParams
 ) -> tuple[list[str], list[str], list[str]]:
-    """Format FR-type instruction."""
+    """Format FIX-type instruction."""
     assert params.fs1 is not None and params.fs1val is not None
-    assert params.fs2 is not None and params.fs2val is not None
-    assert params.fd is not None
-    frm = f", {params.frm}" if params.frm is not None else ""
+    assert params.rd is not None
     setup = [
         load_float_reg("fs1", params.fs1, params.fs1val, test_data),
-        load_float_reg("fs2", params.fs2, params.fs2val, test_data),
         "fsflagsi 0b00000 # clear all fflags",
     ]
     test = [
-        f"{instr_name} f{params.fd}, f{params.fs1}, f{params.fs2}{frm} # perform operation",
+        f"{instr_name} x{params.rd}, f{params.fs1} # perform operation",
     ]
-    check = [write_sigupd(params.fd, test_data, "float")]
+    check = [write_sigupd(params.rd, test_data)]
     return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/instruction_formatters/fl_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/fl_type.py
@@ -1,0 +1,57 @@
+##################################
+# fl_type.py
+#
+# jcarlin@hmc.edu Dec 2025
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+from testgen.data.params import InstructionParams
+from testgen.data.test_data import TestData
+from testgen.instruction_formatters.instruction_formatters import add_instruction_formatter
+from testgen.utils.common import to_hex, write_sigupd
+
+
+@add_instruction_formatter(
+    "FL", required_params={"fd", "rs1", "temp_fval", "immval", "temp_reg"}, imm_bits=12, imm_signed=True
+)
+def format_fl_type(
+    instr_name: str, test_data: TestData, params: InstructionParams
+) -> tuple[list[str], list[str], list[str]]:
+    """Format FL-type instruction."""
+    assert params.rs1 is not None, "rs1 must be provided for FL-type instruction"
+    assert params.fd is not None, "fd must be provided for FL-type instruction"
+    assert params.immval is not None and params.temp_fval is not None, (
+        "immval and temp_fval must be provided for FL-type instruction"
+    )
+
+    # Add value to load data region
+    test_data.add_test_data_value(params.temp_fval)
+
+    # Ensure rs1 is not x0 (base address)
+    if params.rs1 == 0:
+        test_data.int_regs.return_register(params.rs1)
+        params.rs1 = test_data.int_regs.get_register(exclude_regs=[0])
+
+    setup: list[str] = []
+
+    # Handle special case where offset is -2048 (can't represent +2048 in 12 bits)
+    if params.immval == -2048:
+        setup.extend(
+            [
+                f"addi x{params.rs1}, x{test_data.int_regs.data_reg}, 2047 # copy data_ptr to rs1 and increment by 2047",
+                f"addi x{params.rs1}, x{params.rs1}, 1    # increment by 1 more for total +2048 offset",
+            ]
+        )
+    else:
+        setup.append(
+            f"addi x{params.rs1}, x{test_data.int_regs.data_reg}, {-params.immval} # copy data_ptr to rs1 and adjust for offset"
+        )
+
+    test = [
+        f"{instr_name} f{params.fd}, {params.immval}(x{params.rs1}) # perform load ({to_hex(params.temp_fval, test_data.flen)})",
+    ]
+    check = [
+        write_sigupd(params.fd, test_data, "float"),
+        f"addi x{test_data.int_regs.data_reg}, x{test_data.int_regs.data_reg}, SIG_STRIDE # increment data_ptr",
+    ]
+    return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/instruction_formatters/fr4_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/fr4_type.py
@@ -1,5 +1,5 @@
 ##################################
-# fr_type.py
+# fr4_type.py
 #
 # jcarlin@hmc.edu Dec 2025
 # SPDX-License-Identifier: Apache-2.0
@@ -11,22 +11,24 @@ from testgen.instruction_formatters.instruction_formatters import add_instructio
 from testgen.utils.common import load_float_reg, write_sigupd
 
 
-@add_instruction_formatter("FR", required_params={"fd", "fs1", "fs1val", "fs2", "fs2val"})
-def format_fr_type(
+@add_instruction_formatter("FR4", required_params={"fd", "fs1", "fs1val", "fs2", "fs2val", "fs3", "fs3val"})
+def format_fr4_type(
     instr_name: str, test_data: TestData, params: InstructionParams
 ) -> tuple[list[str], list[str], list[str]]:
-    """Format FR-type instruction."""
+    """Format FR4-type instruction."""
     assert params.fs1 is not None and params.fs1val is not None
     assert params.fs2 is not None and params.fs2val is not None
+    assert params.fs3 is not None and params.fs3val is not None
     assert params.fd is not None
     frm = f", {params.frm}" if params.frm is not None else ""
     setup = [
         load_float_reg("fs1", params.fs1, params.fs1val, test_data),
         load_float_reg("fs2", params.fs2, params.fs2val, test_data),
+        load_float_reg("fs3", params.fs3, params.fs3val, test_data),
         "fsflagsi 0b00000 # clear all fflags",
     ]
     test = [
-        f"{instr_name} f{params.fd}, f{params.fs1}, f{params.fs2}{frm} # perform operation",
+        f"{instr_name} f{params.fd}, f{params.fs1}, f{params.fs2}, f{params.fs3}{frm} # perform operation",
     ]
     check = [write_sigupd(params.fd, test_data, "float")]
     return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/instruction_formatters/fs_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/fs_type.py
@@ -1,29 +1,29 @@
 ##################################
-# s_type.py
+# fs_type.py
 #
-# jcarlin@hmc.edu Oct 2025
+# jcarlin@hmc.edu Dec 2025
 # SPDX-License-Identifier: Apache-2.0
 ##################################
 
 from testgen.data.params import InstructionParams
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters.instruction_formatters import add_instruction_formatter
-from testgen.utils.common import load_int_reg, write_sigupd
+from testgen.utils.common import load_float_reg, write_sigupd
 
 
 @add_instruction_formatter(
-    "S", required_params={"temp_reg", "rs1", "rs1val", "rs2", "rs2val", "immval"}, imm_bits=12, imm_signed=True
+    "FS", required_params={"temp_reg", "rs1", "rs1val", "fs2", "fs2val", "immval"}, imm_bits=12, imm_signed=True
 )
-def format_s_type(
+def format_fs_type(
     instr_name: str, test_data: TestData, params: InstructionParams
 ) -> tuple[list[str], list[str], list[str]]:
-    """Format S-type instruction."""
-    assert params.rs1 is not None, "rs1 must be provided for S-type instructions"
-    assert params.rs2 is not None and params.rs2val is not None, (
-        "rs2 and rs2val must be provided for S-type instructions"
+    """Format FS-type instruction."""
+    assert params.rs1 is not None, "rs1 must be provided for FS-type instructions"
+    assert params.fs2 is not None and params.fs2val is not None, (
+        "fs2 and fs2val must be provided for FS-type instructions"
     )
-    assert params.temp_reg is not None, "temp_reg must be provided for S-type instructions"
-    assert params.immval is not None, "immval must be provided for S-type instructions"
+    assert params.temp_reg is not None, "temp_reg must be provided for FS-type instructions"
+    assert params.immval is not None, "immval must be provided for FS-type instructions"
 
     # Ensure rs1 is not x0 (base address)
     if params.rs1 == 0:
@@ -32,7 +32,7 @@ def format_s_type(
 
     # load test value
     setup = [
-        load_int_reg("rs2", params.rs2, params.rs2val, test_data),
+        load_float_reg("fs2", params.fs2, params.fs2val, test_data),
     ]
 
     # Move sig_reg to rs1
@@ -55,7 +55,7 @@ def format_s_type(
     else:
         setup.append(f"addi x{sig_reg}, x{sig_reg}, {-params.immval} # adjust base address for offset")
 
-    test = [f"{instr_name} x{params.rs2}, {params.immval}(x{sig_reg}) # perform store"]
+    test = [f"{instr_name} f{params.fs2}, {params.immval}(x{sig_reg}) # perform store"]
     check = [
         f"addi x{sig_reg}, x{sig_reg}, {params.immval} # restore base address",
         f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # increment signature pointer",
@@ -63,7 +63,7 @@ def format_s_type(
         f"LREG x{params.temp_reg}, -SIG_STRIDE(x{sig_reg}) # load stored value for checking",
         write_sigupd(params.temp_reg, test_data),
         "#else",
-        f"{instr_name} x{params.rs2}, 0(x{sig_reg}) # repeat store so it is available for checking",
+        f"{instr_name} f{params.fs2}, 0(x{sig_reg}) # repeat store so it is available for checking",
         f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # adjust base address for offset",
         "# nops to ensure length matches SELFCHECK",
         "nop",

--- a/generators/tests/testgen/src/testgen/instruction_formatters/jr_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/jr_type.py
@@ -8,7 +8,7 @@
 from testgen.data.params import InstructionParams
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters.instruction_formatters import add_instruction_formatter
-from testgen.utils.common import write_sigupd
+from testgen.utils.common import return_test_regs, write_sigupd
 
 
 @add_instruction_formatter("JR", required_params={"rd", "rs1", "rs2", "immval"}, imm_bits=12, imm_signed=True)
@@ -54,5 +54,5 @@ def format_jr_type(
         write_sigupd(params.rs2, test_data, "int"),
     ]
     test_data.int_regs.return_register(temp_reg)
-    test_data.int_regs.return_registers(params.used_int_regs)
+    return_test_regs(test_data, params)
     return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/instruction_formatters/x2f_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/x2f_type.py
@@ -1,5 +1,5 @@
 ##################################
-# fr_type.py
+# x2f_type.py
 #
 # jcarlin@hmc.edu Dec 2025
 # SPDX-License-Identifier: Apache-2.0
@@ -8,25 +8,23 @@
 from testgen.data.params import InstructionParams
 from testgen.data.test_data import TestData
 from testgen.instruction_formatters.instruction_formatters import add_instruction_formatter
-from testgen.utils.common import load_float_reg, write_sigupd
+from testgen.utils.common import load_int_reg, write_sigupd
 
 
-@add_instruction_formatter("FR", required_params={"fd", "fs1", "fs1val", "fs2", "fs2val"})
-def format_fr_type(
+@add_instruction_formatter("X2F", required_params={"fd", "rs1", "rs1val"})
+def format_x2f_type(
     instr_name: str, test_data: TestData, params: InstructionParams
 ) -> tuple[list[str], list[str], list[str]]:
-    """Format FR-type instruction."""
-    assert params.fs1 is not None and params.fs1val is not None
-    assert params.fs2 is not None and params.fs2val is not None
+    """Format X2F-type instruction."""
+    assert params.rs1 is not None and params.rs1val is not None
     assert params.fd is not None
     frm = f", {params.frm}" if params.frm is not None else ""
     setup = [
-        load_float_reg("fs1", params.fs1, params.fs1val, test_data),
-        load_float_reg("fs2", params.fs2, params.fs2val, test_data),
+        load_int_reg("rs1", params.rs1, params.rs1val, test_data),
         "fsflagsi 0b00000 # clear all fflags",
     ]
     test = [
-        f"{instr_name} f{params.fd}, f{params.fs1}, f{params.fs2}{frm} # perform operation",
+        f"{instr_name} f{params.fd}, x{params.rs1}{frm} # perform operation",
     ]
     check = [write_sigupd(params.fd, test_data, "float")]
     return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/utils/common.py
+++ b/generators/tests/testgen/src/testgen/utils/common.py
@@ -104,7 +104,7 @@ def generate_test_data_section(test_data: TestData) -> str:
     lines: list[str] = []
 
     # Use .word for 32-bit, .dword for 64-bit
-    directive = ".word" if max(test_data.xlen, test_data.flen) == 32 else ".dword"
+    directive = ".word" if max(test_data.xlen, test_data.flen) == 32 else ".dword"  # TODO: handle Q extension
 
     for value in test_data.test_data_values:
         hex_value = to_hex(value, test_data.xlen)

--- a/generators/tests/testgen/src/testgen/utils/common.py
+++ b/generators/tests/testgen/src/testgen/utils/common.py
@@ -11,6 +11,7 @@ Common utilities for riscv-arch-test test generation.
 
 from typing import Literal
 
+from testgen.data.params import InstructionParams
 from testgen.data.test_data import TestData
 
 
@@ -51,13 +52,16 @@ def write_sigupd(check_reg: int, test_data: TestData, sig_type: Literal["int", "
     if sig_type == "int":
         test_data.sigupd_count += 1
         return (
-            f"# Check if x{check_reg} contains the expected result. x{sig_reg} is the signature ptr, x{link_reg} is the link ptr, x{temp_reg} is a temp reg.\n"
+            f"# Check if x{check_reg} contains the expected result. x{sig_reg} is the signature ptr, "
+            + f"x{link_reg} is the link ptr, x{temp_reg} is a temp reg.\n"
             + f'RVTEST_SIGUPD(x{sig_reg}, x{link_reg}, x{temp_reg}, x{check_reg}, "test_{test_data.test_count}")'
         )
     elif sig_type == "float":
         test_data.sigupd_count += 2
         return (
-            f"# Check if f{check_reg} contains the expected result. Also checks fflags. x{sig_reg} is the signature ptr, x{link_reg} is the link ptr, x{temp_reg} is a temp reg.\n"
+            f"# Check if f{check_reg} contains the expected result. Also checks fflags. "
+            + f"x{sig_reg} is the signature ptr, x{link_reg} is the link ptr, x{temp_reg} "
+            + f"is a temp reg, f{fp_temp_reg} is a floating point temp reg.\n"
             + f'RVTEST_SIGUPD_F(x{sig_reg}, x{link_reg}, x{temp_reg}, f{fp_temp_reg}, f{check_reg}, "test_{test_data.test_count}")'
         )
 
@@ -127,3 +131,15 @@ def generate_test_data_string_section(test_data: TestData) -> str:
     lines.extend(test_data.test_data_strings)
 
     return "\n".join(lines)
+
+
+def return_test_regs(test_data: TestData, params: InstructionParams) -> None:
+    """
+    Return all registers used in a test case back to the pool.
+
+    Args:
+        test_data: TestData object managing the registers
+        params: InstructionParams object containing used registers
+    """
+    test_data.int_regs.return_registers(params.used_int_regs)
+    test_data.float_regs.return_registers(params.used_float_regs)

--- a/generators/tests/testgen/src/testgen/utils/param_generator.py
+++ b/generators/tests/testgen/src/testgen/utils/param_generator.py
@@ -97,7 +97,7 @@ def generate_random_params(
         params.rs2val = random_int(bits=test_data.xlen)
 
     if "temp_reg" in required_params and params.temp_reg is None:
-        params.temp_reg = test_data.int_regs.get_register(exclude_regs=[*exclude_regs, 2], reg_range=reg_range)
+        params.temp_reg = test_data.int_regs.get_register(exclude_regs=[*exclude_regs, 0, 2], reg_range=reg_range)
 
     if "temp_val" in required_params and params.temp_val is None:
         params.temp_val = random_int(bits=test_data.xlen)

--- a/generators/tests/testgen/src/testgen/utils/param_generator.py
+++ b/generators/tests/testgen/src/testgen/utils/param_generator.py
@@ -127,6 +127,9 @@ def generate_random_params(
     if "fs3val" in required_params and params.fs3val is None:
         params.fs3val = random_int(bits=test_data.flen)
 
+    if "temp_fval" in required_params and params.temp_fval is None:
+        params.temp_fval = random_int(bits=test_data.flen)
+
     # Fill in missing immediate parameters (only if required)
     if "immval" in required_params and params.immval is None:
         # Get immediate metadata from formatter config

--- a/tests/env/signature.h
+++ b/tests/env/signature.h
@@ -3,24 +3,6 @@
 # Jordan Carlin jcarlin@hmc.edu October 2025
 # SPDX-License-Identifier: Apache-2.0
 
-// SEW signature update stride
-#ifdef RVTEST_VECTOR
-  #if (VDSEW > XLEN)                // max(VDSEW, XLEN)
-    #define SIG_STRIDE (VDSEW / 8)
-  #else
-    #define SIG_STRIDE (XLEN / 8)
-  #endif
-#else
-  #define SIG_STRIDE REGWIDTH
-#endif
-
-// Define XLEN-sized pointer directive
-#if __riscv_xlen == 64
-  #define RVTEST_WORD_PTR .dword
-#else
-  #define RVTEST_WORD_PTR .word
-#endif
-
 // RVTEST_SIGUPD(sigptr, linkreg, tempreg, sigreg, strptr)
 // compares the value in sigreg with the value in memory at 0(sigptr).
 // If they are different, it jumps to a failure handler whose label is formed
@@ -87,6 +69,9 @@
 // Floating point values are stored to memory and then loaded back into integer registers
 // for comparison, to avoid issues with NaN that arise from using feq. There is no way to
 // directly transfer a floating point value to an integer register without Zfa when FLEN > XLEN.
+#if FLEN == 128 && XLEN == 32
+  #error "Q on RV32 is not supported yet."
+#endif
 #if FLEN > XLEN
   #ifdef SELFCHECK
     #define RVTEST_SIGUPD_F(_SIG_PTR, _LINK_REG, _TEMP_REG, _F_TEMP_REG, _FR, _STR_PTR)  \
@@ -96,17 +81,20 @@
       LREG _TEMP_REG, 0(_SIG_PTR)                            ;\
       beq _TEMP_REG, _LINK_REG, 1f                           ;\
       jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+      RVTEST_WORD_PTR _STR_PTR                               ;\
       1:                                                     ;\
       LA(_LINK_REG, scratch)                                 ;\
       LREG _LINK_REG, REGWIDTH(_LINK_REG)                    ;\
       LREG _TEMP_REG, SIG_STRIDE(_SIG_PTR)                   ;\
       beq _TEMP_REG, _LINK_REG, 2f                           ;\
       jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+      RVTEST_WORD_PTR _STR_PTR                               ;\
       2:                                                     ;\
       csrr _LINK_REG, fcsr                                   ;\
       LREG _TEMP_REG, 2*SIG_STRIDE(_SIG_PTR)                 ;\
       beq _TEMP_REG, _LINK_REG, 3f                           ;\
       jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+      RVTEST_WORD_PTR _STR_PTR                               ;\
       3:                                                     ;\
       addi _SIG_PTR, _SIG_PTR, 3*SIG_STRIDE
   #else
@@ -117,17 +105,20 @@
       SREG _LINK_REG, 0(_SIG_PTR)                            ;\
       beq x0, x0, 1f                                         ;\
       jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+      RVTEST_WORD_PTR _STR_PTR                               ;\
       1:                                                     ;\
       LA(_LINK_REG, scratch)                                 ;\
       LREG _LINK_REG, REGWIDTH(_LINK_REG)                    ;\
       SREG _LINK_REG, SIG_STRIDE(_SIG_PTR)                   ;\
       beq x0, x0, 2f                                         ;\
       jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+      RVTEST_WORD_PTR _STR_PTR                               ;\
       2:                                                     ;\
       csrr _LINK_REG, fcsr                                   ;\
       SREG _LINK_REG, 2*SIG_STRIDE(_SIG_PTR)                 ;\
       beq x0, x0, 3f                                         ;\
       jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+      RVTEST_WORD_PTR _STR_PTR                               ;\
       3:                                                     ;\
       addi _SIG_PTR, _SIG_PTR, 3*SIG_STRIDE
   #endif
@@ -140,11 +131,13 @@
       LREG _TEMP_REG, 0(_SIG_PTR)                            ;\
       beq _TEMP_REG, _LINK_REG, 1f                           ;\
       jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+      RVTEST_WORD_PTR _STR_PTR                               ;\
       1:                                                     ;\
       csrr _LINK_REG, fcsr                                   ;\
       LREG _TEMP_REG, SIG_STRIDE(_SIG_PTR)                   ;\
       beq _TEMP_REG, _LINK_REG, 3f                           ;\
       jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+      RVTEST_WORD_PTR _STR_PTR                               ;\
       3:                                                     ;\
       addi _SIG_PTR, _SIG_PTR, 2*SIG_STRIDE
   #else
@@ -155,18 +148,20 @@
       SREG _LINK_REG, 0(_SIG_PTR)                            ;\
       beq x0, x0, 1f                                         ;\
       jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+      RVTEST_WORD_PTR _STR_PTR                               ;\
       1:                                                     ;\
       csrr _LINK_REG, fcsr                                   ;\
       SREG _LINK_REG, SIG_STRIDE(_SIG_PTR)                   ;\
       beq x0, x0, 3f                                         ;\
       jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
+      RVTEST_WORD_PTR _STR_PTR                               ;\
       3:                                                     ;\
       addi _SIG_PTR, _SIG_PTR, 2*SIG_STRIDE
   #endif
 #endif
 
 // Canary value to indicate bounds of signature region
-#if SIGALIGN==8
+#if SIG_STRIDE==8
   #define CANARY_VALUE \
       0x6F5CA309E7D4B281
   #define CANARY \

--- a/tests/env/test_macros.h
+++ b/tests/env/test_macros.h
@@ -1,22 +1,3 @@
-// RVTEST_TESTDATA_LOAD_INT(data_ptr, dest_reg) loads an integer value from the
-// test data section into dest_reg and increments the data_ptr pointer by REGWIDTH.
-// This macro is used to load integer test values from the .data section.
-//  _DATA_PTR - Pointer register to current position in test data section (will be incremented)
-//  _DEST_REG - Destination register to load the value into
-#define RVTEST_TESTDATA_LOAD_INT(_DATA_PTR, _DEST_REG)  \
-  LREG _DEST_REG, 0(_DATA_PTR)                          ;\
-  addi _DATA_PTR, _DATA_PTR, REGWIDTH
-
-// RVTEST_TESTDATA_LOAD_FLOAT(data_ptr, dest_reg) loads a floating-point value from the
-// test data section into dest_reg and increments the data_ptr pointer by FREGWIDTH.
-// This macro is used to load floating point test values from the .data section.
-//  _DATA_PTR - Pointer register to current position in test data section (will be incremented)
-//  _DEST_REG - Floating point destination register to load the value into
-#define RVTEST_TESTDATA_LOAD_FLOAT(_DATA_PTR, _DEST_REG)  \
-  FLREG _DEST_REG, 0(_DATA_PTR)                          ;\
-  addi _DATA_PTR, _DATA_PTR, FREGWIDTH
-
-
 /* This function set up the Page table entry for Sv32 Translation scheme
     Arguments:
     _PAR: Register containing Physical Address

--- a/tests/env/utils.h
+++ b/tests/env/utils.h
@@ -32,41 +32,79 @@
 #define REGWIDTH (XLEN>>3)      // in units of #bytes
 #define ALIGNSZ ((XLEN>>5)+2)   // log2(XLEN): 2,3,4 for XLEN 32,64,128
 
-#if XLEN>FLEN
-  #define SIGALIGN REGWIDTH
-#else
-  #define SIGALIGN FREGWIDTH
-#endif
-
 #if   XLEN==32
     #define SREG sw
     #define LREG lw
-    #define XLEN_WIDTH 5
 #elif XLEN==64
     #define SREG sd
     #define LREG ld
-    #define XLEN_WIDTH 6
 #else
     #define SREG sq
     #define LREG lq
-    #define XLEN_WIDTH 7
 #endif
 
 # FLEN specific macros
+#define FREGWIDTH (FLEN>>3)      // in units of #bytes
+
 #if FLEN==32
     #define FLREG flw
     #define FSREG fsw
-    #define FREGWIDTH 4
 #elif FLEN==64
     #define FLREG fld
     #define FSREG fsd
-    #define FREGWIDTH 8
 #elif FLEN==128
     #define FLREG flq
     #define FSREG fsq
-    #define FREGWIDTH 16
 #endif
 
+// Default VDSEW to 0 for non-vector tests
+#ifndef VDSEW
+  #define VDSEW 0
+#endif
+#define VDSEWWIDTH (VDSEW>>3)  // in units of #bytes
+
+// Max data size alignment for signature and data region
+// Max of XLEN, FLEN, and SEW
+#if XLEN>FLEN
+  #define _SIG_STRIDE_1 REGWIDTH
+#else
+  #define _SIG_STRIDE_1 FREGWIDTH
+#endif
+
+#if (VDSEWWIDTH > _SIG_STRIDE_1)
+  #define SIG_STRIDE VDSEWWIDTH
+#else
+  #define SIG_STRIDE _SIG_STRIDE_1
+#endif
+
+// Define XLEN-sized pointer directive
+#if XLEN == 64
+  #define RVTEST_WORD_PTR .dword
+#else
+  #define RVTEST_WORD_PTR .word
+#endif
+
+
+// RVTEST_TESTDATA_LOAD_INT(data_ptr, dest_reg) loads an integer value from the
+// test data section into dest_reg and increments the data_ptr pointer by SIG_STRIDE.
+// This macro is used to load integer test values from the .data section.
+//  _DATA_PTR - Pointer register to current position in test data section (will be incremented)
+//  _DEST_REG - Destination register to load the value into
+#define RVTEST_TESTDATA_LOAD_INT(_DATA_PTR, _DEST_REG)  \
+  LREG _DEST_REG, 0(_DATA_PTR)                          ;\
+  addi _DATA_PTR, _DATA_PTR, SIG_STRIDE
+
+// RVTEST_TESTDATA_LOAD_FLOAT(data_ptr, dest_reg) loads a floating-point value from the
+// test data section into dest_reg and increments the data_ptr pointer by SIG_STRIDE.
+// This macro is used to load floating point test values from the .data section.
+//  _DATA_PTR - Pointer register to current position in test data section (will be incremented)
+//  _DEST_REG - Floating point destination register to load the value into
+#define RVTEST_TESTDATA_LOAD_FLOAT(_DATA_PTR, _DEST_REG)  \
+  FLREG _DEST_REG, 0(_DATA_PTR)                          ;\
+  addi _DATA_PTR, _DATA_PTR, SIG_STRIDE
+
+
+/* TODO: Add support for Zfinx
 #if ZFINX==1
     #define FLREG ld
     #define FSREG sd
@@ -88,6 +126,7 @@
         #define FREGWIDTH 4
         #define FLEN 32
 #endif
+*/
 
 //-----------------------------------------------------------------------
 //Fixed length la, li macros; # of ops is ADDR_SZ dependent, not data dependent


### PR DESCRIPTION
All F extension instructions are at 100% coverage with the following exceptions:
- Several flag related coverpoints are missing coverage due to a bug in the Sail model's logging. Fixed in https://github.com/riscv/sail-riscv/pull/1432.
- The F4 (fmadd/etc.) tests are too large for the linker when all coverpoints are generated. Currently one of the cross products is skipped. We will need to break these tests up.