### PR TITLE
[ACT 4] Various Usability Enhancements

### DIFF
--- a/framework/src/act/config.py
+++ b/framework/src/act/config.py
@@ -8,6 +8,7 @@
 ##################################
 
 import shutil
+import subprocess
 from enum import Enum
 from pathlib import Path
 
@@ -87,6 +88,30 @@ class Config(BaseModel):
         return "\n".join(lines)
 
 
+def check_ref_model_version(config: Config) -> None:
+    """Check that the reference model version is compatible."""
+    if config.ref_model_type == RefModelType.SAIL:
+        required_version = "0.9"
+        try:
+            result = subprocess.run(
+                [str(config.ref_model_exe), "--version"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=5,
+            )
+            version = result.stdout.strip()
+            if version != required_version:
+                raise ValueError(
+                    f"Sail reference model version mismatch. ACT4 requires version {required_version}, but {version} was found. "
+                    "Refer to the ACT4 README for installation instructions: https://github.com/riscv-non-isa/riscv-arch-test/tree/act4?tab=readme-ov-file#3-risc-v-sail-golden-reference-model",
+                )
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"Failed to check Sail version: {e}") from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"Timeout while checking Sail version: {e}") from e
+
+
 def load_config(config_file: Path) -> Config:
     """Load riscv-arch-test framework configuration from a YAML file."""
     if not config_file.exists():
@@ -99,4 +124,6 @@ def load_config(config_file: Path) -> Config:
     if yaml_data is None:
         raise ValueError(f"Configuration file is empty: {config_file}")
 
-    return Config.model_validate(yaml_data, context={"config_file_dir": config_file.parent})
+    config = Config.model_validate(yaml_data, context={"config_file_dir": config_file.parent})
+    check_ref_model_version(config)
+    return config

--- a/framework/src/act/makefile_gen.py
+++ b/framework/src/act/makefile_gen.py
@@ -284,10 +284,11 @@ def generate_config_makefile(
                 f"{final_elf}: {common_elf} | {final_elf.parent}\n"
                 f"\tln -sf {common_elf} \\\n"
                 f"\t\t{final_elf}\n"
-                f"\tln -sf {common_elf}.objdump \\\n"
-                f"\t\t{final_elf}.objdump\n"
-                if config.objdump_exe is not None
-                else "# skipping objdump\n",
+                f"{
+                    f'\tln -sf {common_elf}.objdump \\\n\t\t{final_elf}.objdump\n'
+                    if debug and config.objdump_exe is not None
+                    else '\t# skipping objdump generation\n'
+                }"
             )
         else:
             makefile_lines.append(

--- a/framework/src/act/parse_udb_config.py
+++ b/framework/src/act/parse_udb_config.py
@@ -17,6 +17,23 @@ from typing import Any
 from ruamel.yaml import YAML
 
 
+def update_udb_submodule() -> None:
+    """Ensure the riscv-unified-db submodule is initialized and up to date."""
+    udb_path = Path("./external/riscv-unified-db/bin/udb")
+
+    if not udb_path.exists():
+        print("riscv-unified-db not found; initializing submodule external/riscv-unified-db...")
+    else:
+        print("Updating riscv-unified-db submodule...")
+
+    try:
+        subprocess.run(["git", "submodule", "update", "--init", "--", "external/riscv-unified-db"], check=True)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            "Failed to initialize/update riscv-unified-db submodule. Please run 'git submodule update --init' manually and try again."
+        ) from e
+
+
 def validate_udb_config(udb_config_file: Path) -> None:
     validate_udb_config_cmd = [
         "./external/riscv-unified-db/bin/udb",
@@ -60,9 +77,10 @@ def get_implemented_extensions(extension_list_file: Path) -> set[str]:
 
 
 def generate_udb_files(udb_config_file: Path, output_dir: Path) -> None:
+    update_udb_submodule()
+
     # TODO: Figure out a more robust way to handle UDB validation
     # Currently only works if using docker as container runtime and requires copying UDB config into riscv-unified-db directory
-
     copied_udb_config = Path(f"./external/riscv-unified-db/cfgs/{udb_config_file.name}")
     if not copied_udb_config.exists() or not filecmp.cmp(udb_config_file, copied_udb_config):
         shutil.copy(udb_config_file, copied_udb_config)


### PR DESCRIPTION
- Fix generated Makefile when `objdump_exe` is not specified
- Automatically initialize the UDB submodule and ensure the correct version is checked out
- Add a runtime check for the Sail model version to provide a more descriptive error when the wrong version is installed instead of hitting hard to debug errors when running tests.