### PR TITLE
[ACT4] Cancel in-progress CI jobs when a PR is updated

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -7,6 +7,11 @@ on:
   push:
   pull_request:
 
+# Only run CI on the latest commit if a PR is updated
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Pre-commit check


### PR DESCRIPTION
Avoid overloading the number of CI jobs we are allowed to run concurrently.