### PR TITLE
All cve2 variants have a single memory region

### DIFF
--- a/config/cores/cve2/cv32e20/rvmodel_macros.h
+++ b/config/cores/cve2/cv32e20/rvmodel_macros.h
@@ -67,9 +67,9 @@
 
 ##### Machine Timer #####
 
-#define RVMODEL_MTIME_ADDR  /* Unimplemented */
+#define RVMODEL_MTIME_ADDRESS /* unimplemented */
 
-#define RVMODEL_MTIMECMP_ADDR  /* Unimplemented */
+#define RVMODEL_MTIMECMP_ADDRESS /* unimplemented */
 
 ##### Machine Interrupts #####
 

--- a/config/cores/cve2/cv32e20/sail.json
+++ b/config/cores/cve2/cv32e20/sail.json
@@ -49,7 +49,7 @@
         },
         "size": {
           "len": 64,
-          "value": "0x40000"
+          "value": "0x80000000"
         },
         "attributes": {
           "cacheable": true,
@@ -62,52 +62,6 @@
           "misaligned_fault": "NoFault",
           "reservability": "RsrvNone",
           "supports_cbo_zero": false
-        },
-        "include_in_device_tree": true
-      },
-      {
-        "base": {
-          "len": 64,
-          "value": "0x2000000"
-        },
-        "size": {
-          "len": 64,
-          "value": "0x2000000"
-        },
-        "attributes": {
-          "cacheable": false,
-          "coherent": true,
-          "executable": false,
-          "readable": true,
-          "writable": true,
-          "read_idempotent": false,
-          "write_idempotent": false,
-          "misaligned_fault": "AlignmentFault",
-          "reservability": "RsrvNone",
-          "supports_cbo_zero": false
-        },
-        "include_in_device_tree": false
-      },
-      {
-        "base": {
-          "len": 64,
-          "value": "0x80000000"
-        },
-        "size": {
-          "len": 64,
-          "value": "0x80000000"
-        },
-        "attributes": {
-          "cacheable": true,
-          "coherent": true,
-          "executable": true,
-          "readable": true,
-          "writable": true,
-          "read_idempotent": true,
-          "write_idempotent": true,
-          "misaligned_fault": "NoFault",
-          "reservability": "RsrvEventual",
-          "supports_cbo_zero": true
         },
         "include_in_device_tree": true
       }


### PR DESCRIPTION
1. Update to `config/cores/cve2/cv32e20/sail.json` to reflect the CVE2's single memory region.
2. Update to `config/cores/cve2/cv32e20/rvmodel_macros.h`: RVMODEL_MTIME_ADDR and RVMODEL_MTIMECMP_ADDR, rshould be RVMODEL_MTIME_ADDRESS and RVMODEL_MTIMECMP_ADDRESS.