### PR TITLE
Update README with act4 becomes default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# ⚠️ **Important**: The default branch is now `act4`.  Please make sure you're working on `act4` for all new contributions.
+ACT 3 is now deprecated, new contributions to act 3 will not be accepted.
+this branch will be renamed to `old-framework-3.x`
 
 # RISC-V Architecture Test SIG
 


### PR DESCRIPTION
Added a note about the default branch and deprecation of ACT 3.

<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Provide a detailed description of the changes performed by the PR.

### Related Issues

> Please list all the issues related to this PR. Use NA if no issues exist

### Ratified/Unratified Extensions

- [ ] Ratified
- [ ] Unratified

### List Extensions

> List the extensions that your PR affects. In case of unratified extensions, please provide a link to the spec draft that was referred to make this PR.

### Reference Model Used

- [ ] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

- [ ] All tests are compliant with the test-format spec present in this repo ?
- [ ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
- [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
- [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

- [ ] Were the tests hand-written/modified ?
- [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
- [ ] If you have modified arch_test.h Please provide a detailed description of the changes in the Description section above.
