### PR TITLE
Fix bf16 subnorm values

### DIFF
--- a/generators/coverage/templates/cp_fs1_edges_BF16.sv
+++ b/generators/coverage/templates/cp_fs1_edges_BF16.sv
@@ -16,8 +16,8 @@
         bins negmax_subnorm   = {32'h807f};
         bins posmid_subnorm   = {32'h0040};
         bins negmid_subnorm   = {32'h8040};
-        bins posmin_subnorm   = {32'h0000};
-        bins negmin_subnorm   = {32'h8000};
+        bins posmin_subnorm   = {32'h0001};
+        bins negmin_subnorm   = {32'h8001};
         bins posinfinity      = {32'h7f80};
         bins neginfinity      = {32'hff80};
         bins posQNaN          = {[32'h7fc0:32'h7fff]};

--- a/generators/coverage/templates/cp_fs1_edges_frm_BF16.sv
+++ b/generators/coverage/templates/cp_fs1_edges_frm_BF16.sv
@@ -16,8 +16,8 @@
         bins negmax_subnorm   = {32'h807f};
         bins posmid_subnorm   = {32'h0040};
         bins negmid_subnorm   = {32'h8040};
-        bins posmin_subnorm   = {32'h0000};
-        bins negmin_subnorm   = {32'h8000};
+        bins posmin_subnorm   = {32'h0001};
+        bins negmin_subnorm   = {32'h8001};
         bins posinfinity      = {32'h7f80};
         bins neginfinity      = {32'hff80};
         bins posQNaN          = {[32'h7fc0:32'h7fff]};

--- a/generators/coverage/templates/cp_fs2_edges_BF16.sv
+++ b/generators/coverage/templates/cp_fs2_edges_BF16.sv
@@ -16,8 +16,8 @@
         bins negmax_subnorm   = {32'h807f};
         bins posmid_subnorm   = {32'h0040};
         bins negmid_subnorm   = {32'h8040};
-        bins posmin_subnorm   = {32'h0000};
-        bins negmin_subnorm   = {32'h8000};
+        bins posmin_subnorm   = {32'h0001};
+        bins negmin_subnorm   = {32'h8001};
         bins posinfinity      = {32'h7f80};
         bins neginfinity      = {32'hff80};
         bins posQNaN          = {[32'h7fc0:32'h7fff]};

--- a/generators/coverage/templates/cp_fs3_edges_BF16.sv
+++ b/generators/coverage/templates/cp_fs3_edges_BF16.sv
@@ -16,8 +16,8 @@
         bins negmax_subnorm   = {32'h807f};
         bins posmid_subnorm   = {32'h0040};
         bins negmid_subnorm   = {32'h8040};
-        bins posmin_subnorm   = {32'h0000};
-        bins negmin_subnorm   = {32'h8000};
+        bins posmin_subnorm   = {32'h0001};
+        bins negmin_subnorm   = {32'h8001};
         bins posinfinity      = {32'h7f80};
         bins neginfinity      = {32'hff80};
         bins posQNaN          = {[32'h7fc0:32'h7fff]};

--- a/generators/testgen/src/testgen/data/edges.py
+++ b/generators/testgen/src/testgen/data/edges.py
@@ -366,14 +366,14 @@ class FLOAT_EDGES:
         0x807F,  # largest negative subnorm
         0x0040,  # positive subnorm with leading 1
         0x8040,  # negative subnorm with leading 1
-        0x0000,  # smallest positive subnorm
-        0x8000,  # smallest negative subnorm
+        0x0001,  # smallest positive subnorm
+        0x8001,  # smallest negative subnorm
         0x7F80,  # positive infinity
         0xFF80,  # negative infinity
         0x7FC0,  # canonical quiet NaN
         0x7FFF,  # noncanonical quiet NaN
         0xFFFF,  # noncanonical quiet NaN with sign bit set
-        0x7F80,  # signaling NaN with lsb set
+        0x7F81,  # signaling NaN with lsb set
         0x7FBF,  # signaling NaN with all mantissa bits set
         0xFFBF,  # signaling Nan with all mantissa bits and sign bit set
         0x7EF8,  # random positive 1.6482427e+38


### PR DESCRIPTION
Subnorms were incorrectly truncated from single-precion values.