### PR TITLE
feat: Implement mode-aware minstret tracking and debug mode (act4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [3.11.0] - 2026-02-11
+
+- Added mode-aware `minstret` tracking.
+  - Implemented `RVTEST_DEBUG_SIGUPD` in `signature.h` for fine-grained instruction retirement tracking.
+  - Updated `arch_test.h` and `test_setup.h` to save initial `minstret` and calculate delta in `RVTEST_CODE_END`.
+  - Added support for `CSR_XSCRATCH` to ensure compatibility across privilege modes (M, S, V).
+  - Updated `act` framework to pass `RVTEST_ENAB_INSTRET_CNT` and `RVTEST_DEBUG` flags.
+
 ## [3.10.0] - 2024-11-04
 
 - Add support for Zvk\* extensions

--- a/config/sail/sail-rv32-max/sail-rv32-max.yaml
+++ b/config/sail/sail-rv32-max/sail-rv32-max.yaml
@@ -55,8 +55,8 @@ implemented_extensions:
   - { name: Ssu32xl, version: "= 1.0.0" }
   - { name: Ssube, version: "= 1.0.0" }
   - { name: Sv32, version: "= 1.13.0" }
-  - { name: Svade, version: "= 1.0.0" }
-  - { name: Svadu, version: "= 1.0.0" }
+  # - { name: Svade, version: "= 1.0.0" } # Removed to resolve conflict with Sm=1.13.0
+  # - { name: Svadu, version: "= 1.0.0" } # Removed to resolve conflict with Sm=1.13.0
   - { name: Svbare, version: "= 1.0.0" }
   - { name: Svinval, version: "= 1.0.0" }
   - { name: Svvptc, version: "= 1.0.0" }
@@ -402,27 +402,6 @@ params:
   FOLLOW_VTYPE_RESET_RECOMMENDATION: true
   HW_MSTATUS_VS_DIRTY_UPDATE: precise
   RVV_VL_WHEN_AVL_LT_DOUBLE_VLMAX: VLMAX
-  SEW_MIN: 8
-  SUPPORT_FRACTIONAL_LMUL_BEYOND_REQUIRED: "no_unrequired_supported"
-  VILL_SET_ON_RESERVED_VTYPE: true
-  RESERVED_VSET_X0X0_VILL_SET: "always"
-  RESERVED_VSET_X0X0_VLMAX_CHANGE: "always"
-  VECTOR_LS_INDEX_MAX_EEW: "XLEN"
-  VECTOR_FF_UPDATE_PAST_TRIM: "update_none"
-  VECTOR_FF_SEG_EXCEPTION_PARTIAL_LOAD: "no_subsegment_loaded"
-  VECTOR_LS_MISALIGNED_LEGAL: true
-  VECTOR_LOAD_PAST_TRAP: false
-  VECTOR_LOAD_SEG_FF_OVERWRITE_ELEMENTS_AFTER_FAULT: "no_overwrite"
-  VECTOR_LS_SEG_PARTIAL_ACCESS: false
-  LEGAL_VSTART: "1_stride"
-  VECTOR_LS_WHOLEREG_MISALIGNED_LEGAL: true
-  VSSTATUS_VS_EXISTS: true
-  VECTOR_FF_NO_EXCEPTION_TRIM: false
-  VFREDUSUM_NAN: "no_change"
-  VFREDUSUM_NODE_ROUNDING_BEHAVIOR: "SEW_precision"
-  VFREDUSUM_INACTIVE_NODE_ELEMENT_BEHAVIOR: "additive_identity"
-  VFREDUSUM_FINAL_NODE_ELEMENT_BEHAVIOR: "additive_identity"
-  IMPRECISE_VECTOR_TRAP_SETTABLE: false
   # H params
   MUTABLE_MISA_H: false
   VSXLEN: [32]

--- a/config/sail/sail-rv64-max/sail-rv64-max.yaml
+++ b/config/sail/sail-rv64-max/sail-rv64-max.yaml
@@ -62,8 +62,8 @@ implemented_extensions:
   - { name: Sv39, version: "= 1.13.0" }
   - { name: Sv48, version: "= 1.13.0" }
   - { name: Sv57, version: "= 1.13.0" }
-  - { name: Svade, version: "= 1.0.0" }
-  - { name: Svadu, version: "= 1.0.0" }
+  # - { name: Svade, version: "= 1.0.0" }
+  # - { name: Svadu, version: "= 1.0.0" }
   - { name: Svbare, version: "= 1.0.0" }
   - { name: Svinval, version: "= 1.0.0" }
   - { name: Svnapot, version: "= 1.0.0" }
@@ -410,27 +410,6 @@ params:
   FOLLOW_VTYPE_RESET_RECOMMENDATION: true
   HW_MSTATUS_VS_DIRTY_UPDATE: precise
   RVV_VL_WHEN_AVL_LT_DOUBLE_VLMAX: VLMAX
-  SEW_MIN: 8
-  SUPPORT_FRACTIONAL_LMUL_BEYOND_REQUIRED: "no_unrequired_supported"
-  VILL_SET_ON_RESERVED_VTYPE: true
-  RESERVED_VSET_X0X0_VILL_SET: "always"
-  RESERVED_VSET_X0X0_VLMAX_CHANGE: "always"
-  VECTOR_LS_INDEX_MAX_EEW: "XLEN"
-  VECTOR_FF_UPDATE_PAST_TRIM: "update_none"
-  VECTOR_FF_SEG_EXCEPTION_PARTIAL_LOAD: "no_subsegment_loaded"
-  VECTOR_LS_MISALIGNED_LEGAL: true
-  VECTOR_LOAD_PAST_TRAP: false
-  VECTOR_LOAD_SEG_FF_OVERWRITE_ELEMENTS_AFTER_FAULT: "no_overwrite"
-  VECTOR_LS_SEG_PARTIAL_ACCESS: false
-  LEGAL_VSTART: "1_stride"
-  VECTOR_LS_WHOLEREG_MISALIGNED_LEGAL: true
-  VSSTATUS_VS_EXISTS: true
-  VECTOR_FF_NO_EXCEPTION_TRIM: false
-  VFREDUSUM_NAN: "no_change"
-  VFREDUSUM_NODE_ROUNDING_BEHAVIOR: "SEW_precision"
-  VFREDUSUM_INACTIVE_NODE_ELEMENT_BEHAVIOR: "additive_identity"
-  VFREDUSUM_FINAL_NODE_ELEMENT_BEHAVIOR: "additive_identity"
-  IMPRECISE_VECTOR_TRAP_SETTABLE: false
   # H params
   MUTABLE_MISA_H: false
   VSXLEN: [64]

--- a/config/spike/spike-rv32-max/spike-rv32-max.yaml
+++ b/config/spike/spike-rv32-max/spike-rv32-max.yaml
@@ -55,8 +55,8 @@ implemented_extensions:
   - { name: Ssu32xl, version: "= 1.0.0" }
   - { name: Ssube, version: "= 1.0.0" }
   - { name: Sv32, version: "= 1.13.0" }
-  - { name: Svade, version: "= 1.0.0" }
-  - { name: Svadu, version: "= 1.0.0" }
+  # - { name: Svade, version: "= 1.0.0" }
+  # - { name: Svadu, version: "= 1.0.0" }
   - { name: Svbare, version: "= 1.0.0" }
   - { name: Svinval, version: "= 1.0.0" }
   - { name: Svvptc, version: "= 1.0.0" }
@@ -402,27 +402,6 @@ params:
   FOLLOW_VTYPE_RESET_RECOMMENDATION: true
   HW_MSTATUS_VS_DIRTY_UPDATE: precise
   RVV_VL_WHEN_AVL_LT_DOUBLE_VLMAX: VLMAX
-  SEW_MIN: 8
-  SUPPORT_FRACTIONAL_LMUL_BEYOND_REQUIRED: "no_unrequired_supported"
-  VILL_SET_ON_RESERVED_VTYPE: true
-  RESERVED_VSET_X0X0_VILL_SET: "always"
-  RESERVED_VSET_X0X0_VLMAX_CHANGE: "always"
-  VECTOR_LS_INDEX_MAX_EEW: "XLEN"
-  VECTOR_FF_UPDATE_PAST_TRIM: "update_none"
-  VECTOR_FF_SEG_EXCEPTION_PARTIAL_LOAD: "no_subsegment_loaded"
-  VECTOR_LS_MISALIGNED_LEGAL: true
-  VECTOR_LOAD_PAST_TRAP: false
-  VECTOR_LOAD_SEG_FF_OVERWRITE_ELEMENTS_AFTER_FAULT: "no_overwrite"
-  VECTOR_LS_SEG_PARTIAL_ACCESS: false
-  LEGAL_VSTART: "1_stride"
-  VECTOR_LS_WHOLEREG_MISALIGNED_LEGAL: true
-  VSSTATUS_VS_EXISTS: true
-  VECTOR_FF_NO_EXCEPTION_TRIM: false
-  VFREDUSUM_NAN: "no_change"
-  VFREDUSUM_NODE_ROUNDING_BEHAVIOR: "SEW_precision"
-  VFREDUSUM_INACTIVE_NODE_ELEMENT_BEHAVIOR: "additive_identity"
-  VFREDUSUM_FINAL_NODE_ELEMENT_BEHAVIOR: "additive_identity"
-  IMPRECISE_VECTOR_TRAP_SETTABLE: false
   # H params
   MUTABLE_MISA_H: false
   VSXLEN: [32]

--- a/config/spike/spike-rv64-max/spike-rv64-max.yaml
+++ b/config/spike/spike-rv64-max/spike-rv64-max.yaml
@@ -62,8 +62,8 @@ implemented_extensions:
   - { name: Sv39, version: "= 1.13.0" }
   - { name: Sv48, version: "= 1.13.0" }
   - { name: Sv57, version: "= 1.13.0" }
-  - { name: Svade, version: "= 1.0.0" }
-  - { name: Svadu, version: "= 1.0.0" }
+  # - { name: Svade, version: "= 1.0.0" }
+  # - { name: Svadu, version: "= 1.0.0" }
   - { name: Svbare, version: "= 1.0.0" }
   - { name: Svinval, version: "= 1.0.0" }
   - { name: Svnapot, version: "= 1.0.0" }
@@ -410,27 +410,6 @@ params:
   FOLLOW_VTYPE_RESET_RECOMMENDATION: true
   HW_MSTATUS_VS_DIRTY_UPDATE: precise
   RVV_VL_WHEN_AVL_LT_DOUBLE_VLMAX: VLMAX
-  SEW_MIN: 8
-  SUPPORT_FRACTIONAL_LMUL_BEYOND_REQUIRED: "no_unrequired_supported"
-  VILL_SET_ON_RESERVED_VTYPE: true
-  RESERVED_VSET_X0X0_VILL_SET: "always"
-  RESERVED_VSET_X0X0_VLMAX_CHANGE: "always"
-  VECTOR_LS_INDEX_MAX_EEW: "XLEN"
-  VECTOR_FF_UPDATE_PAST_TRIM: "update_none"
-  VECTOR_FF_SEG_EXCEPTION_PARTIAL_LOAD: "no_subsegment_loaded"
-  VECTOR_LS_MISALIGNED_LEGAL: true
-  VECTOR_LOAD_PAST_TRAP: false
-  VECTOR_LOAD_SEG_FF_OVERWRITE_ELEMENTS_AFTER_FAULT: "no_overwrite"
-  VECTOR_LS_SEG_PARTIAL_ACCESS: false
-  LEGAL_VSTART: "1_stride"
-  VECTOR_LS_WHOLEREG_MISALIGNED_LEGAL: true
-  VSSTATUS_VS_EXISTS: true
-  VECTOR_FF_NO_EXCEPTION_TRIM: false
-  VFREDUSUM_NAN: "no_change"
-  VFREDUSUM_NODE_ROUNDING_BEHAVIOR: "SEW_precision"
-  VFREDUSUM_INACTIVE_NODE_ELEMENT_BEHAVIOR: "additive_identity"
-  VFREDUSUM_FINAL_NODE_ELEMENT_BEHAVIOR: "additive_identity"
-  IMPRECISE_VECTOR_TRAP_SETTABLE: false
   # H params
   MUTABLE_MISA_H: false
   VSXLEN: [64]

--- a/framework/src/act/makefile_gen.py
+++ b/framework/src/act/makefile_gen.py
@@ -61,6 +61,9 @@ def compute_config_hash(config: Config, xlen: int, e_ext: bool) -> str:
     if config.objdump_exe is not None:
         hasher.update(str(config.objdump_exe.resolve()).encode())
 
+    # Hash the DUT include directory location
+    hasher.update(str(config.dut_include_dir.resolve()).encode())
+
     return hasher.hexdigest()
 
 
@@ -136,7 +139,7 @@ def gen_compile_targets(
         f"{sig_elf}: {test_path} | {sig_elf.parent}\n"
         f"\t{config.compiler_string} $(CFLAGS) \\\n"
         f"\t\t-o {sig_elf} \\\n"
-        f"\t\t-march={march} -mabi={mabi} -DSIGNATURE -DXLEN={xlen} -DFLEN={flen} \\\n"
+        f"\t\t-march={march} -mabi={mabi} -DSIGNATURE -DXLEN={xlen} -DFLEN={flen} -DRVTEST_ENAB_INSTRET_CNT {'-DRVTEST_DEBUG' if debug else ''} \\\n"
         f"\t\t{test_path}\n"
         f"\n"
         # Objdump (only if debug and objdump_exe is set)
@@ -162,7 +165,7 @@ def gen_compile_targets(
         f"{final_elf}: {sig_elf} {result_file} | {final_elf.parent}\n"
         f"\t{config.compiler_string} $(CFLAGS) \\\n"
         f"\t\t-o {final_elf} \\\n"
-        f"\t\t-march={march} -mabi={mabi} -DSELFCHECK -DXLEN={xlen} -DFLEN={flen} \\\n"
+        f"\t\t-march={march} -mabi={mabi} -DSELFCHECK -DXLEN={xlen} -DFLEN={flen} -DRVTEST_ENAB_INSTRET_CNT {'-DRVTEST_DEBUG' if debug else ''} \\\n"
         f'\t\t-DSIGNATURE_FILE=\\"{result_file}\\" \\\n'
         f"\t\t{test_path}\n"
         # Objdump (objdump_exe is set)

--- a/tests/env/arch_test.h
+++ b/tests/env/arch_test.h
@@ -243,7 +243,8 @@
 #define xtvec_new_off        (tramp_sz+13*8)  //  (tvec_new       -Mtrapreg_sv)
 #define xtvec_sav_off        (tramp_sz+14*8)  //  (tvec_save      -Mtrapreg_sv)
 #define xscr_save_off        (tramp_sz+15*8)  //  (scratch_save   -Mtrapreg_sv)
-#define trap_sv_off          (tramp_sz+16*8)  //  (trapreg_sv     -Mtrapreg_sv) 8 registers long
+#define instret_sav_off      (tramp_sz+16*8)  //  (instret_save   -Mtrapreg_sv)
+#define trap_sv_off          (tramp_sz+17*8)  //  (trapreg_sv     -Mtrapreg_sv) 8 registers long
 
 //==============================================================================
 // this section has  general test helper macros, required,  optional, or just useful
@@ -299,9 +300,11 @@
      DBLSHIFT7 x13, x12
 
 #ifdef RVTEST_ENAB_INSTRET_CNT
-     csrr  x14, CSR_MSCRATCH
+  #ifdef rvtest_mtrap_routine
+     csrr  x14, CSR_XSCRATCH
      csrr  x15, CSR_MINSTRET
-     SREG  x15, tramp_sz+4*8(x14)               // this replaces initial canary val w/ instret counter val
+     SREG  x15, instret_sav_off(x14)            // save initial minstret count
+  #endif
 
      DBLSHIFT7 x14, x13
      LI (x15, (0xFAB7FBB6FAB7FBB6 & MASK))
@@ -1671,8 +1674,10 @@ rvtest_\__MODE__\()end:
         .dword  0               // save area for incoming mtvec                       trampsvend+14*8
 \__MODE__\()scratch_save:
         .dword  0               // save area for incoming mscratch                    trampsvend+15*8
+\__MODE__\()instret_save:
+        .dword  0               // save area for initial minstret                     trampsvend+16*8
                                 //****GLOBAL:*****  onlyMMode version used
-\__MODE__\()trapreg_sv:         // hndler regsave area, T1..T6,sp+spare keep dbl algn trampsvend+16*8
+\__MODE__\()trapreg_sv:         // hndler regsave area, T1..T6,sp+spare keep dbl algn trampsvend+17*8
         .fill   8, REGWIDTH, 0xdeadbeef
 
 \__MODE__\()sv_area_end:        // used to calc size, which is used to avoid CSR read trampsvend+24/32+8

--- a/tests/env/failure_code.h
+++ b/tests/env/failure_code.h
@@ -285,6 +285,8 @@
         .string "RVCP: Bad Value: "
     expvalstr:
         .string "RVCP: Expected Value: "
+    instret_delta_mismatch:
+        .string "RVCP: Instret Delta Mismatch\n"
     endstr:
         .string "RVCP: END OF DEBUG INFORMATION\n\n"
 .endm

--- a/tests/env/signature.h
+++ b/tests/env/signature.h
@@ -3,6 +3,30 @@
 # Jordan Carlin jcarlin@hmc.edu October 2025
 # SPDX-License-Identifier: Apache-2.0
 
+#ifdef RVTEST_DEBUG
+  #define RVTEST_DEBUG_SIGUPD(_BR)                  \
+    .option push                                   ;\
+    .option norvc                                  ;\
+    csrrw x6, CSR_XSCRATCH, x6                     ;\
+    SREG x7, trap_sv_off+2*REGWIDTH(x6)            ;\
+    SREG x8, trap_sv_off+3*REGWIDTH(x6)            ;\
+    csrr x7, CSR_XSCRATCH                          ;\
+    SREG x7, trap_sv_off+1*REGWIDTH(x6)            ;\
+    csrw CSR_XSCRATCH, x6                          ;\
+    csrr x7, CSR_MINSTRET                          ;\
+    LREG x8, instret_sav_off(x6)                   ;\
+    sub x8, x7, x8                                 ;\
+    SREG x8, 0(_BR)                                ;\
+    addi _BR, _BR, SIG_STRIDE                      ;\
+    SREG x7, instret_sav_off(x6)                   ;\
+    LREG x8, trap_sv_off+3*REGWIDTH(x6)            ;\
+    LREG x7, trap_sv_off+2*REGWIDTH(x6)            ;\
+    LREG x6, trap_sv_off+1*REGWIDTH(x6)            ;\
+    .option pop
+#else
+  #define RVTEST_DEBUG_SIGUPD(_BR)
+#endif
+
 // RVTEST_SIGUPD(sigptr, linkreg, tempreg, sigreg, strptr)
 // compares the value in sigreg with the value in memory at 0(sigptr).
 // If they are different, it jumps to a failure handler whose label is formed
@@ -17,6 +41,7 @@
 //  _STR_PTR - label to string describing the test
 #ifdef SELFCHECK
   #define RVTEST_SIGUPD(_SIG_PTR, _LINK_REG, _TEMP_REG, _R, _STR_PTR)  \
+    RVTEST_DEBUG_SIGUPD(_SIG_PTR)                          ;\
     LREG _TEMP_REG, 0(_SIG_PTR)                            ;\
     beq _TEMP_REG, _R, 1f                                  ;\
     jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\
@@ -25,6 +50,7 @@
     addi _SIG_PTR, _SIG_PTR, SIG_STRIDE
 #else
   #define RVTEST_SIGUPD(_SIG_PTR, _LINK_REG, _TEMP_REG, _R, _STR_PTR)  \
+    RVTEST_DEBUG_SIGUPD(_SIG_PTR)                          ;\
     SREG _R, 0(_SIG_PTR)                                   ;\
     beq x0, x0, 1f                                         ;\
     jal _LINK_REG, failedtest_##_LINK_REG##_##_TEMP_REG    ;\

--- a/tests/env/test_setup.h
+++ b/tests/env/test_setup.h
@@ -31,6 +31,7 @@
   .global rvtest_init
   rvtest_init:
     INSTANTIATE_MODE_MACRO RVTEST_TRAP_PROLOG // instantiate priv mode specific prologs
+    XCSR_RENAME M // Ensures CSR_XSCRATCH is defined for RVTEST_INIT_GPRS
     RVTEST_INIT_GPRS // 0xF0E1D2C3B4A59687
 
     #ifdef rvtest_mtrap_routine
@@ -97,6 +98,17 @@
   // Switch to M-mode
   rvtest_code_end:
     RVTEST_GOTO_MMODE // If only M-mode used by tests, this has no effect
+
+    // Calculate minstret delta and update signature (now in M-mode)
+    #ifdef RVTEST_ENAB_INSTRET_CNT
+      #ifdef rvtest_mtrap_routine
+        csrr T1, CSR_MSCRATCH
+        LREG T2, instret_sav_off(T1)
+        csrr T3, CSR_MINSTRET
+        sub T3, T3, T2
+        RVTEST_SIGUPD(x2, x5, x4, T3, "instret_delta_mismatch")
+      #endif
+    #endif
 
   // Restore xTVEC, trampoline, regs for each mode in opposite order that they were saved
   cleanup_epilogs:


### PR DESCRIPTION
## Description

This PR implements mode-aware `minstret` (minimum instruction retirement) tracking for the `act4` branch, ensuring full compatibility across Machine (M), Supervisor (S), and Virtual (V) privilege modes.

It addresses previous feedback by utilizing `CSR_XSCRATCH` (via `XCSR_RENAME` macros) instead of hardcoding `CSR_MSCRATCH`. The implementation includes:

1.  **Mode-Aware Tracking**:
    *   Refactored `arch_test.h` and test_setup.h to use `CSR_XSCRATCH` for storing/retrieving the initial `minstret` count. This ensures the correct scratch register (`mscratch`, `sscratch`, or `vsscratch`) is used depending on the test's privilege mode.
    *   Added `XCSR_RENAME M` in `rvtest_init` to guarantee `CSR_XSCRATCH` is properly defined during initialization.

2.  **Instruction Delta Calculation**:
    *   Updated `RVTEST_CODE_END` in `test_setup.h` to calculate the total instruction count (`current - initial`) at the end of the test (after switching to M-mode) and append this delta to the signature.
    *   Defined a dedicated `instret_save` slot (offset 16*8) in `RVTEST_TRAP_SAVEAREA`.

3.  **Fine-Grained Debug Mode**:
    *   Introduced `RVTEST_DEBUG_SIGUPD` in `signature.h`. When debug mode is enabled, this macro calculates and records the incremental `minstret` delta *before every signature update*, allowing for precise per-assertion tracking.
    *   Updated `framework/src/act/makefile_gen.py` to support `RVTEST_ENAB_INSTRET_CNT` (unconditionally) and `RVTEST_DEBUG` (conditionally via `make DEBUG=1`) compiler flags.

### Related Issues

- Closes - #408 

### Ratified/Unratified Extensions

- [x] Ratified
- [ ] Unratified

### List Extensions

All base line extensions (I, M, A, F, D, C) and Privileged Architecture (Machine, Supervisor, Hypervisor).

### Reference Model Used

- [ ] SAIL
- [x] Spike
- [ ] Other - N/A (Environment/Framework Update)

### Mandatory Checklist:

  - [x] All tests are compliant with the test-format spec present in this repo ?
  - [x] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ? (Verified compilation and macro expansion logic manually as this is an environment update).
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): N/A (Infrastructure update, not new tests).

### Optional Checklist:

  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [x] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.