### PR TITLE
[ACT4] Support for Zcf and Zcd extensions

### DIFF
--- a/generators/tests/testgen/src/testgen/data/test_data.py
+++ b/generators/tests/testgen/src/testgen/data/test_data.py
@@ -71,13 +71,13 @@ class TestData:
     @property
     def fp_load_size(self) -> Literal["single", "double", "half", "quad"]:
         """Get the floating point load size based on the instruction."""
-        if self.instr_name.endswith(".q") or self.instr_name in ["flq", "fsq"]:
+        if self.instr_name.endswith("q"):
             return "quad"
-        elif self.instr_name.endswith(".d") or self.instr_name in ["fld", "fsd"]:
+        elif self.instr_name.endswith("d"):
             return "double"
-        elif self.instr_name.endswith((".s", ".w")) or self.instr_name in ["flw", "fsw"]:
+        elif self.instr_name.endswith(("s", "w")):
             return "single"
-        elif self.instr_name.endswith(".h") or self.instr_name in ["flh", "fsh"]:
+        elif self.instr_name.endswith("h"):
             return "half"
         else:
             raise ValueError(

--- a/generators/tests/testgen/src/testgen/instruction_formatters/cfl_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/cfl_type.py
@@ -1,0 +1,53 @@
+##################################
+# cfl_type.py
+#
+# jcarlin@hmc.edu Dec 2025
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+from testgen.data.params import InstructionParams
+from testgen.data.test_data import TestData
+from testgen.instruction_formatters.instruction_formatters import add_instruction_formatter
+from testgen.utils.common import write_sigupd
+
+
+@add_instruction_formatter(
+    "CFL", required_params={"fd", "rs1", "immval", "temp_val"}, reg_range=range(8, 16), imm_bits=8, imm_signed=False
+)
+def format_cfl_type(
+    instr_name: str, test_data: TestData, params: InstructionParams
+) -> tuple[list[str], list[str], list[str]]:
+    """Format CFL-type instruction."""
+    assert params.rs1 is not None
+    assert params.temp_val is not None
+    assert params.fd is not None and params.immval is not None
+
+    # Determine alignment requirement and max value: c.fld needs 8-byte, c.flw needs 4-byte
+    if instr_name == "c.fld":
+        alignment = 8
+        max_val = 248
+    elif instr_name == "c.flw":
+        alignment = 4
+        max_val = 124
+    else:
+        raise ValueError(f"Unknown CFL instruction: {instr_name}")
+
+    # Mask off lower bits to ensure alignment
+    params.immval = params.immval & ~(alignment - 1)
+    # Wrap into valid range
+    params.immval = params.immval % (max_val + alignment)
+
+    # Add value to load data region
+    test_data.add_test_data_value(params.temp_val)
+
+    setup = [
+        f"addi x{params.rs1}, x{test_data.int_regs.data_reg}, {-params.immval} # adjust base address for load",
+    ]
+    test = [
+        f"{instr_name} f{params.fd}, {params.immval}(x{params.rs1}) # perform operation",
+    ]
+    check = [
+        write_sigupd(params.fd, test_data, "float"),
+        f"addi x{test_data.int_regs.data_reg}, x{test_data.int_regs.data_reg}, SIG_STRIDE # increment data_ptr",
+    ]
+    return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/instruction_formatters/cfls_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/cfls_type.py
@@ -1,0 +1,66 @@
+##################################
+# cfls_type.py
+#
+# jcarlin@hmc.edu Dec 2025
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+from testgen.data.params import InstructionParams
+from testgen.data.test_data import TestData
+from testgen.instruction_formatters.instruction_formatters import add_instruction_formatter
+from testgen.utils.common import to_hex, write_sigupd
+
+
+@add_instruction_formatter(
+    "CFLS",
+    required_params={"fd", "immval", "temp_reg", "temp_val"},
+    reg_range=range(1, 31),  # fd cannot be x0
+    imm_bits=9,  # c.ldsp: [0, 504] in multiples of 8, c.lwsp: [0, 252] in multiples of 4
+    imm_signed=False,
+)
+def format_cfls_type(
+    instr_name: str, test_data: TestData, params: InstructionParams
+) -> tuple[list[str], list[str], list[str]]:
+    """Format CFLS-type stack-pointer-based loads instruction."""
+    assert params.temp_reg is not None and params.temp_val is not None
+    assert params.fd is not None and params.immval is not None
+
+    # Determine alignment requirement and max value: c.ldsp needs 8-byte, c.lwsp needs 4-byte
+    if instr_name == "c.fldsp":
+        alignment = 8
+        max_val = 504
+    elif instr_name == "c.flwsp":
+        alignment = 4
+        max_val = 252
+    else:
+        raise ValueError(f"Unknown CFLS instruction: {instr_name}")
+
+    # Mask off lower bits to ensure alignment
+    params.immval = params.immval & ~(alignment - 1)
+    # Wrap into valid range
+    params.immval = params.immval % (max_val + alignment)
+
+    # Add value to load data region
+    test_data.add_test_data_value(params.temp_val)
+
+    setup: list[str] = []
+    # sp (x2) is used as the base pointer for CFLS instructions
+    # Ensure sp is allocated
+    setup.append(test_data.int_regs.consume_registers([2]))
+
+    setup.extend(
+        [
+            f"mv sp, x{test_data.int_regs.data_reg} # move data_ptr to sp",
+            f"addi sp, sp, {-params.immval} # adjust base address for load",
+        ]
+    )
+    test = [
+        f"{instr_name} f{params.fd}, {params.immval}(sp) # perform load ({to_hex(params.temp_val, test_data.xlen)})",
+    ]
+    check = [
+        write_sigupd(params.fd, test_data, "float"),
+        f"addi x{test_data.int_regs.data_reg}, x{test_data.int_regs.data_reg}, SIG_STRIDE # increment data_ptr",
+    ]
+    # Return sp
+    test_data.int_regs.return_register(2)
+    return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/instruction_formatters/cfs_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/cfs_type.py
@@ -1,0 +1,78 @@
+##################################
+# cfs_type.py
+#
+# harris@hmc.edu Dec 2025
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+from testgen.data.params import InstructionParams
+from testgen.data.test_data import TestData
+from testgen.instruction_formatters.instruction_formatters import add_instruction_formatter
+from testgen.utils.common import load_float_reg, write_sigupd
+
+
+@add_instruction_formatter(
+    "CFS",
+    required_params={"rs1", "rs1val", "fs2", "fs2val", "immval", "temp_reg"},
+    reg_range=range(8, 16),
+    imm_bits=8,
+    imm_signed=False,
+)
+def format_cfs_type(
+    instr_name: str, test_data: TestData, params: InstructionParams
+) -> tuple[list[str], list[str], list[str]]:
+    """Format CFS-type instruction."""
+    assert params.rs1 is not None, "rs1 must be provided for CFS-type instructions"
+    assert params.fs2 is not None and params.fs2val is not None, (
+        "fs2 and fs2val must be provided for CFS-type instructions"
+    )
+    assert params.temp_reg is not None, "temp_reg must be provided for CFS-type instructions"
+    assert params.immval is not None, "immval must be provided for CFS-type instructions"
+
+    # Determine alignment requirement and max value: c.fsd needs 8-byte, c.fsw needs 4-byte
+    if instr_name == "c.fsd":
+        alignment = 8
+        max_val = 248
+    elif instr_name == "c.fsw":
+        alignment = 4
+        max_val = 124
+    else:
+        raise ValueError(f"Unknown CFS instruction: {instr_name}")
+
+    # Mask off lower bits to ensure alignment
+    params.immval = params.immval & ~(alignment - 1)
+    # Wrap into valid range
+    params.immval = params.immval % (max_val + alignment)
+
+    # Move sig_reg to rs1
+    setup = [
+        load_float_reg("fs2", params.fs2, params.fs2val, test_data),
+    ]
+    if params.rs1 != test_data.int_regs.sig_reg:
+        setup.append(
+            test_data.int_regs.move_sig_reg(params.rs1),
+        )
+        params.rs1 = None
+
+    sig_reg = test_data.int_regs.sig_reg
+
+    setup.append(f"addi x{sig_reg}, x{sig_reg}, {-params.immval} # adjust base address for offset")
+
+    test = [f"{instr_name} f{params.fs2}, {params.immval}(x{sig_reg}) # perform store"]
+    check = [
+        f"addi x{sig_reg}, x{sig_reg}, {params.immval} # restore base address",
+        f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # increment signature pointer",
+        "#ifdef SELFCHECK",
+        f"LREG x{params.temp_reg}, -SIG_STRIDE(x{sig_reg}) # load stored value for checking",
+        write_sigupd(params.temp_reg, test_data),
+        "#else",
+        f"{instr_name} f{params.fs2}, 0(x{sig_reg}) # repeat store so it is available for checking",
+        f"addi x{sig_reg}, x{sig_reg}, SIG_STRIDE # adjust base address for offset",
+        "# nops to ensure length matches SELFCHECK",
+        "nop",
+        "nop",
+        "nop",
+        "#endif",
+    ]
+    test_data.sigupd_count += 1
+    return (setup, test, check)

--- a/generators/tests/testgen/src/testgen/instruction_formatters/cfss_type.py
+++ b/generators/tests/testgen/src/testgen/instruction_formatters/cfss_type.py
@@ -1,7 +1,7 @@
 ##################################
-# css_type.py
+# cfss_type.py
 #
-# harris@hmc.edu Oct 2025
+# harris@hmc.edu Dec 2025
 # SPDX-License-Identifier: Apache-2.0
 ##################################
 
@@ -11,18 +11,20 @@ from testgen.instruction_formatters.instruction_formatters import add_instructio
 from testgen.utils.common import load_int_reg, write_sigupd
 
 
-@add_instruction_formatter("CSS", required_params={"rs2", "rs2val", "immval", "temp_reg"}, imm_bits=9, imm_signed=False)
+@add_instruction_formatter(
+    "CFSS", required_params={"rs2", "rs2val", "immval", "temp_reg"}, imm_bits=9, imm_signed=False
+)
 def format_css_type(
     instr_name: str, test_data: TestData, params: InstructionParams
 ) -> tuple[list[str], list[str], list[str]]:
-    """Format CSS-type stack-pointer-based store instruction."""
+    """Format CFSS-type stack-pointer-based store instruction."""
     assert params.rs2 is not None and params.rs2val is not None, (
-        "rs2 and rs2val must be provided for CSS-type instructions"
+        "rs2 and rs2val must be provided for CFSS-type instructions"
     )
-    assert params.temp_reg is not None, "temp_reg must be provided for CSS-type instructions"
-    assert params.immval is not None, "immval must be provided for CSS-type instructions"
+    assert params.temp_reg is not None, "temp_reg must be provided for CFSS-type instructions"
+    assert params.immval is not None, "immval must be provided for CFSS-type instructions"
 
-    return (["#TODO: CSS tests are still a work in progress"], [], [])
+    return (["#TODO: CFSS tests are still a work in progress"], [], [])
     # TODO: Fix CSS trapping bug and re-enable these tests
 
     # Determine alignment requirement and max value: c.sdsp needs 8-byte, c.swsp needs 4-byte

--- a/generators/tests/testgen/src/testgen/testgen.py
+++ b/generators/tests/testgen/src/testgen/testgen.py
@@ -118,7 +118,7 @@ def generate_tests_for_extension(task: tuple[int, bool, str, Path, Path]) -> Non
         test_lines = [insert_setup_template("testgen_header.S", xlen, extension, test_file_relative)]
 
         # Enable floating point if needed
-        if "F" in extension or "D" in extension or "Q" in extension or "Zf" in extension:
+        if any(ext in extension for ext in ["F", "D", "Q", "Zf", "Zcf", "Zcd"]):
             test_lines.append("# set mstatus.FS to 01 to enable fp\nLI(t0,0x4000)\ncsrs mstatus, t0\n")
 
         # Generate tests for this instruction


### PR DESCRIPTION
100% coverage except stack pointer stores, which still need to be fixed for integer as well. Once that is resolved, the updated version will be copied over to fp.