### PR TITLE
Add Test Case Where JALR Instructions Expect Clearing the Least Significant Bit

### DIFF
--- a/riscv-test-suite/rv32i_m/I/src/jalr-01.S
+++ b/riscv-test-suite/rv32i_m/I/src/jalr-01.S
@@ -196,6 +196,16 @@ inst_32:
 // imm_val == 32, 
 // opcode: jalr; op1:x10; dest:x11; immval:0x20; align:0 
 TEST_JALR_OP(x5, x11, x10, 0x20, x3, 48,0)
+
+inst_33:
+// imm_val == 0, 
+// opcode: jalr; op1:x14; dest:x17; immval:0x0; align:1 
+TEST_JALR_OP(x9, x17, x14, 0x0, x3, 0,1)
+
+inst_34:
+// imm_val == 1,
+// opcode: jalr; op1:x21; dest:x6; immval:0x1; align:1 
+TEST_JALR_OP(x9, x6, x21, 0x1, x3, 4,1)
 #endif
 
 


### PR DESCRIPTION
This is my first contribution to this repository. I'm trying to be pertinent and follow the reccommended format, so I want to ask for a little patience.

## Description

The RISC-V ISA Manual defines that part of the JALR instruction execution consists of clearing the LSB for calculating the target address.

<img width="851" height="106" alt="Captura de tela 2026-01-26 201758" src="https://github.com/user-attachments/assets/27c62985-91c2-4096-89f3-a40bec4bea6b" />

This detail is sometimes overlooked by enginners, in such a way that forgetting to clear the bit is a common bug, as shown by Yosys's [examplebugs.rst](https://github.com/YosysHQ/riscv-formal/blob/main/docs/source/examplebugs.rst). Also, multiple authors have found this bug in other cores, like in the BlackParrot core by [Kabylkas et al.](https://doi.org/10.1145/3466752.3480092) and in another core by [Rojas et al.](https://doi.org/10.1109/ISCAS51556.2021.9401510). I have found the same bug in one more core, [tinyriscv](https://github.com/liangkangnan/tinyriscv/pull/13).

To improve architectural verification coverage, I propose adding test cases that specifically exercise LSB clearing. I suggest incorporating these into `rv32i_m/I/jalr-01.S`:

```
inst_33:
// imm_val == 0, 
// opcode: jalr; op1:x14; dest:x17; immval:0x0; align:1 
TEST_JALR_OP(x9, x17, x14, 0x0, x3, 0,1)

inst_34:
// imm_val == 1,
// opcode: jalr; op1:x21; dest:x6; immval:0x1; align:1 
TEST_JALR_OP(x9, x6, x21, 0x1, x3, 4,1)
```

### Related Issues

Currently there is a test case [`misalign1-jalr-01.S`](https://github.com/riscv-non-isa/riscv-arch-test/blob/dev/riscv-test-suite/rv32i_m/privilege/src/misalign1-jalr-01.S) inside the `privilege` folder. It looks like most tests in this folder are intended to raise traps and exercise execution mode transitions. I believe that misalign1-jalr looks like an outlier here because it is not supposed to raise a trap if JALR is implemented correctly.

Adding JALR LSB clearing test cases to the `rv32i_m/I` looks like a pertinent option as these tests exercise functional execution logic rather than privilege-mode trap handling.

### List Extensions

This PR only affects the RV32I extension.

### Reference Model Used

I used SAIL for the coverage report generation.

### Mandatory Checklist:

  - [ OK!] All tests are compliant with the test-format spec present in this repo ?
  - [ OK!] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ OK!] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ WAIT] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): I'll wait for your opinion before uploading the coverage report.
