### PR TITLE
[ACT4] Enable `.option norelax` for all tests and add 8k `jal`test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ coverpoints/norm/yaml/new
 coverpoints/norm/yaml/chapters
 ctp/mismatch_report.txt
 tests/priv/Sm/Sm-00.S
+tests/priv/ExceptionsZc/ExceptionsZc-00.S
 crd/build

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more details on uv and alternate installation methods, see the [uv installat
 
 #### 3. RISC-V Compiler
 
-The ACT framework is compatible with GCC or LLVM/Clang. This guide uses GCC, but if you prefer LLVM you just need to set the path for the compiler appropriately when [creating your config file](#act-framework-configuration-file).
+The ACT framework is compatible with GCC or LLVM/Clang. This guide uses GCC, but if you prefer LLVM you just need to set the path for the compiler appropriately when [creating your config file](#act-framework-configuration-file). See [config/sail/sail-rv64-max-clang/test_config.yaml](./config/sail/sail-rv64-max-clang/test_config.yaml) for an example.
 
 > [!NOTE]
 >

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more details on uv and alternate installation methods, see the [uv installat
 
 #### 3. RISC-V Compiler
 
-The ACT framework is compatible with GCC or LLVM. This guide uses GCC, but if you prefer LLVM you just need to set the path for the compiler appropriately when [creating your config file](#act-framework-configuration-file).
+The ACT framework is compatible with GCC or LLVM/Clang. This guide uses GCC, but if you prefer LLVM you just need to set the path for the compiler appropriately when [creating your config file](#act-framework-configuration-file).
 
 > [!NOTE]
 >

--- a/config/cores/cve2/cv32e20/sail.json
+++ b/config/cores/cve2/cv32e20/sail.json
@@ -380,7 +380,7 @@
     // Enabling Sstvala requires that the exceptions specified in the extension
     // have their appropriate settings under `base.xtval_nonzero`.
     "Sstvala": {
-      "supported": true
+      "supported": false
     },
     "Svinval": {
       "supported": false

--- a/generators/coverage/templates/cp_imm_edges_jal.txt
+++ b/generators/coverage/templates/cp_imm_edges_jal.txt
@@ -1,7 +1,5 @@
-    cp_imm_edges_jal : coverpoint signed'(ins.current.imm[12:0])  iff (ins.trap == 0 )  {
+    cp_imm_edges_jal : coverpoint ins.current.imm  iff (ins.trap == 0 )  {
         // imm is the jump offset
-        // Adding a range to account for signature logic (32 bytes)
-        // Adding a range to account for signature logic (32 bytes)
         bins b_4     = {4};
         bins b_8     = {8};
         bins b_16    = {16};
@@ -12,8 +10,8 @@
         bins b_512   = {512};
         bins b_1024  = {1024};
         bins b_2048  = {2048};
-        bins b_4096  = {[4064:4096]};
-        bins b_8192  = {8192};
+        bins b_4096  = {4096};
+        // bins b_8192  = {8192}; TODO: We were not generating tests for this coverpoint but it was
         bins b_m4    = {-4};
         bins b_m8    = {-8};
         bins b_m16   = {-16};

--- a/generators/coverage/templates/cp_imm_edges_jal.txt
+++ b/generators/coverage/templates/cp_imm_edges_jal.txt
@@ -1,4 +1,4 @@
-    cp_imm_edges_jal : coverpoint ins.current.imm  iff (ins.trap == 0 )  {
+    cp_imm_edges_jal : coverpoint signed'(ins.current.imm)  iff (ins.trap == 0 )  {
         // imm is the jump offset
         bins b_4     = {4};
         bins b_8     = {8};
@@ -11,7 +11,7 @@
         bins b_1024  = {1024};
         bins b_2048  = {2048};
         bins b_4096  = {4096};
-        // bins b_8192  = {8192}; TODO: We were not generating tests for this coverpoint but it was
+        bins b_8192  = {8192};
         bins b_m4    = {-4};
         bins b_m8    = {-8};
         bins b_m16   = {-16};
@@ -23,4 +23,5 @@
         bins b_m1024 = {-1024};
         bins b_m2048 = {-2048};
         bins b_m4096 = {-4096};
+        bins b_m8192 = {-8192};
     }

--- a/generators/testgen/src/testgen/coverpoints/cp_imm_edges_jal.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_imm_edges_jal.py
@@ -35,8 +35,8 @@ def make_cp_imm_edges_jal(instr_name: str, instr_type: str, coverpoint: str, tes
     if coverpoint == "cp_imm_edges_jal":
         instr_size = 4
         # jal has 20-bit signed offset, but we only test up to 4096
-        max_fwd_align = 12  # 2^12 = 4096
-        max_bwd_align = 12  # 2^12 = 4096
+        max_fwd_align = 13  # 2^13 = 8192
+        max_bwd_align = 13  # 2^13 = 8192
         min_align = 2
         li_instr = "li"
     elif coverpoint == "cp_imm_edges_c_jal":

--- a/tests/env/test_setup.h
+++ b/tests/env/test_setup.h
@@ -17,7 +17,11 @@
   .global rvtest_entry_point
   rvtest_entry_point:
 
-  // Disable assembler/linker optimizations
+  // Globally disable linker relaxation
+  .option push
+  .option norelax
+
+  // Disable assembler/linker optimizations for RVTEST_BEGIN
   .option push
   .option rvc
   .align UNROLLSZ
@@ -87,7 +91,7 @@
 /**** - Terminate test with call to RVMODEL_HALT                                        ****/
 /*******************************************************************************************/
 .macro RVTEST_CODE_END
-  // Disable assembler/linker optimizations
+  // Disable assembler/linker optimizations for RVTEST_CODE_END
   .option push
   .option norvc
   .global rvtest_code_end       // define the label and make it available
@@ -141,6 +145,9 @@
     LA (T1, rvtest_init)
     jr T1                         // Jump back to the start of the test
 
+  .option pop
+
+  // Pop the .option norelax from RVTEST_BEGIN
   .option pop
 .endm
 /******************************** end of RVTEST_CODE_END ***********************************/

--- a/tests/env/test_setup.h
+++ b/tests/env/test_setup.h
@@ -18,6 +18,11 @@
   rvtest_entry_point:
 
   // Globally disable linker relaxation
+  // The linker tries to simplify some code sequences (auipc + addi, jumps, etc.) by default.
+  // This disables that behavior to ensure tests match the desired assembly. The unusual structure
+  // of the ACT tests (compared to standard production code) also has a tendency to hit bugs in the
+  // relaxation process (including incorrect addresses being loaded and c.nops being inserted when
+  // they shouldn't be), so just disable it since we don't care about optimizations.
   .option push
   .option norelax
 

--- a/tests/env/utils.h
+++ b/tests/env/utils.h
@@ -275,9 +275,6 @@
 #endif
 
 /**** fixed length LA macro; alignment and rvc/norvc unknown before execution ****/
-# GCC emits c.nop instructions for alignment even when rvc is off.
-# To avoid executing compressed instructions, we jump over the second alignment
-# directive after loading the address.
 #define LA(reg,val) ;\
   .ifnc(reg, X0)    ;\
     .option push    ;\
@@ -285,10 +282,8 @@
     .align UNROLLSZ ;\
     .option norvc   ;\
     la reg,val      ;\
-    j 9f            ;\
     .align UNROLLSZ ;\
     .option pop     ;\
-    9:              ;\
   .endif
 
 // CSR Macros


### PR DESCRIPTION
- Wrap all tests in `.option norelax` to avoid linker relaxations/optimizations.
  - This fixes a bug that came up in the D-fmul.d tests for QEMU.
  - Disabling relaxation had the side benefit of fixing the Clang issue (all unpriv tests now compile and achieve 100% coverage when compiled with clang) and eliminated the `c.nops` in the `LA` macro, so the hack with a jump was removed.
- Fix issue with `cp_imm_edges_jal` coverpoint testing for values above 12 bits when looking at a 12 bit immediate and add 8k `jal` test.