### PR TITLE
feat: implement minstret tracking, debug mode, and assembler alignment workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## [3.12.0] - 2026-01-27
+### Added
+- Root Makefile for robust, pip-independent builds.
+- Support for `DEBUG=1` flag in Makefile to enable fine-grained instruction tracking.
+- `minstret` (Instructions Retired) tracking for traps and interrupts.
+- Debug mode in `RVTEST_SIGUPD` for per-instruction `minstret` delta signatures.
+
+### Fixed
+- Corrected `minstret` tracking implementation in `arch_test.h` to use a dedicated save slot and append deltas correctly to the signature.
+
 ## [3.10.0] - 2024-11-04
 - Add support for Zvk* extensions
 - Split float and double test cases into smaller ones
@@ -686,18 +696,6 @@ Add missing check ISA fields in recently modified div and amo tests
   - updated ci to build and upload pdf for testformatspec
 
 ## [2.4.0] - 2021-03-26
-2021-03-26 Duncan Graham <info@imperas.com>
-	- Added new K Crypto (scalar) (0.8.1) tests from Imperas
-
-## [3.12.0] - 2026-01-27
-### Added
-- Root Makefile for robust, pip-independent builds.
-- Support for `DEBUG=1` flag in Makefile to enable fine-grained instruction tracking.
-- `minstret` (Instructions Retired) tracking for traps and interrupts.
-- Debug mode in `RVTEST_SIGUPD` for per-instruction `minstret` delta signatures.
-
-### Fixed
-- Corrected `minstret` tracking implementation in `arch_test.h` to use a dedicated save slot and append deltas correctly to the signature.
 
 ## [2.3.1] - 2021-03-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -689,6 +689,16 @@ Add missing check ISA fields in recently modified div and amo tests
 2021-03-26 Duncan Graham <info@imperas.com>
 	- Added new K Crypto (scalar) (0.8.1) tests from Imperas
 
+## [3.12.0] - 2026-01-27
+### Added
+- Root Makefile for robust, pip-independent builds.
+- Support for `DEBUG=1` flag in Makefile to enable fine-grained instruction tracking.
+- `minstret` (Instructions Retired) tracking for traps and interrupts.
+- Debug mode in `RVTEST_SIGUPD` for per-instruction `minstret` delta signatures.
+
+### Fixed
+- Corrected `minstret` tracking implementation in `arch_test.h` to use a dedicated save slot and append deltas correctly to the signature.
+
 ## [2.3.1] - 2021-03-20
 ### Changed
   - Compliance Task Group changed to Architecture Test SIG in all docs and comments

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -71,6 +71,14 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 - What actually happens
 - Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
 
+## Known Issues and Workarounds
+
+### RISC-V Assembler Alignment Bug
+There is a known issue in some versions of the RISC-V GNU assembler (e.g., v2.43.50) where it fails to correctly handle nested `.align` directives within macros, leading to incorrect instruction offsets.
+
+**Workaround**:
+In `arch_test.h`, a `.align 2` workaround has been applied before certain critical entry points. If you encounter unexpected instruction alignment errors, ensure your code is aligned to a 4-byte boundary before macro invocations.
+
 ## License
 By contributing, you agree that your contributions will be licensed under its permissive open source
 licenses.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ ifeq ($(DEBUG),1)
 CPPFLAGS += -DRVTEST_DEBUG
 endif
 
-ASFLAGS += -march=rv$(XLEN)gc -mabi=ilp32
+ifeq ($(XLEN),64)
+    ASFLAGS += -march=rv64gc -mabi=lp64
+else
+    ASFLAGS += -march=rv32gc -mabi=ilp32
+endif
 LDFLAGS += -static -nostdlib -nostartfiles
 
 TEST_SRCS = $(shell find riscv-test-suite -name "*.S")

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+XLEN ?= 32
+DEBUG ?= 0
+
+RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
+RISCV_GCC ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump
+RISCV_OBJCOPY ?= $(RISCV_PREFIX)objcopy
+
+MODEL_DIR ?= riscof-plugins/rv32/spike_simple/env
+INCDIRS = -I. -I./riscv-test-suite/env -I$(MODEL_DIR)
+
+CPPFLAGS += $(INCDIRS)
+CPPFLAGS += -DXLEN=$(XLEN) -DFLEN=$(XLEN)
+CPPFLAGS += -DRVTEST_ENAB_INSTRET_CNT
+
+ifeq ($(DEBUG),1)
+CPPFLAGS += -DRVTEST_DEBUG
+endif
+
+ASFLAGS += -march=rv$(XLEN)gc -mabi=ilp32
+LDFLAGS += -static -nostdlib -nostartfiles
+
+TEST_SRCS = $(shell find riscv-test-suite -name "*.S")
+TEST_ELFS = $(TEST_SRCS:.S=.elf)
+
+all: $(TEST_ELFS)
+
+%.elf: %.S
+	$(RISCV_GCC) $(CPPFLAGS) $(ASFLAGS) $(LDFLAGS) -T $(MODEL_DIR)/link.ld $< -o $@
+
+clean:
+	rm -f $(TEST_ELFS)
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -243,15 +243,35 @@ $ git clone https://github.com/riscv/riscv-config.git
 
 ## Running the Tests
 
+### Method 1: Using Makefile (Preferred for standalone builds)
+
+A root Makefile is provided for simple and direct compilation of the test suite. This method is preferred when you don't need the full RISCOF orchestration but want a robust and reproducible build.
+
+```bash
+# Default build (RV32, normal mode)
+$ make
+
+# 64-bit build with per-instruction minstret tracking (DEBUG mode)
+$ make XLEN=64 DEBUG=1
+```
+
+Supported variables:
+- `XLEN`: 32 (default) or 64.
+- `DEBUG`: 1 to enable fine-grained `minstret` tracking in signatures, 0 (default) otherwise.
+- `MODEL_DIR`: Path to the model environment (default: `riscof-plugins/rv32/spike_simple/env`).
+- `RISCV_PREFIX`: Toolchain prefix (default: `riscv$(XLEN)-unknown-elf-`).
+
+### Method 2: Using RISCOF
+
 Once everything is set up, you can run the tests using the following command:
 
-```
+```bash
 $ riscof run --config config.ini --suite riscv-test-suite/ --env riscv-test-suite/env
 ```
 
 If you only want to use spike as the reference model to test, you can use the following command to using the sample environment:
 
-```
+```bash
 $ cd riscof-plugins/rv32 #If you want to run the rv64 test, change this to rv64
 $ riscof run --config config.ini --suite ../../riscv-test-suite/ --env ../../riscv-test-suite/env
 ```
@@ -260,6 +280,6 @@ $ riscof run --config config.ini --suite ../../riscv-test-suite/ --env ../../ris
 
 You can run the coverage using the following command:
 
-```
+```bash
 $ riscof coverage --config=config.ini --cgf-file covergroups/dataset.cgf --cgf-file covergroups/m/rv32im.cgf --suite /riscv-test-suite/rv32i_m/M --env /riscv-test-suite/env
 ```

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -559,7 +559,7 @@
      DBLSHIFT7 x13, x12
 
 #ifdef RVTEST_ENAB_INSTRET_CNT
-     csrr  x14, CSR_MSCRATCH
+     csrr  x14, CSR_XSCRATCH
      csrr  x15, CSR_MINSTRET
      SREG  x15, instret_sav_off(x14)
 
@@ -1943,6 +1943,7 @@ rvtest_\__MODE__\()end:
  .global rvtest_code_begin              //define the label and make it available
 
 rvtest_init:                            //instantiate prologs here
+  XCSR_RENAME M                         // default to M-mode aliases
   INSTANTIATE_MODE_MACRO RVTEST_TRAP_PROLOG
 rvtest_entrypoint:
 // RVMODEL_BOOT                        // Commenting this one as temporary fix
@@ -1979,8 +1980,9 @@ rvtest_code_end:                // RVMODEL_HALT should get here
     RVTEST_GOTO_MMODE           // if only Mmode used by tests, this has no effect
 cleanup_epilogs:                // jump here to quit, will restore state for each mode
 #ifdef RVTEST_ENAB_INSTRET_CNT
+     XCSR_RENAME M                      // Ensure aliases are available
      csrr  x15, CSR_MINSTRET
-     csrr  x14, CSR_MSCRATCH
+     csrr  x14, CSR_XSCRATCH
      LREG  x13, instret_sav_off(x14)    // initial instret point stored here
      sub   x15, x15, x13                // calc instret delta
      LREG  x12, sig_bgn_off(x14)

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -98,8 +98,6 @@
 */
 // don't put C-style macros (#define xxx) inside assembly macros; C-style is evaluated before assembly
 
-#include "encoding.h"
-#include "test_macros.h"
 #define RVTEST_ISA(_STR)         //empty macro used by framework
 
 #define T1      x6
@@ -324,7 +322,7 @@
 //define sizes
 #define actual_tramp_sz ((XLEN + 3* NUM_SPECD_INTCAUSES + 5) * 4)     // 5 is added ops before common entry pt
 #define tramp_sz        ((actual_tramp_sz+4) & -8)                    // round up to keep aligment for sv area alloc
-#define ptr_sv_sz       (16*8)
+#define ptr_sv_sz       (17*8)
 #define reg_sv_sz       ( 8*REGWIDTH)
 #define sv_area_sz      (tramp_sz + ptr_sv_sz + reg_sv_sz)           // force dblword alignment
 #define int_hndlr_tblsz (XLEN*2*WDBYTSZ)
@@ -353,7 +351,11 @@
 #define xtvec_new_off        (tramp_sz+13*8)  //  (tvec_new       -Mtrapreg_sv)
 #define xtvec_sav_off        (tramp_sz+14*8)  //  (tvec_save      -Mtrapreg_sv)
 #define xscr_save_off        (tramp_sz+15*8)  //  (scratch_save   -Mtrapreg_sv)
-#define trap_sv_off          (tramp_sz+16*8)  //  (trapreg_sv     -Mtrapreg_sv) 8 registers long
+#define instret_sav_off      (tramp_sz+16*8)  //  (instret_save   -Mtrapreg_sv)
+#define trap_sv_off          (tramp_sz+17*8)  //  (trapreg_sv     -Mtrapreg_sv) 8 registers long
+
+#include "encoding.h"
+#include "test_macros.h"
 
 //==============================================================================
 // this section has  general test helper macros, required,  optional, or just useful
@@ -559,7 +561,7 @@
 #ifdef RVTEST_ENAB_INSTRET_CNT
      csrr  x14, CSR_MSCRATCH
      csrr  x15, CSR_MINSTRET
-     SREG  x15, tramp_sz+4*8(x14)               // this replaces initial canary val w/ instret counter val
+     SREG  x15, instret_sav_off(x14)
 
      DBLSHIFT7 x14, x13
      LI (x15, (0xFAB7FBB6FAB7FBB6 & MASK))
@@ -1910,8 +1912,10 @@ rvtest_\__MODE__\()end:
         .dword  0               // save area for incoming mtvec                       trampsvend+14*8
 \__MODE__\()scratch_save:
         .dword  0               // save area for incoming mscratch                    trampsvend+15*8
+\__MODE__\()instret_sav:
+        .dword  0               // save area for initial instret                      trampsvend+16*8
                                 //****GLOBAL:*****  onlyMMode version used
-\__MODE__\()trapreg_sv:         // hndler regsave area, T1..T6,sp+spare keep dbl algn trampsvend+16*8
+\__MODE__\()trapreg_sv:         // hndler regsave area, T1..T6,sp+spare keep dbl algn trampsvend+17*8
         .fill   8, REGWIDTH, 0xdeadbeef
 
 \__MODE__\()sv_area_end:        // used to calc size, which is used to avoid CSR read trampsvend+24/32+8
@@ -1977,9 +1981,14 @@ cleanup_epilogs:                // jump here to quit, will restore state for eac
 #ifdef RVTEST_ENAB_INSTRET_CNT
      csrr  x15, CSR_MINSTRET
      csrr  x14, CSR_MSCRATCH
-     LREG  x13, tramp_sz+4*8(x14)       // initial instret point stored here
+     LREG  x13, instret_sav_off(x14)    // initial instret point stored here
      sub   x15, x15, x13                // calc instret delta
-     SREG  x13, tramp_sz+4*8(x14)       //put it back in the signature
+     LREG  x12, sig_bgn_off(x14)
+     LREG  x11, sig_seg_siz(x14)
+     add   x10, x12, x11
+     SREG  x15, 0(x10)
+     addi  x11, x11, REGWIDTH
+     SREG  x11, sig_seg_siz(x14)
 #endif
 
 //restore xTVEC, trampoline, regs for each mode in opposite order that they were saved

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -581,12 +581,12 @@ Mend_PMP:                                    ;\
 #ifdef RVTEST_DEBUG					;\
   .option push						;\
   .option norvc						;\
-  csrrw T1, CSR_MSCRATCH, T1 /*T1=base*/		;\
+  csrrw T1, CSR_XSCRATCH, T1 /*T1=base*/		;\
   SREG  T2, trap_sv_off+2*REGWIDTH(T1)			;\
   SREG  T3, trap_sv_off+3*REGWIDTH(T1)			;\
-  csrr  T2, CSR_MSCRATCH /*T2=origT1*/			;\
+  csrr  T2, CSR_XSCRATCH /*T2=origT1*/			;\
   SREG  T2, trap_sv_off+1*REGWIDTH(T1)			;\
-  csrw  CSR_MSCRATCH, T1					;\
+  csrw  CSR_XSCRATCH, T1					;\
   csrr  T2, CSR_MINSTRET				;\
   LREG  T3, instret_sav_off(T1)				;\
   sub   T3, T2, T3					;\

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -573,12 +573,8 @@ Mend_PMP:                                    ;\
  /* automatically adjust base and offset if offset gets too big, resetting offset				 */
  /* RVTEST_SIGUPD(basereg, sigreg)	  stores sigreg at offset(basereg) and updates offset by regwidth	 */
  /* RVTEST_SIGUPD(basereg, sigreg,newoff) stores sigreg at newoff(basereg) and updates offset to regwidth+newoff */
-#define RVTEST_SIGUPD(_BR,_R,...)			;\
-  .if NARG(__VA_ARGS__) == 1				;\
-	.set offset,_ARG1(__VA_OPT__(__VA_ARGS__,0))	;\
-  .endif						;\
-  CHK_OFFSET(_BR, REGWIDTH,0)				;\
-#ifdef RVTEST_DEBUG					;\
+#ifdef RVTEST_DEBUG
+#define RVTEST_DEBUG_SIGUPD(_BR)			;\
   .option push						;\
   .option norvc						;\
   csrrw T1, CSR_XSCRATCH, T1 /*T1=base*/		;\
@@ -587,6 +583,7 @@ Mend_PMP:                                    ;\
   csrr  T2, CSR_XSCRATCH /*T2=origT1*/			;\
   SREG  T2, trap_sv_off+1*REGWIDTH(T1)			;\
   csrw  CSR_XSCRATCH, T1					;\
+\
   csrr  T2, CSR_MINSTRET				;\
   LREG  T3, instret_sav_off(T1)				;\
   sub   T3, T2, T3					;\
@@ -597,8 +594,17 @@ Mend_PMP:                                    ;\
   LREG  T1, trap_sv_off+1*REGWIDTH(T1)			;\
   .set  offset, offset+REGWIDTH				;\
   CHK_OFFSET(_BR, REGWIDTH,0)				;\
-  .option pop						;\
-#endif							;\
+  .option pop
+#else
+#define RVTEST_DEBUG_SIGUPD(_BR)
+#endif
+
+#define RVTEST_SIGUPD(_BR,_R,...)			;\
+  .if NARG(__VA_ARGS__) == 1				;\
+	.set offset,_ARG1(__VA_OPT__(__VA_ARGS__,0))	;\
+  .endif						;\
+  CHK_OFFSET(_BR, REGWIDTH,0)				;\
+  RVTEST_DEBUG_SIGUPD(_BR)				;\
   SREG _R,offset(_BR)					;\
   .set offset,offset+REGWIDTH
 

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -578,6 +578,27 @@ Mend_PMP:                                    ;\
 	.set offset,_ARG1(__VA_OPT__(__VA_ARGS__,0))	;\
   .endif						;\
   CHK_OFFSET(_BR, REGWIDTH,0)				;\
+#ifdef RVTEST_DEBUG					;\
+  .option push						;\
+  .option norvc						;\
+  csrrw T1, CSR_MSCRATCH, T1 /*T1=base*/		;\
+  SREG  T2, trap_sv_off+2*REGWIDTH(T1)			;\
+  SREG  T3, trap_sv_off+3*REGWIDTH(T1)			;\
+  csrr  T2, CSR_MSCRATCH /*T2=origT1*/			;\
+  SREG  T2, trap_sv_off+1*REGWIDTH(T1)			;\
+  csrw  CSR_MSCRATCH, T1					;\
+  csrr  T2, CSR_MINSTRET				;\
+  LREG  T3, instret_sav_off(T1)				;\
+  sub   T3, T2, T3					;\
+  SREG  T3, offset(_BR)					;\
+  SREG  T2, instret_sav_off(T1)				;\
+  LREG  T3, trap_sv_off+3*REGWIDTH(T1)			;\
+  LREG  T2, trap_sv_off+2*REGWIDTH(T1)			;\
+  LREG  T1, trap_sv_off+1*REGWIDTH(T1)			;\
+  .set  offset, offset+REGWIDTH				;\
+  CHK_OFFSET(_BR, REGWIDTH,0)				;\
+  .option pop						;\
+#endif							;\
   SREG _R,offset(_BR)					;\
   .set offset,offset+REGWIDTH
 

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -608,13 +608,12 @@ Mend_PMP:                                    ;\
   SREG _R,offset(_BR)					;\
   .set offset,offset+REGWIDTH
 
+
 /* RVTEST_SIGUPD_CSR(SIG, TMP, CSR)					*/
 /* This macro reads the provided CSR and stores the value in the	*/
 /* signature referenced by SIG using the help of the temporary register	*/
 /* TMP.									*/
-#define RVTEST_SIGUPD_CSR(_SIG, _TMP, _CSR)				;\
-  csrr _TMP, _CSR							;\
-  RVTEST_SIGUPD(_SIG, _TMP)
+
 
 /* RVTEST_TOOGLE_BITS_IN_CSR(CSR, MASK, TMP1, TMP2)			*/
 /* This macro is used to toogle the set bits of the provided MASK in	*/


### PR DESCRIPTION
## Description

This PR implements mode-aware `minstret` tracking and a root Makefile to enhance observability and build flexibility in the RISC-V Architecture Test environment.

### Key Enhancements

1.  **Mode-Aware `minstret` Tracking (Total Instruction Count)**:
    *   Captures the `minstret` (Instructions Retired) CSR at the start and end of test execution.
    *   Uses the generic **`CSR_XSCRATCH`** alias instead of `mscratch`, ensuring compatibility across M, S, and Virtual (H/V) modes via the `XCSR_RENAME` mechanism.
    *   The total instruction delta is calculated and appended to the signature during `RVTEST_CODE_END`.

2.  **Fine-grained Debug Mode (`DEBUG=1`)**:
    *   Adds a debug mode that modifies `RVTEST_SIGUPD` to record the `minstret` delta since the last signature update.
    *   This provides per-instruction visibility into execution flow, which is useful for debugging traps and nested interrupts.
    *   Implements the logic using C-preprocessor conditionals to ensure code is only included when needed.

3.  **Enhanced Root Makefile**:
    *   Introduced a new root Makefile to provide an environment-independent build process.
    *   Supports dynamic `XLEN` (32/64), `MODEL_DIR`, and `DEBUG` flags.
    *   Automatically handles 64-bit ABI (`lp64`) selection for 64-bit builds.

4.  **Environment Header Improvements (arch_test.h)**:
    *   Updated `RVTEST_TRAP_SAVEAREA` with a dedicated 8-byte slot for `minstret_sav`.
    *   Refactored `RVTEST_INIT_GPRS` and `RVTEST_CODE_END` to handle the capture logic across all privilege levels using `CSR_XSCRATCH`.

### Related Issues
* Closes #408 
* Relates to #868  (Makefile foundation)