### PR TITLE
[ACT4] Disable auto release notes

### DIFF
--- a/.github/workflows/ctp-build.yml
+++ b/.github/workflows/ctp-build.yml
@@ -77,9 +77,9 @@ jobs:
           draft: false
           prerelease: ${{ ! (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true') }}
           make_latest: true
-          # generate_release_notes: true
-          tag_name: ctp-release-${{ env.SHORT_SHA }}-${{ env.CURRENT_DATE }}
-          name: ctp-release-${{ env.SHORT_SHA }}-${{ env.CURRENT_DATE }}
+          generate_release_notes: true
+          tag_name: ctp-${{ env.CURRENT_DATE }}-${{ env.SHORT_SHA }}
+          name: "CTP Release ${{ env.CURRENT_DATE }}: ${{ env.SHORT_SHA }}"
           body: |
             This release was created by: ${{ github.event.sender.login }}
           files: |

--- a/.github/workflows/ctp-build.yml
+++ b/.github/workflows/ctp-build.yml
@@ -77,7 +77,7 @@ jobs:
           draft: false
           prerelease: ${{ ! (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true') }}
           make_latest: true
-          generate_release_notes: true
+          # generate_release_notes: true
           tag_name: ctp-${{ env.CURRENT_DATE }}-${{ env.SHORT_SHA }}
           name: "CTP Release ${{ env.CURRENT_DATE }}: ${{ env.SHORT_SHA }}"
           body: |


### PR DESCRIPTION
They are broken because of the different branches.