### PR TITLE
feat: include sail.json memory map in config hash

### DIFF
--- a/framework/src/act/makefile_gen.py
+++ b/framework/src/act/makefile_gen.py
@@ -32,7 +32,7 @@ def compute_config_hash(config: Config, xlen: int, e_ext: bool) -> str:
     """Compute a hash of the config options that affect common test compilation.
 
     Includes the linker script, `rvmodel_macros.h`, the paths to the compiler, reference model,
-    and objdump executables, xlen, and e_ext.
+    and objdump executables, xlen, e_ext, and the memory map from `sail.json` (if present).
     """
     hasher = hashlib.sha256()
 
@@ -46,6 +46,17 @@ def compute_config_hash(config: Config, xlen: int, e_ext: bool) -> str:
     # Hash rvmodel_macros.h contents
     model_test_h = config.dut_include_dir / "rvmodel_macros.h"
     hasher.update(model_test_h.read_bytes())
+
+    # Hash sail.json memory map (if present)
+    sail_config = config.dut_include_dir / "sail.json"
+    if sail_config.exists():
+        try:
+            sail_data = pyjson5.decode(sail_config.read_text())
+            if "memory" in sail_data and "regions" in sail_data["memory"]:
+                hasher.update(str(sail_data["memory"]["regions"]).encode())
+        except Exception:
+            pass
+
 
     # Hash executable paths (resolved paths to detect different binaries)
     hasher.update(str(config.compiler_exe.resolve()).encode())

--- a/framework/src/act/makefile_gen.py
+++ b/framework/src/act/makefile_gen.py
@@ -57,7 +57,6 @@ def compute_config_hash(config: Config, xlen: int, e_ext: bool) -> str:
         except Exception:
             pass
 
-
     # Hash executable paths (resolved paths to detect different binaries)
     hasher.update(str(config.compiler_exe.resolve()).encode())
     hasher.update(str(config.ref_model_exe.resolve()).encode())

--- a/framework/src/act/makefile_gen.py
+++ b/framework/src/act/makefile_gen.py
@@ -9,6 +9,7 @@
 
 import hashlib
 import importlib.resources
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypedDict
@@ -50,12 +51,9 @@ def compute_config_hash(config: Config, xlen: int, e_ext: bool) -> str:
     # Hash sail.json memory map (if present)
     sail_config = config.dut_include_dir / "sail.json"
     if sail_config.exists():
-        try:
-            sail_data = pyjson5.decode(sail_config.read_text())
-            if "memory" in sail_data and "regions" in sail_data["memory"]:
-                hasher.update(str(sail_data["memory"]["regions"]).encode())
-        except Exception:
-            pass
+        sail_data = pyjson5.decode(sail_config.read_text())
+        if "memory" in sail_data and "regions" in sail_data["memory"]:
+            hasher.update(json.dumps(sail_data["memory"]["regions"], sort_keys=True).encode())
 
     # Hash executable paths (resolved paths to detect different binaries)
     hasher.update(str(config.compiler_exe.resolve()).encode())


### PR DESCRIPTION
## Description

This PR updates `compute_config_hash` in `framework/src/act/makefile_gen.py` to include the memory map from a `sail.json` configuration file (if present) when computing the configuration hash.

Previously, configurations with identical linker scripts and compiler settings but different `sail.json` memory maps would result in the same hash, potentially causing `common` test build collisions. Since the reference model (e.g., Sail) relies on `sail.json` during signature generation, differing memory maps must trigger separate `common` build directories to ensure correct execution.

This change:
- Uses `pyjson5` to robustly parse `sail.json`.
- Extracts specifically the `["memory"]["regions"]` section to update the SHA256 hasher.
- Ensures unrelated changes in `sail.json` (comments, other fields) do **not** trigger a rebuild.

### Related Issues

- Follow-up to PR #914.
- Addresses feedback discussed in PR #898 regarding potential memory map inconsistencies.

### Ratified/Unratified Extensions

- [x] Ratified
- [ ] Unratified

### List Extensions

NA (Framework infrastructure update only)

### Reference Model Used

- [ ] SAIL
- [ ] Spike
- [x] Other - Verified logic with Python unit test [test_hash_sail.py](cci:7://file:///home/amit/riscv-arch-test/test_hash_sail.py:0:0-0:0).

### Mandatory Checklist:

  - [ ] All tests are compliant with the test-format spec present in this repo ? (NA - Framework update)
  - [ ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ? (NA - Framework update)
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage) (NA)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): NA

### Optional Checklist:

  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.