### PR TITLE
[ACT4] Move `RVMODEL_BOOT` to end of test and jump to it

### DIFF
--- a/ctp/src/trickbox.adoc
+++ b/ctp/src/trickbox.adoc
@@ -21,7 +21,7 @@ The trick box is implemented with DUT-specific macros in given in <<t-trickbox>>
 |===
 |Macro|Description
 |RVMODEL_DATA_SECTION|Model-specific data that will be placed in a .data section. Used for memory-mapped regions like `tohost`/`fromhost`.
-|RVMODEL_BOOT|Perform boot operations, such as turning on a phase-locked loop or DRAM controller or initializing custom state
+|RVMODEL_BOOT|Perform boot operations, such as turning on a phase-locked loop or DRAM controller or initializing custom state. Cannot clobber `x1`/`ra`, but any other registers may be trashed.
 |RVMODEL_HALT_PASS|Terminate test with a pass indication.  When the test is run in simulation, this should end the simulation.
 |RVMODEL_HALT_FAIL|Terminate test with a fail indication.  When the test is run in simulation, this should end the simulation.
 |RVMODEL_IO_INIT(_R1, _R2, _R3)|Initialization steps needed prior to writing to the console. _R1, _R2, and _R3 are temporary registers that may be trashed by the macro.

--- a/tests/env/test_setup.h
+++ b/tests/env/test_setup.h
@@ -17,16 +17,15 @@
   .global rvtest_entry_point
   rvtest_entry_point:
 
-  // Include model specific boot code
-  RVMODEL_BOOT
-  RVMODEL_IO_INIT(T1, T2, T3)
-
   // Disable assembler/linker optimizations
   .option push
   .option rvc
   .align UNROLLSZ
   .option norvc
   .section .text.init
+
+  // Include model specific boot code
+  jal x1, rvmodel_boot
 
   // Test initialization
   .global rvtest_init
@@ -130,6 +129,13 @@
     LA(T4, successstr)
     RVMODEL_IO_WRITE_STR(T1, T2, T3, T4)
     RVMODEL_HALT_PASS
+
+  // Model specific boot code
+  rvmodel_boot:
+    RVMODEL_BOOT
+    RVMODEL_IO_INIT(T1, T2, T3)
+    jr x1
+
   .option pop
 .endm
 /******************************** end of RVTEST_CODE_END ***********************************/

--- a/tests/env/test_setup.h
+++ b/tests/env/test_setup.h
@@ -135,6 +135,7 @@
     RVMODEL_BOOT
     RVMODEL_IO_INIT(T1, T2, T3)
     jr x1
+    nop // Padding to ensure valid memory after jr in case it's at the edge of the .text section
 
   .option pop
 .endm


### PR DESCRIPTION
This makes the PC independent of the `RVMODEL_BOOT` code size.