### PR TITLE
[ACT4] Update extension parsing logic

### DIFF
--- a/generators/testgen/src/testgen/cli.py
+++ b/generators/testgen/src/testgen/cli.py
@@ -34,7 +34,7 @@ class UnprivTask:
 
     xlen: int
     E_ext: bool
-    extension: str
+    testsuite: str
     testplan_dir: Path
     output_test_dir: Path
 
@@ -43,7 +43,7 @@ class UnprivTask:
 class PrivTask:
     """Task for generating privileged tests."""
 
-    extension: str
+    testsuite: str
     output_test_dir: Path
 
 
@@ -109,13 +109,13 @@ def generate_all_tests(
 
     for xlen in [32, 64]:
         for E_ext in [False, True]:
-            for extension in sorted(unpriv_ext_list):
-                if E_ext and extension not in E_EXTENSION_TESTS:
+            for testsuite in sorted(unpriv_ext_list):
+                if E_ext and testsuite not in E_EXTENSION_TESTS:
                     continue
-                tasks.append(UnprivTask(xlen, E_ext, extension, testplan_dir, output_test_dir))
+                tasks.append(UnprivTask(xlen, E_ext, testsuite, testplan_dir, output_test_dir))
 
-    for extension in sorted(priv_ext_list):
-        tasks.append(PrivTask(extension, output_test_dir))
+    for testsuite in sorted(priv_ext_list):
+        tasks.append(PrivTask(testsuite, output_test_dir))
 
     # Generate all tests in parallel
     with ProcessPoolExecutor(max_workers=jobs) as executor:
@@ -132,13 +132,13 @@ def _dispatch_test_gen(task: UnprivTask | PrivTask) -> None:
         generate_unpriv_extension_tests(
             xlen=task.xlen,
             E_ext=task.E_ext,
-            extension=task.extension,
+            testsuite=task.testsuite,
             testplan_dir=task.testplan_dir,
             output_test_dir=task.output_test_dir,
         )
     elif isinstance(task, PrivTask):
         generate_priv_test(
-            extension=task.extension,
+            testsuite=task.testsuite,
             output_test_dir=task.output_test_dir,
         )
     else:

--- a/generators/testgen/src/testgen/data/config.py
+++ b/generators/testgen/src/testgen/data/config.py
@@ -22,16 +22,20 @@ class TestConfig:
     Attributes:
         xlen: Register width (32 or 64 bits)
         flen: Floating-point register width (32, 64, or 128 bits)
-        extension: RISC-V extension being tested
+        testsuite: Name of the testsuite (e.g., "I", "M", "ZcbM", "MisalignD", "ExceptionsSm")
         E_ext: Whether to use RV32E/RV64E (16 registers instead of 32)
         config_dependent: Whether this test is config dependent
+        required_extensions: List of RISC-V extensions required for the test.
+                             Used for march string and header defines generation.
+                             If None, extensions are parsed from testsuite name.
     """
 
     xlen: int
     flen: int
-    extension: str
+    testsuite: str
     E_ext: bool = False
     config_dependent: bool = False
+    required_extensions: list[str] | None = None
 
     @property
     def xlen_format_str(self) -> str:

--- a/generators/testgen/src/testgen/data/state.py
+++ b/generators/testgen/src/testgen/data/state.py
@@ -55,7 +55,7 @@ class TestData:
         """Get the immutable test configuration."""
         return self._config
 
-    # Extension and instruction name accessors
+    # Testsuite and instruction name accessors
     @property
     def instr_name(self) -> str:
         """Get the instruction name this test is exercising."""
@@ -99,9 +99,9 @@ class TestData:
 
     # Read-only properties delegated to config
     @property
-    def extension(self) -> str:
-        """Get the RISC-V extension this test is exercising."""
-        return self._config.extension
+    def testsuite(self) -> str:
+        """Get the testsuite name."""
+        return self._config.testsuite
 
     @property
     def xlen(self) -> int:
@@ -171,7 +171,7 @@ class TestData:
         self.increment_test_count()
 
         if covergroup is None:
-            covergroup = f"{self.extension}_{self.instr_name}_cg"
+            covergroup = f"{self.testsuite}_{self.instr_name}_cg"
 
         if bin_name is None:
             bin_name = f"test_{self.test_count}"

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -13,19 +13,19 @@ from pathlib import Path
 from testgen.data.config import TestConfig
 from testgen.data.state import TestData
 from testgen.io.writer import write_test_file
-from testgen.priv.registry import get_priv_test_defines, get_priv_test_generator
+from testgen.priv.registry import get_priv_test_defines, get_priv_test_generator, get_priv_test_required_extensions
 
 
-def generate_priv_test(extension: str, output_test_dir: Path) -> None:
+def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     """
-    Generate tests for a privileged extension.
+    Generate tests for a privileged testsuite.
 
     Args:
-        extension: Extension name (e.g., "Sm")
+        testsuite: Testsuite name (e.g., "ExceptionsSm")
         output_test_dir: Base directory to output generated tests
     """
-    # Output always goes to priv/<extension>
-    output_path = output_test_dir / "priv" / extension
+    # Output always goes to priv/<testsuite>
+    output_path = output_test_dir / "priv" / testsuite
     output_path.mkdir(parents=True, exist_ok=True)
 
     # Create test configuration - privileged tests are config_dependent and don't have a fixed xlen
@@ -33,21 +33,22 @@ def generate_priv_test(extension: str, output_test_dir: Path) -> None:
     test_config = TestConfig(
         xlen=0,  # One test for all XLENs
         flen=0,
-        extension=extension,
+        testsuite=testsuite,
         E_ext=False,
         config_dependent=True,
+        required_extensions=get_priv_test_required_extensions(testsuite),
     )
 
     # Create test data
     test_data = TestData(test_config)
 
     # Generate test body
-    priv_test_generator = get_priv_test_generator(extension)
+    priv_test_generator = get_priv_test_generator(testsuite)
     body_lines = priv_test_generator(test_data)
 
     write_test_file(
         test_data,
         body_lines,
         output_path,
-        extra_defines=get_priv_test_defines(extension),
+        extra_defines=get_priv_test_defines(testsuite),
     )

--- a/generators/testgen/src/testgen/generate/unpriv.py
+++ b/generators/testgen/src/testgen/generate/unpriv.py
@@ -23,32 +23,32 @@ from testgen.io.writer import write_test_file
 
 
 def generate_unpriv_extension_tests(
-    xlen: int, E_ext: bool, extension: str, testplan_dir: Path, output_test_dir: Path
+    xlen: int, E_ext: bool, testsuite: str, testplan_dir: Path, output_test_dir: Path
 ) -> None:
     """
-    Generate tests for all instructions in a given unprivileged extension.
+    Generate tests for all instructions in a given unprivileged testsuite.
 
     Args:
         xlen: Target XLEN (32 or 64)
         E_ext: Whether to generate RV32E tests
-        extension: Extension to generate tests for (e.g., 'I', 'M', 'Zmmul')
+        testsuite: Testsuite to generate tests for (e.g., 'I', 'M', 'ZcbM', 'MisalignD')
         testplan_dir: Directory containing testplan CSV files
         output_test_dir: Directory to output generated tests
     """
-    # Read testplan for this extension
-    instructions = read_testplan(testplan_dir / f"{extension}.csv")
-    if extension == "I" and E_ext:
-        extension = "E"
+    # Read testplan for this testsuite
+    instructions = read_testplan(testplan_dir / f"{testsuite}.csv")
+    if testsuite == "I" and E_ext:
+        testsuite = "E"
 
-    # Create extension-wide test configuration
-    output_dir = output_test_dir / f"rv{xlen}{'e' if E_ext else 'i'}/{extension}"
+    # Create testsuite-wide test configuration
+    output_dir = output_test_dir / f"rv{xlen}{'e' if E_ext else 'i'}/{testsuite}"
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    flen = get_flen_for_extension(extension)
-    config_dependent = extension in CONFIG_DEPENDENT_EXTENSIONS
-    test_config = TestConfig(xlen=xlen, flen=flen, extension=extension, E_ext=E_ext, config_dependent=config_dependent)
+    flen = get_flen_for_extension(testsuite)
+    config_dependent = testsuite in CONFIG_DEPENDENT_EXTENSIONS
+    test_config = TestConfig(xlen=xlen, flen=flen, testsuite=testsuite, E_ext=E_ext, config_dependent=config_dependent)
 
-    # Iterate through each instruction in the extension; generate separate test files for each
+    # Iterate through each instruction in the testsuite; generate separate test files for each
     for instr_name, instr_data in sorted(instructions.items()):
         # Skip instructions not valid for this xlen
         if (xlen == 32 and not instr_data.rv32) or (xlen == 64 and not instr_data.rv64):

--- a/generators/testgen/src/testgen/io/templates.py
+++ b/generators/testgen/src/testgen/io/templates.py
@@ -26,13 +26,21 @@ def load_template(template_name: str) -> str:
 def insert_header_template(
     test_config: TestConfig, test_file: Path, sigupd_count: int, extra_defines: list[str] | None = None
 ) -> str:
-    """Load testgen header template file and replace placeholders."""
+    """Load testgen header template file and replace placeholders.
+
+    Args:
+        test_config: Test configuration containing xlen, testsuite, E_ext, etc.
+        test_file: Path to the test file (for header comments).
+        sigupd_count: Number of signature updates in the test.
+        extra_defines: (optional) Additional #define statements for the test.
+    """
     template = load_template("testgen_header.S")
     # Extract extension components
     xlen = test_config.xlen
-    extension = test_config.extension
+    testsuite = test_config.testsuite
     E_ext = test_config.E_ext
-    ext_components, params = canonicalize_extensions(extension, xlen, E_ext)
+    required_extensions = test_config.required_extensions
+    ext_components, params = canonicalize_extensions(testsuite, xlen, E_ext, required_extensions)
     march = generate_march_string(ext_components, xlen)
     if extra_defines is None:
         extra_defines = []
@@ -59,9 +67,19 @@ def insert_footer_template(test_data_section: str, test_string_section: str) -> 
     return template
 
 
-def canonicalize_extensions(extension: str, xlen: int, E_ext: bool) -> tuple[list[str], list[str]]:
-    """Canonicalize extension string."""
-    ext_components = re.findall(r"[A-Z][a-z]*", extension)
+def canonicalize_extensions(
+    testsuite: str, xlen: int, E_ext: bool, required_extensions: list[str] | None = None
+) -> tuple[list[str], list[str]]:
+    """Canonicalize extension string.
+
+    Args:
+        testsuite: Test suite name from test config.
+        xlen: XLEN value.
+        E_ext: Whether the E extension is enabled.
+        required_extensions: If provided, use these extensions instead of parsing from testsuite.
+    """
+    # Use required_extensions if provided, otherwise parse from testsuite name
+    ext_components = required_extensions.copy() if required_extensions else re.findall(r"[A-Z][a-z]*", testsuite)
 
     # Extract parameters
     params: list[str] = []
@@ -74,39 +92,40 @@ def canonicalize_extensions(extension: str, xlen: int, E_ext: bool) -> tuple[lis
 
     # Canonicize extensions
     if "I" not in ext_components and "E" not in ext_components:
-        # Always include base integer extension
-        if E_ext:
-            ext_components.insert(0, "E")
-        else:
-            ext_components.insert(0, "I")
-    if "Zcd" in ext_components and "D" not in ext_components:
+        ext_components.insert(0, "E" if E_ext else "I")  # Always include base integer extension
+    if "Zcd" in ext_components:
         ext_components.append("D")  # Add D if Zcd is present
-    if (
-        any(ext in ext_components for ext in ["Zcf", "D", "Zfh", "Zfhmin", "Zfa", "Zfbfmin"])
-        and "F" not in ext_components
-    ):
+    if any(ext in ext_components for ext in ["Zcf", "D", "Zfh", "Zfhmin", "Zfa", "Zfbfmin"]):
         ext_components.append("F")  # Add F if any floating point extension is present
-    if any(ext in ext_components for ext in ["Sm", "S", "U", "H"]) and "F" not in ext_components:
+    if any(ext in ext_components for ext in ["Sm", "S", "U", "H"]):
         ext_components.append("Zicsr")  # Add Zicsr if any priv extension is present
-    if any(ext in ext_components for ext in ["V", "Zvfh"]) and "M" not in ext_components:
+    if any(ext in ext_components for ext in ["V", "Zvfh"]):
         ext_components.append("M")  # Add M if V is present (required for gcc 15)
+
+    ext_components = list(dict.fromkeys(ext_components))  # Remove duplicates while preserving order
 
     return ext_components, params
 
 
 def generate_march_string(ext_components: list[str], xlen: int) -> str:
     """Generate march string from extension components."""
-    # Construct march string
-    ext_str = ""
+    # Separate single-letter and multi-letter extensions
+    single_letter = []
+    multi_letter = []
     for ext in ext_components:
         if ext in ["Sm", "S", "U"]:
             continue  # Skip privilege modes in march string
-        if len(ext_str) > 0:
-            ext_str += "_"
-        ext_str += ext
+        if len(ext) == 1:
+            single_letter.append(ext)
+        else:
+            multi_letter.append(ext)
+
+    # Construct march string: single-letter extensions first (no separator), then multi-letter (underscore separated)
+    ext_str = "".join(single_letter)
+    if multi_letter:
+        ext_str += "_".join(multi_letter)
     ext_str = ext_str.lower()
     march = f"rv{xlen if xlen != 0 else '${XLEN}'}{ext_str}"
-    march = march.replace("zaamo", "a").replace("zalrsc", "a")  # gcc 14 does not accept Zaamo/Zalrsc
 
     return march
 

--- a/generators/testgen/src/testgen/io/writer.py
+++ b/generators/testgen/src/testgen/io/writer.py
@@ -34,16 +34,16 @@ def write_test_file(
     """
     # Extract test configuration
     test_config = test_data.config
-    extension = test_config.extension
+    testsuite = test_config.testsuite
 
     # Construct filename and paths
     try:
-        filename = f"{extension}-{test_data.instr_name}-{file_idx:02d}.S"
-    except ValueError:  # instr_name is None for extension-level tests
-        filename = f"{extension}-{file_idx:02d}.S"
+        filename = f"{testsuite}-{test_data.instr_name}-{file_idx:02d}.S"
+    except ValueError:  # instr_name is None for priv tests
+        filename = f"{testsuite}-{file_idx:02d}.S"
     test_file = output_dir / filename
     arch_dir = f"rv{test_config.xlen}{'e' if test_config.E_ext else 'i'}" if test_config.xlen else ""
-    test_file_relative = Path(arch_dir) / extension / filename if arch_dir else Path(extension) / filename
+    test_file_relative = Path(arch_dir) / testsuite / filename if arch_dir else Path(testsuite) / filename
 
     # Test header
     final_lines = [insert_header_template(test_config, test_file_relative, test_data.sigupd_count, extra_defines)]

--- a/generators/testgen/src/testgen/priv/__init__.py
+++ b/generators/testgen/src/testgen/priv/__init__.py
@@ -6,6 +6,7 @@ from testgen.priv.registry import (
     get_priv_test_defines,
     get_priv_test_extensions,
     get_priv_test_generator,
+    get_priv_test_required_extensions,
 )
 
 __all__ = [
@@ -13,4 +14,5 @@ __all__ = [
     "get_priv_test_defines",
     "get_priv_test_extensions",
     "get_priv_test_generator",
+    "get_priv_test_required_extensions",
 ]

--- a/generators/testgen/src/testgen/priv/extensions/sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/sm.py
@@ -600,9 +600,9 @@ def _generate_mcsr_cntr_tests(test_data: TestData) -> list[str]:
     return lines
 
 
-@add_priv_test_generator("Sm")
+@add_priv_test_generator("Sm", extensions=["Sm", "Zicsr"])
 def make_sm(test_data: TestData) -> list[str]:
-    """Generate tests for Sm machine-mode extension."""
+    """Generate tests for Sm machine-mode testsuite."""
     lines: list[str] = []
 
     lines.extend(_generate_mcause_tests(test_data))

--- a/generators/testgen/src/testgen/priv/registry.py
+++ b/generators/testgen/src/testgen/priv/registry.py
@@ -20,41 +20,44 @@ PrivTestGenerator = Callable[[TestData], list[str]]
 
 
 class MissingPrivGeneratorError(MissingRegistryItemError):
-    """Raised when no priv test generator is registered for a given extension."""
+    """Raised when no priv test generator is registered for a given testsuite."""
 
-    def __init__(self, extension: str, available_extensions: list[str] | None = None) -> None:
+    def __init__(self, testsuite: str, available_extensions: list[str] | None = None) -> None:
         registry_location = Path(__file__).parent / "extensions"
         super().__init__(
-            extension,
+            testsuite,
             available_extensions,
             item_type="privileged test generator",
             registry_location=registry_location,
         )
-        self.extension = extension
+        self.testsuite = testsuite
 
 
-# Registry: dict mapping extension name to (priv_test_generator, extra_defines)
-_PRIV_TEST_GENERATORS: dict[str, tuple[PrivTestGenerator, list[str]]] = {}
+# Registry: dict mapping testsuite name to (priv_test_generator, extra_defines, extensions)
+_PRIV_TEST_GENERATORS: dict[str, tuple[PrivTestGenerator, list[str], list[str] | None]] = {}
 
 
 def add_priv_test_generator(
-    extension: str,
+    testsuite: str,
     *,
     extra_defines: list[str] | None = None,
+    extensions: list[str] | None = None,
 ) -> Callable[[PrivTestGenerator], PrivTestGenerator]:
     """
     Decorator to register a privileged test generator.
 
     Args:
-        extension: Extension name (e.g., "Sm")
+        testsuite: Testsuite name (e.g., "ExceptionsSm")
         extra_defines: List of extra #define statements for the test header.
                        Trap handlers are added automatically based on extensions.
+        extensions: List of RISC-V extensions required for the test (e.g., ["Sm", "Zicsr"]).
+                    Used for generating the march string and header defines.
     """
     if extra_defines is None:
         extra_defines = []
 
     def decorator(func: PrivTestGenerator) -> PrivTestGenerator:
-        _PRIV_TEST_GENERATORS[extension] = (func, extra_defines)
+        _PRIV_TEST_GENERATORS[testsuite] = (func, extra_defines, extensions)
         return func
 
     return decorator
@@ -65,18 +68,25 @@ def get_priv_test_extensions() -> list[str]:
     return list(_PRIV_TEST_GENERATORS.keys())
 
 
-def get_priv_test_generator(extension: str) -> PrivTestGenerator:
-    """Get the priv test generator function for an extension."""
-    if extension not in _PRIV_TEST_GENERATORS:
-        raise MissingPrivGeneratorError(extension, list(_PRIV_TEST_GENERATORS.keys()))
-    return _PRIV_TEST_GENERATORS[extension][0]
+def get_priv_test_generator(testsuite: str) -> PrivTestGenerator:
+    """Get the priv test generator function for an testsuite."""
+    if testsuite not in _PRIV_TEST_GENERATORS:
+        raise MissingPrivGeneratorError(testsuite, list(_PRIV_TEST_GENERATORS.keys()))
+    return _PRIV_TEST_GENERATORS[testsuite][0]
 
 
-def get_priv_test_defines(extension: str) -> list[str]:
-    """Get the extra_defines for a priv extension."""
-    if extension not in _PRIV_TEST_GENERATORS:
-        raise MissingPrivGeneratorError(extension, list(_PRIV_TEST_GENERATORS.keys()))
-    return _PRIV_TEST_GENERATORS[extension][1]
+def get_priv_test_defines(testsuite: str) -> list[str]:
+    """Get the extra_defines for a priv testsuite."""
+    if testsuite not in _PRIV_TEST_GENERATORS:
+        raise MissingPrivGeneratorError(testsuite, list(_PRIV_TEST_GENERATORS.keys()))
+    return _PRIV_TEST_GENERATORS[testsuite][1]
+
+
+def get_priv_test_required_extensions(testsuite: str) -> list[str] | None:
+    """Get the required RISC-V extensions for a priv testsuite."""
+    if testsuite not in _PRIV_TEST_GENERATORS:
+        raise MissingPrivGeneratorError(testsuite, list(_PRIV_TEST_GENERATORS.keys()))
+    return _PRIV_TEST_GENERATORS[testsuite][2]
 
 
 def _discover_and_import_priv_generators() -> None:


### PR DESCRIPTION
- Refactor test generation to use 'testsuite' terminology instead of 'extension'
- Update priv test generators to take an explicit list of extensions instead of inferring from the testsuite name