### PR TITLE
Use upstream isa manual norm rules

### DIFF
--- a/ctp/src/strategy.adoc
+++ b/ctp/src/strategy.adoc
@@ -130,7 +130,7 @@ The testplan for each extension contains a list of normative rules applicable to
 Normative rules are generally direct quotations from a ratified RISC-V specification describing a single certifiable feature.  Normative rules specify the behaviors an implementation must meet in order to be compliant with the standard. In particular, introductory overview and
 non-normative explanatory text is not quoted as a normative rule.
 
-See https://github.com/RISC-V-Certification-Steering-Committee/riscv-isa-manual/blob/main/tagging_normative_rules.adoc[tagging_normative_rules] for more information about normative rules and IDs and how to tag them in the specification.
+See https://github.com/riscv/riscv-isa-manual/blob/main/tagging_normative_rules.adoc[tagging_normative_rules] for more information about normative rules and IDs and how to tag them in the specification.
 
 === Coverpoints
 

--- a/generators/ctp/generate_norm_table.py
+++ b/generators/ctp/generate_norm_table.py
@@ -390,7 +390,7 @@ def main() -> None:
     # Default: download the canonical norm-rules.json from the ISA manual snapshot
     # canonical remote JSON used as default and as the fetch target when
     # --always-fetch is requested
-    canonical_json_url = 'https://risc-v-certification-steering-committee.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.json'
+    canonical_json_url = 'https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.json'
     p.add_argument('--json', default=canonical_json_url, help='Path or URL to norm-rules.json')
     p.add_argument('--yaml', default='coverpoints/norm/yaml', help='Path to a YAML file or a directory containing YAML files (default directory: coverpoints/norm/yaml)')
     p.add_argument('--out', default='ctp/src/norm/', help='Output directory for ASCIIDoc files (default: ctp/src/norm/)')
@@ -465,8 +465,8 @@ def main() -> None:
     # The link should apply to the tagged text (tag['text']) and the
     # tag 'name' (e.g. 'norm:...') should not be printed.
         linked_text_parts = []
-        UNPRIV_BASE = 'https://risc-v-certification-steering-committee.github.io/riscv-isa-manual/snapshot/unprivileged/index.html'
-        PRIV_BASE = 'https://risc-v-certification-steering-committee.github.io/riscv-isa-manual/snapshot/privileged/index.html'
+        UNPRIV_BASE = 'https://riscv.github.io/riscv-isa-manual/snapshot/unprivileged/index.html'
+        PRIV_BASE = 'https://riscv.github.io/riscv-isa-manual/snapshot/privileged/index.html'
         tags_iter = [tags] if isinstance(tags, dict) else list(tags) if tags is not None else []
         for tg in tags_iter:
             if not isinstance(tg, dict):


### PR DESCRIPTION
The normative rules are now upstream. Switch away from the CSC fork.