### PR TITLE
[ACT4] Refactor common test selection and simplify config file selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore editor backup files
 *~
 
+# Log files
+*.log
+
 #ignore Mac file system artifacts
 *.DS_Store
 
@@ -19,7 +22,6 @@ __pycache__
 
 # Work directories
 work/
-work-ref/
 
 # Don't check in generated files for now
 coverpoints/unpriv

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 # Directories and files
 # CONFIG_FILES is used as the input configs when just running `make` and will produce elfs in the `work/<config-name>/elfs` directory.
-# COVERAGE_CONFIG_FILES is used as the input configs when just running `make coverage` and will coverage reports in addition to the elfs.
+# COVERAGE_CONFIG_FILES is used as the input configs when just running `make coverage` and will generate coverage reports in addition to the elfs.
 CONFIG_FILES ?= config/spike/spike-rv32-max/test_config.yaml config/spike/spike-rv64-max/test_config.yaml
 COVERAGE_CONFIG_FILES ?= config/sail/sail-rv64-max/test_config.yaml config/sail/sail-rv32-max/test_config.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Directories and files
-# CONFIG_FILES is used as the input configs when just running `make` and will produce els in the `work` directory
-# REF_CONFIG_FILES is used as the input configs when running `make coverage` and will produce elfs and coverage reports in the `work-ref` directory
+# CONFIG_FILES is used as the input configs when just running `make` and will produce elfs in the `work/<config-name>/elfs` directory.
+# COVERAGE_CONFIG_FILES is used as the input configs when just running `make coverage` and will coverage reports in addition to the elfs.
 CONFIG_FILES ?= config/spike/spike-rv32-max/test_config.yaml config/spike/spike-rv64-max/test_config.yaml
-# REF_CONFIG_FILES ?= config/ref/sail-rvi20_32/test_config.yaml config/ref/sail-rvi20_64/test_config.yaml
-REF_CONFIG_FILES ?= config/sail/sail-rv32-max/test_config.yaml config/sail/sail-rv64-max/test_config.yaml
-# REF_CONFIG_FILES ?= config/ref/sail-rv32gc-clang/test_config.yaml config/ref/sail-rv64gc-clang/test_config.yaml
-# REF_CONFIG_FILES ?= config/ref/sail-rv32e/test_config.yaml
+COVERAGE_CONFIG_FILES ?= config/sail/sail-rv64-max/test_config.yaml config/sail/sail-rv32-max/test_config.yaml
 
 WORKDIR     ?= work
-WORKDIR_REF ?= work-ref
-EXTENSIONS  ?= I,M,F,D,Zca,Zcf,Zcd,Zaamo,Zalrsc,Zifencei,Sm # Extensions to generate tests for. Leave blank to generate for all tests.
+EXTENSIONS  ?= I # Extensions to generate tests for. Leave blank to generate for all tests.
+# EXTENSIONS  ?= I,M,F,D,Zca,Zcf,Zcd,Zaamo,Zalrsc,Zifencei,Zicntr,Sm # Extensions to generate tests for. Leave blank to generate for all tests.
 EXCLUDE_EXTENSIONS ?= # Extensions to exclude from test generation. Applies as a negative filter after EXTENSIONS.
 DEBUG       ?= # Set to True to generate debug output (signature objdump and trace files). Leave blank for no debug output.
 
@@ -24,8 +21,6 @@ SRCDIR32       := $(TESTDIR)/rv32i
 SRCDIR32E      := $(TESTDIR)/rv32e
 PRIVDIR        := $(TESTDIR)/priv
 PRIVHEADERSDIR := $(PRIVDIR)/headers
-PRIVDIR64      := $(PRIVDIR)/rv64
-PRIVDIR32      := $(PRIVDIR)/rv32
 
 TEMPLATEDIR := templates
 TESTGEN_SRC_DIR := generators/testgen
@@ -70,16 +65,22 @@ spike-rv64: elfs
 
 ###### Test compilation targets ######
 .PHONY: elfs
-elfs: generate-makefiles-dut Makefile
+elfs: generate-makefiles Makefile
 	$(MAKE) -C $(WORKDIR) compile
 
-.PHONY: generate-makefiles-dut
-generate-makefiles-dut: # too many dependencies to track; always regenerate Makefile
+.PHONY: generate-makefiles
+generate-makefiles: # too many dependencies to track; always regenerate Makefile
 	$(MAKE) tests
-	$(UV_RUN) act $(CONFIG_FILES) --workdir $(WORKDIR) --test-dir $(TESTDIR) $(if $(EXTENSIONS),--extensions $(EXTENSIONS)) $(if $(EXCLUDE_EXTENSIONS),--exclude $(EXCLUDE_EXTENSIONS)) $(if $(DEBUG),--debug)
+	$(UV_RUN) act $(CONFIG_FILES) \
+		--workdir $(WORKDIR) \
+		--test-dir $(TESTDIR) \
+		$(if $(EXTENSIONS),--extensions $(EXTENSIONS)) \
+		$(if $(EXCLUDE_EXTENSIONS),--exclude $(EXCLUDE_EXTENSIONS)) \
+		$(if $(DEBUG),--debug) \
+		$(if $(COVERAGE),--coverage)
 
 .PHONY: clean
-clean: clean-tests clean-ref
+clean: clean-tests
 	@if [ -d $(WORKDIR) ]; then \
 		find $(WORKDIR) \( -type f -o -type l \) ! -name 'extensions.txt' -delete; \
 		find $(WORKDIR) -type d -empty -delete; \
@@ -120,7 +121,7 @@ tests: covergroupgen testgen privheaders
 
 .PHONY: clean-tests
 clean-tests:
-	rm -rf $(SRCDIR64) $(SRCDIR32) $(SRCDIR64E) $(SRCDIR32E) $(PRIVHEADERSDIR) $(PRIVDIR64) $(PRIVDIR32)
+	rm -rf $(SRCDIR64) $(SRCDIR32) $(SRCDIR64E) $(SRCDIR32E) $(PRIVHEADERSDIR)
 	rm -rf fcov/unpriv/*
 	rm -rf $(STAMP_DIR)
 
@@ -128,23 +129,13 @@ $(PRIVHEADERSDIR) $(STAMP_DIR):
 	mkdir -p $@
 
 ###### Coverage targets ######
-.PHONY: generate-makefiles-ref
-generate-makefiles-ref: # too many dependencies to track; always regenerate Makefile
-	$(MAKE) tests
-	$(UV_RUN) act $(REF_CONFIG_FILES) --workdir $(WORKDIR_REF) --test-dir $(TESTDIR) --coverage $(if $(EXTENSIONS),--extensions $(EXTENSIONS)) $(if $(EXCLUDE_EXTENSIONS),--exclude $(EXCLUDE_EXTENSIONS)) $(if $(DEBUG),--debug)
-
 .PHONY: coverage
-coverage: generate-makefiles-ref Makefile
-	$(MAKE) -C $(WORKDIR_REF) coverage
+coverage: COVERAGE := True
+coverage: CONFIG_FILES := $(COVERAGE_CONFIG_FILES)
+coverage: generate-makefiles Makefile
+	$(MAKE) -C $(WORKDIR) coverage
 
-.PHONY: clean-ref
-clean-ref:
-	@if [ -d $(WORKDIR_REF) ]; then \
-		find $(WORKDIR_REF) \( -type f -o -type l \) ! -name 'extensions.txt' -delete; \
-		find $(WORKDIR_REF) -type d -empty -delete; \
-	fi
-
-# Dev targets
+##### Dev targets #####
 .PHONY: lint
 lint:
 	$(UV_RUN) ruff check

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Directories and files
-# CONFIG_FILES is used as the input configs when just running `make` and will produce elfs in the `work/<config-name>/elfs` directory.
-# COVERAGE_CONFIG_FILES is used as the input configs when just running `make coverage` and will generate coverage reports in addition to the elfs.
+# CONFIG_FILES is used as the default input configs when running `make` and will produce elfs in the `work/<config-name>/elfs` directory.
+# COVERAGE_CONFIG_FILES is used as the default input configs when running `make coverage` and will generate coverage reports in addition to the elfs.
 CONFIG_FILES ?= config/spike/spike-rv32-max/test_config.yaml config/spike/spike-rv64-max/test_config.yaml
 COVERAGE_CONFIG_FILES ?= config/sail/sail-rv64-max/test_config.yaml config/sail/sail-rv32-max/test_config.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ CONFIG_FILES ?= config/spike/spike-rv32-max/test_config.yaml config/spike/spike-
 COVERAGE_CONFIG_FILES ?= config/sail/sail-rv64-max/test_config.yaml config/sail/sail-rv32-max/test_config.yaml
 
 WORKDIR     ?= work
-EXTENSIONS  ?= I # Extensions to generate tests for. Leave blank to generate for all tests.
-# EXTENSIONS  ?= I,M,F,D,Zca,Zcf,Zcd,Zaamo,Zalrsc,Zifencei,Zicntr,Sm # Extensions to generate tests for. Leave blank to generate for all tests.
+EXTENSIONS  ?= I,M,F,D,Zca,Zcf,Zcd,Zaamo,Zalrsc,Zifencei,Zicntr,Sm # Extensions to generate tests for. Leave blank to generate for all tests.
 EXCLUDE_EXTENSIONS ?= # Extensions to exclude from test generation. Applies as a negative filter after EXTENSIONS.
 DEBUG       ?= # Set to True to generate debug output (signature objdump and trace files). Leave blank for no debug output.
 

--- a/framework/src/act/act.py
+++ b/framework/src/act/act.py
@@ -16,7 +16,7 @@ from act.config import load_config
 from act.makefile_gen import ConfigData, generate_makefiles
 from act.parse_test_constraints import generate_test_dict
 from act.parse_udb_config import generate_udb_files, get_config_params, get_implemented_extensions
-from act.select_tests import get_common_tests, select_tests
+from act.select_tests import select_tests
 
 # CLI interface setup
 act_app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
@@ -51,13 +51,9 @@ def run_act(
 ) -> None:
     if workdir is None:
         workdir = Path.cwd() / "work"
+
     # Generate test list
     full_test_dict = generate_test_dict(test_dir, extensions, exclude)
-    rv32i_common_tests = get_common_tests(full_test_dict, 32, False)
-    rv32e_common_tests = get_common_tests(full_test_dict, 32, False)
-    rv64i_common_tests = get_common_tests(full_test_dict, 64, False)
-    rv64e_common_tests = get_common_tests(full_test_dict, 64, False)
-    common_test_dicts = [rv32i_common_tests, rv32e_common_tests, rv64i_common_tests, rv64e_common_tests]
 
     configs: list[ConfigData] = []
     for config_file in config_files:
@@ -83,12 +79,9 @@ def run_act(
             }
         )
 
-    # TODO: Add a check that all configs use the same header files/compiler/etc. Otherwise error out or don't use common tests
-
     # Generate Makefiles
     generate_makefiles(
         configs,
-        common_test_dicts,
         test_dir.absolute(),
         coverpoint_dir.absolute(),
         workdir.absolute(),

--- a/framework/src/act/makefile_gen.py
+++ b/framework/src/act/makefile_gen.py
@@ -7,7 +7,9 @@
 # Generate Makefile for tests
 ##################################
 
+import hashlib
 import importlib.resources
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypedDict
 
@@ -24,6 +26,34 @@ MAKEFILE_HEADER = """
 """
 
 OBJDUMP_FLAGS = "-Stsxd -M no-aliases,numeric"
+
+
+def compute_config_hash(config: Config, xlen: int, e_ext: bool) -> str:
+    """Compute a hash of the config options that affect common test compilation.
+
+    Includes the linker script, `model_test.h`, the paths to the compiler, reference model,
+    and objdump executables, xlen, and e_ext.
+    """
+    hasher = hashlib.sha256()
+
+    # Hash the architecture parameters
+    hasher.update(f"{xlen=}".encode())
+    hasher.update(f"{e_ext=}".encode())
+
+    # Hash the linker script contents
+    hasher.update(config.linker_script.read_bytes())
+
+    # Hash model_test.h contents
+    model_test_h = config.dut_include_dir / "model_test.h"
+    hasher.update(model_test_h.read_bytes())
+
+    # Hash executable paths (resolved paths to detect different binaries)
+    hasher.update(str(config.compiler_exe.resolve()).encode())
+    hasher.update(str(config.ref_model_exe.resolve()).encode())
+    if config.objdump_exe is not None:
+        hasher.update(str(config.objdump_exe.resolve()).encode())
+
+    return hasher.hexdigest()
 
 
 def generate_sail_config(xlen: int, e_ext: bool, user_sail_config: Path, common_wkdir: Path) -> Path:
@@ -190,7 +220,7 @@ def generate_common_makefile(
     config: Config,
     common_test_list: dict[str, TestMetadata],
     tests_dir: Path,
-    wkdir: Path,
+    common_wkdir: Path,
     xlen: int,
     e_ext: bool,
     debug: bool,
@@ -204,13 +234,12 @@ def generate_common_makefile(
         config: Configuration object.
         common_test_list: Dictionary of common tests.
         tests_dir: Path to tests directory.
-        wkdir: Working directory.
+        common_wkdir: Working directory for common tests.
         xlen: XLEN (32 or 64).
         e_ext: Whether the 'E' extension is enabled.
         debug: Whether to generate debug output (signature objdump and trace files).
     """
     # Define paths
-    common_wkdir = wkdir / "common"
     common_elf_dir = common_wkdir / "elfs"
     common_build_dir = common_wkdir / "build"
 
@@ -251,6 +280,7 @@ def generate_config_makefile(
     wkdir: Path,
     config_name: str,
     xlen: int,
+    common_dir: str,
     coverage_enabled: bool,
     debug: bool = False,
 ) -> None:
@@ -265,6 +295,7 @@ def generate_config_makefile(
         wkdir: Working directory.
         config_name: Name of the configuration.
         xlen: XLEN (32 or 64).
+        common_dir: directory to generate common tests in. Hash specific.
         coverage_enabled: Whether coverage generation is enabled.
         debug: Whether to generate debug output (signature objdump and trace files).
     """
@@ -274,7 +305,7 @@ def generate_config_makefile(
     config_build_dir = config_wkdir / "build"
     config_coverage_dir = config_wkdir / "coverage"
     config_report_dir = config_wkdir / "reports"
-    common_wkdir = wkdir / "common"
+    common_wkdir = wkdir / common_dir
     common_elf_dir = common_wkdir / "elfs"
 
     # Makefile targets
@@ -444,9 +475,19 @@ class ConfigData(TypedDict):
     selected_tests: dict[str, TestMetadata]
 
 
+@dataclass
+class CommonGroup:
+    """A group of configs that share a common test directory."""
+
+    config: Config  # Representative config (for compiler/linker paths)
+    xlen: int
+    e_ext: bool
+    common_tests: dict[str, TestMetadata] = field(default_factory=dict)
+    configs: list[ConfigData] = field(default_factory=list)
+
+
 def generate_makefiles(
     configs: list[ConfigData],
-    common_test_dicts: list[dict[str, TestMetadata]],
     tests_dir: Path,
     coverpoint_dir: Path,
     workdir: Path,
@@ -455,93 +496,107 @@ def generate_makefiles(
 ) -> None:
     """Generate Makefiles for multiple configurations with shared common directories.
 
+    Configs with the same hash share a common directory named common/{hash[:8]}.
+    Only common tests needed by at least one config in a group are compiled.
+
     Args:
         configs: List of configuration data dictionaries.
-        common_tests: List of dictionaries of common tests (rv32i, rv32e, rv64e, rv64i).
         tests_dir: Path to tests directory.
         coverpoint_dir: Path to coverpoint directory.
         workdir: Working directory.
         coverage_enabled: Whether coverage generation is enabled.
         debug: Whether to generate debug output (signature objdump and trace files).
+
     """
-    rv32i_common_generated = False
-    rv32e_common_generated = False
-    rv64i_common_generated = False
-    rv64e_common_generated = False
-    top_makefile_lines = [MAKEFILE_HEADER]
-    compile_targets: list[str] = []
-    coverage_targets: list[str] = []
+    # Pass 1: Group configs by hash and compute union of needed common tests
+    common_groups: dict[str, CommonGroup] = {}
 
     for config_data in configs:
         # Unpack config data
         config = config_data["config"]
-        config_name = config.name
         xlen = config_data["xlen"]
         e_ext = config_data["e_ext"]
-        selected_tests = config_data["selected_tests"]
 
-        # Extract config parameters
-        if xlen == 32 and e_ext:
-            common_tests = common_test_dicts[1]  # rv32e
-        elif xlen == 32 and not e_ext:
-            common_tests = common_test_dicts[0]  # rv32i
-        elif xlen == 64 and e_ext:
-            common_tests = common_test_dicts[3]  # rv64e
-        else:  # xlen == 64 and not e_config
-            common_tests = common_test_dicts[2]  # rv64i
+        # Compute config hash and add to list of hashes if needed
+        config_hash = compute_config_hash(config, xlen, e_ext)
+        if config_hash not in common_groups:
+            common_groups[config_hash] = CommonGroup(config=config, xlen=xlen, e_ext=e_ext)
 
-        # Update top-level Makefile
-        compile_targets.append(f"{config_name}-compile")
-        coverage_targets.append(f"{config_name}-coverage")
+        # Add this config to the appropriate common list based on hash and add tests to that common list
+        common_group = common_groups[config_hash]
+        common_group.configs.append(config_data)
+        common_group.common_tests.update(
+            {
+                test: metadata
+                for test, metadata in config_data["selected_tests"].items()
+                if not metadata.config_dependent
+            }
+        )
+
+    # Pass 2: Generate Makefiles
+    top_makefile_lines = [MAKEFILE_HEADER]
+    compile_targets: list[str] = []
+    coverage_targets: list[str] = []
+
+    for config_hash, common_group in common_groups.items():
+        arch_key = f"rv{common_group.xlen}{'e' if common_group.e_ext else 'i'}"
+        common_dir = f"common/{config_hash[:8]}"
+        common_compile_target = f"common-{config_hash[:8]}-{arch_key}-compile"
+
+        # Generate common Makefile for this group
+        generate_common_makefile(
+            common_group.config,
+            common_group.common_tests,
+            tests_dir,
+            workdir / common_dir,
+            common_group.xlen,
+            common_group.e_ext,
+            debug,
+        )
         top_makefile_lines.extend(
             [
-                f"{config_name}-compile: common-rv{xlen}{'e' if e_ext else 'i'}-compile",
-                f"\t$(MAKE) -C {config_name} compile",
+                f"{common_compile_target}:",
+                f"\t$(MAKE) -f {common_dir}/Makefile-{arch_key}.mk compile",
                 "",
             ]
         )
-        if coverage_enabled:
+
+        # Generate config Makefiles for each config in this common group
+        for config_data in common_group.configs:
+            config = config_data["config"]
+            compile_targets.append(f"{config.name}-compile")
+            coverage_targets.append(f"{config.name}-coverage")
             top_makefile_lines.extend(
                 [
-                    f"{config_name}-coverage: {config_name}-compile",
-                    f"\t$(MAKE) -C {config_name} coverage",
+                    f"{config.name}-compile: {common_compile_target}",
+                    f"\t$(MAKE) -C {config.name} compile",
                     "",
                 ]
             )
+            if coverage_enabled:
+                top_makefile_lines.extend(
+                    [
+                        f"{config.name}-coverage: {config.name}-compile",
+                        f"\t$(MAKE) -C {config.name} coverage",
+                        "",
+                    ]
+                )
 
-        # Generate config-specific Makefile
-        generate_config_makefile(
-            config,
-            selected_tests,
-            common_tests,
-            tests_dir,
-            coverpoint_dir,
-            workdir,
-            config_name,
-            xlen,
-            coverage_enabled,
-            debug,
-        )
-
-        # Generate architecture-specific common Makefiles using first config of each XLEN
-        if (
-            (xlen == 32 and not e_ext and not rv32i_common_generated)
-            or (xlen == 32 and e_ext and not rv32e_common_generated)
-            or (xlen == 64 and not e_ext and not rv64i_common_generated)
-            or (xlen == 64 and e_ext and not rv64e_common_generated)
-        ):
-            generate_common_makefile(config, common_tests, tests_dir, workdir, xlen, e_ext, debug)
-            top_makefile_lines.extend(
-                [
-                    f"common-rv{xlen}{'e' if e_ext else 'i'}-compile:",
-                    f"\t$(MAKE) -f common/Makefile-rv{xlen}{'e' if e_ext else 'i'}.mk compile",
-                    "",
-                ]
+            generate_config_makefile(
+                config,
+                config_data["selected_tests"],
+                common_group.common_tests,
+                tests_dir,
+                coverpoint_dir,
+                workdir,
+                config.name,
+                common_group.xlen,
+                common_dir,
+                coverage_enabled,
+                debug,
             )
 
-    # Write top-level Makefile
     top_makefile_lines.append(f"compile: {' '.join(compile_targets)}")
     if coverage_enabled:
         top_makefile_lines.append(f"coverage: {' '.join(coverage_targets)}")
-    top_makefile = workdir / "Makefile"
-    top_makefile.write_text("\n".join(top_makefile_lines))
+    (workdir / "Makefile").write_text("\n".join(top_makefile_lines))

--- a/framework/src/act/select_tests.py
+++ b/framework/src/act/select_tests.py
@@ -33,12 +33,3 @@ def select_tests(
             if check_test_params(test_params, config_params):
                 selected_tests[test_name] = test_metadata
     return selected_tests
-
-
-def get_common_tests(test_dict: dict[str, TestMetadata], xlen: int, e_ext: bool) -> dict[str, TestMetadata]:
-    "Get tests that do not depend on configuration and match the given XLEN."
-    common_tests: dict[str, TestMetadata] = {}
-    for test_name, test_metadata in test_dict.items():
-        if not test_metadata.config_dependent and test_metadata.mxlen == xlen and test_metadata.e_ext == e_ext:
-            common_tests[test_name] = test_metadata
-    return common_tests


### PR DESCRIPTION
- Only common tests that are actually needed by one of the input configs are compiled.
- Multiple configs with different compilers/linker scripts/etc. are now supported. Common tests are grouped based on these files so that they do not conflict. This also means `make clean` is no longer needed when switching configs.
- `work-ref` has been removed; all tests are now compiled in `work` for both regular runs and coverage runs.
- `REF_CONFIG_FILES` has been renamed to `COVERAGE_CONFIG_FILES` for clarity.