### PR TITLE
feat: Implement FP register initialization in cross-combo tests

### DIFF
--- a/riscv-ctg/riscv_ctg/cross_comb.py
+++ b/riscv-ctg/riscv_ctg/cross_comb.py
@@ -388,6 +388,53 @@ class cross():
         freg = random.choice(list(freg_Sol))
         return (sreg, freg)
 
+    def get_source_fp_regs(cross_comb_instrs):
+        
+        #This function extracts all floating point registers used as source operands (rs1, rs2, rs3) in the cross-combination instruction sequence.
+    
+        #Input argument:
+            #- cross_comb_instrs type: list(dict()) Holds info of various instructions in the sequence
+        
+        #Return:
+           # - OrderedSet of source FP register names
+
+        source_fp_regs = OrderedSet()
+        
+        for instr_dict in cross_comb_instrs:
+            for operand in ['rs1', 'rs2', 'rs3']:
+                if operand in instr_dict:
+                    reg_val = instr_dict[operand]
+                    if reg_val[0] == 'f':  # Check if it's a floating point register
+                        source_fp_regs.add(reg_val)
+        
+        return source_fp_regs
+
+    def get_fp_init_str(cross_comb_instrs, freg):
+        '''
+        This function generates initialization code for floating point registers that are used as source operands in the cross-combination sequence.
+        
+        Input argument:
+            - cross_comb_instrs type: list(dict()) Holds info of various instructions in the sequence
+            - freg type: str The temporary register used to load FP register values
+        
+        Return:
+            - List of FP register initialization strings
+        '''
+        fp_init_lst = OrderedSet()
+        source_fp_regs = cross.get_source_fp_regs(cross_comb_instrs)
+        
+        # Generate initialization for each source FP register
+        if source_fp_regs:
+            # Initialize the temporary register with FP bit pattern
+            freg_init = REG_INIT[freg].replace('& MASK', '>> FREGWIDTH')
+            fp_init_lst.add(freg_init)
+            
+            # Load each source FP register
+            for fp_reg in source_fp_regs:
+                fp_init_lst.add('FLREG ' + fp_reg + ', 0(' + freg + ')')
+        
+        return list(fp_init_lst)
+
     def get_reginit_str(cross_comb_instrs, freg):
         '''
         This function fetches the register initlialization macro to initialize
@@ -396,6 +443,7 @@ class cross():
 
         Input argument:
             - cross_comb_instrs type: list(dict()) Holds info of various instructions in the sequence
+            - freg type: str The temporary register used for FP operations
         
         Return:
             - List of initialization strings
@@ -454,6 +502,12 @@ class cross():
             
             sig_label = "signature_" + sreg + "_" + str(sreg_dict[sreg])
             code = code + "\nRVTEST_SIGBASE(" + sreg + ", "+ sig_label + ")\n\n"
+
+            if self.if_fp:
+                fp_init_strs = cross.get_fp_init_str(cross_sol, freg)
+                if fp_init_strs:
+                    code += '// Initialize floating point source registers\n'
+                    code += '\n'.join(fp_init_strs) + '\n\n'
 
             rd_lst = OrderedSet()
             # Generate instruction corresponding to each instruction dictionary

--- a/riscv-ctg/tests/test_fp_init.py
+++ b/riscv-ctg/tests/test_fp_init.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Test script to verify FP register initialization implementation
+"""
+
+import sys
+sys.path.insert(0, '/workspaces/riscv-arch-test')
+
+from riscv_ctg.cross_comb import cross
+from ordered_set import OrderedSet
+
+def test_get_source_fp_regs():
+    """Test extraction of source FP registers"""
+    print("Testing get_source_fp_regs()...")
+    
+    # Mock instruction sequence with FP registers
+    cross_comb_instrs = [
+        {'instr': 'fadd.s', 'rd': 'f1', 'rs1': 'f2', 'rs2': 'f3'},
+        {'instr': 'fmul.s', 'rd': 'f4', 'rs1': 'f1', 'rs2': 'f5'},
+        {'instr': 'add', 'rd': 'x1', 'rs1': 'x2', 'rs2': 'x3'},  # GP register
+    ]
+    
+    source_fp_regs = cross.get_source_fp_regs(cross_comb_instrs)
+    expected = OrderedSet(['f2', 'f3', 'f1', 'f5'])
+    
+    assert source_fp_regs == expected, f"Expected {expected}, got {source_fp_regs}"
+    print("✓ get_source_fp_regs() works correctly")
+    print(f"  Found source FP registers: {list(source_fp_regs)}")
+
+def test_get_fp_init_str():
+    """Test generation of FP register initialization code"""
+    print("\nTesting get_fp_init_str()...")
+    
+    cross_comb_instrs = [
+        {'instr': 'fadd.s', 'rd': 'f1', 'rs1': 'f2', 'rs2': 'f3'},
+        {'instr': 'fmul.s', 'rd': 'f4', 'rs1': 'f1', 'rs2': 'f5'},
+    ]
+    
+    freg = 'x10'  # Temporary register
+    fp_init_strs = cross.get_fp_init_str(cross_comb_instrs, freg)
+    
+    assert len(fp_init_strs) > 0, "Expected non-empty initialization strings"
+    assert any('LI' in s for s in fp_init_strs), "Expected LI instruction in initialization"
+    assert any('FLREG' in s for s in fp_init_strs), "Expected FLREG instruction in initialization"
+    
+    print("✓ get_fp_init_str() works correctly")
+    print(f"  Generated {len(fp_init_strs)} initialization statements:")
+    for i, init_str in enumerate(fp_init_strs):
+        print(f"    {i+1}. {init_str[:60]}{'...' if len(init_str) > 60 else ''}")
+
+def test_no_fp_regs():
+    """Test with GP-only instructions"""
+    print("\nTesting with GP-only instructions...")
+    
+    cross_comb_instrs = [
+        {'instr': 'add', 'rd': 'x1', 'rs1': 'x2', 'rs2': 'x3'},
+        {'instr': 'sub', 'rd': 'x4', 'rs1': 'x1', 'rs2': 'x5'},
+    ]
+    
+    source_fp_regs = cross.get_source_fp_regs(cross_comb_instrs)
+    assert len(source_fp_regs) == 0, "Expected no FP registers in GP-only sequence"
+    
+    freg = 'x10'
+    fp_init_strs = cross.get_fp_init_str(cross_comb_instrs, freg)
+    assert len(fp_init_strs) == 0, "Expected no initialization for GP-only sequence"
+    
+    print("✓ Correctly handles GP-only instructions (no FP initialization)")
+
+if __name__ == '__main__':
+    print("=" * 70)
+    print("FP Register Initialization Tests")
+    print("=" * 70)
+    
+    try:
+        test_get_source_fp_regs()
+        test_get_fp_init_str()
+        test_no_fp_regs()
+        
+        print("\n" + "=" * 70)
+        print("✓ All tests passed!")
+        print("=" * 70)
+        sys.exit(0)
+    except AssertionError as e:
+        print(f"\n✗ Test failed: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n✗ Unexpected error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

This PR implements floating-point (FP) register initialization in the cross-combination test generator (`riscv-ctg`), addressing a critical TODO item in the codebase.

### Related Issues

>NA

### Ratified/Unratified Extensions

- [ ] Ratified
- [x] Unratified

### List Extensions

> NA

### Reference Model Used

- [ ] SAIL
- [ ] Spike
- [X] Other - NA

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ?
  - [ ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

  - [X] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.
