### PR TITLE
Refactor test labels for failure logging

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -190,10 +190,6 @@ def make_rd(instr_name: str, instr_type: str, coverpoint: str, test_data: TestDa
     # in a particular coverpoint. This could be register numbers, register values,
     # immediate values, etc.
     for rd in rd_regs:
-        # Each testcase needs to include a call to the test_data.add_testcase function.
-        # This adds a label for the test to the generated file and adds the appropriate
-        # debugging string.
-        test_lines.append(test_data.add_testcase(bin_name, coverpoint))
         # Any registers that are explicitly used must be marked as used using the
         # test_data.int_regs.consume_registers function. This will automatically move
         # any reserved registers to ensure the desired register is free.
@@ -206,8 +202,9 @@ def make_rd(instr_name: str, instr_type: str, coverpoint: str, test_data: TestDa
         desc = f"{coverpoint} (Test destination rd = x{rd})"
         # format_single_test is the key part of standard coverpoint generators. It takes
         # the provided instruction parameters (created above) and produces the assembly
-        # sequence necessary to test the given instruction.
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        # sequence necessary to test the given instruction. It also calls test_data.add_testcase
+        # to add a label and debugging string.
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{rd}", coverpoint))
         # Once registers are no longer in use, they need to be marked as available again
         # so that the register allocator knows that they can be reused.
         return_test_regs(test_data, params)
@@ -519,7 +516,7 @@ For examples of how to write the individual coverpoint helper functions for priv
 
 - Do not hardcode register numbers. Instead use the register allocator described above for unprivileged coverpoints (`test_data.int_regs.get_registers(3)`, etc.).
 - Begin each coverpoint with a call to `comment_banner(coverpoint, "comments")` to add a descriptive marker to the generated test.
-- Include a call to `test_data.add_testcase` before each testcase within a coverpoint. This creates the appropriate labels and debug strings.
+- Include a call to `test_data.add_testcase` at the beginning of each testcase within a coverpoint. This creates the appropriate labels and debug strings.
 - To the extent possible, reuse functions and define new helper functions if a snippet of assembly seems like it will be useful in multiple tests. See [`csr.py`](../generators/testgen/src/testgen/asm/csr.py) for a few examples including `gen_csr_read_sigupd`, `gen_csr_write_sigupd`, and `csr_walk_test`.
 
 ## Debugging Coverage

--- a/generators/testgen/src/testgen/asm/csr.py
+++ b/generators/testgen/src/testgen/asm/csr.py
@@ -77,12 +77,15 @@ def csr_access_test(test_data: TestData, csr_name: str, covergroup: str, coverpo
         test_data.add_testcase(f"{csr_name}_csrrw0", coverpoint, covergroup),
         f"\tCSRW({csr_name}, x{temp_reg})    # Write all 1s to CSR",
         gen_csr_read_sigupd(check_reg, csr_name, test_data),
+        "",
         test_data.add_testcase(f"{csr_name}_csrrw1", coverpoint, covergroup),
         f"\tCSRW({csr_name}, zero)   # Write all 0s to CSR",
         gen_csr_read_sigupd(check_reg, csr_name, test_data),
+        "",
         test_data.add_testcase(f"{csr_name}_csrs_all", coverpoint, covergroup),
         f"\tCSRS({csr_name}, x{temp_reg})    # Set all CSR bits",
         gen_csr_read_sigupd(check_reg, csr_name, test_data),
+        "",
         test_data.add_testcase(f"{csr_name}_csrrc_all", coverpoint, covergroup),
         f"\tCSRC({csr_name}, x{temp_reg})    # Clear all CSR bits",
         gen_csr_read_sigupd(check_reg, csr_name, test_data),
@@ -117,6 +120,7 @@ def csr_walk_test(test_data: TestData, csr_name: str, covergroup: str, coverpoin
     for i in range(32):
         lines.extend(
             [
+                "",
                 f"    CSRW({csr_name}, zero)    # clear all bits",
                 f"    CSRS({csr_name}, x{walk_reg})      # set walking 1 in column {i}",
                 test_data.add_testcase(f"{csr_name}_set_bit_{i}", coverpoint, covergroup),
@@ -130,6 +134,7 @@ def csr_walk_test(test_data: TestData, csr_name: str, covergroup: str, coverpoin
     for i in range(32, 64):
         lines.extend(
             [
+                "",
                 f"    CSRW({csr_name}, zero)    # clear all bits",
                 f"    CSRS({csr_name}, x{walk_reg})      # set walking 1 in column {i}",
                 test_data.add_testcase(f"{csr_name}_set_bit_{i}", coverpoint, covergroup),
@@ -144,6 +149,7 @@ def csr_walk_test(test_data: TestData, csr_name: str, covergroup: str, coverpoin
     for i in range(32):
         lines.extend(
             [
+                "",
                 f"    CSRW({csr_name}, x{temp_reg})      # set all bits",
                 f"    CSRC({csr_name}, x{walk_reg})      # clear walking 1 in column {i}",
                 test_data.add_testcase(f"{csr_name}_clr_bit_{i}", coverpoint, covergroup),
@@ -157,6 +163,7 @@ def csr_walk_test(test_data: TestData, csr_name: str, covergroup: str, coverpoin
     for i in range(32, 64):
         lines.extend(
             [
+                "",
                 f"    CSRW({csr_name}, x{temp_reg})    # set all bits",
                 f"    CSRC({csr_name}, x{walk_reg})    # clear walking 1 in column {i}",
                 test_data.add_testcase(f"{csr_name}_clr_bit_{i}", coverpoint, covergroup),

--- a/generators/testgen/src/testgen/asm/csr.py
+++ b/generators/testgen/src/testgen/asm/csr.py
@@ -29,7 +29,7 @@ def gen_csr_read_sigupd(check_reg: int, csr_name: str, test_data: TestData) -> s
     test_data.sigupd_count += 1
     return (
         f"\t# Read {csr_name} into x{check_reg} and check against expected.\n"
-        f"\tRVTEST_SIGUPD_CSR_READ({csr_name}, x{check_reg}, test_{test_data.test_count}, test_{test_data.test_count}_str) "
+        f"\tRVTEST_SIGUPD_CSR_READ({csr_name}, x{check_reg}, {test_data.current_testcase_label}, {test_data.current_testcase_label}_str)"
     )
 
 
@@ -51,7 +51,7 @@ def gen_csr_write_sigupd(check_reg: int, csr_name: str, test_data: TestData) -> 
     test_data.sigupd_count += 1
     return (
         f"\t# Write x{check_reg} to {csr_name}, read back and check against expected.\n"
-        f"\tRVTEST_SIGUPD_CSR_WRITE({csr_name}, x{check_reg}, test_{test_data.test_count}, test_{test_data.test_count}_str) "
+        f"\tRVTEST_SIGUPD_CSR_WRITE({csr_name}, x{check_reg}, {test_data.current_testcase_label}, {test_data.current_testcase_label}_str)"
     )
 
 
@@ -76,19 +76,15 @@ def csr_access_test(test_data: TestData, csr_name: str, covergroup: str, coverpo
         f"\tli x{temp_reg}, -1           # x{temp_reg} = all 1s",
         test_data.add_testcase(f"{csr_name}_csrrw0", coverpoint, covergroup),
         f"\tCSRW({csr_name}, x{temp_reg})    # Write all 1s to CSR",
-        f"test_{test_data.test_count}:",
         gen_csr_read_sigupd(check_reg, csr_name, test_data),
         test_data.add_testcase(f"{csr_name}_csrrw1", coverpoint, covergroup),
         f"\tCSRW({csr_name}, zero)   # Write all 0s to CSR",
-        f"test_{test_data.test_count}:",
         gen_csr_read_sigupd(check_reg, csr_name, test_data),
         test_data.add_testcase(f"{csr_name}_csrs_all", coverpoint, covergroup),
         f"\tCSRS({csr_name}, x{temp_reg})    # Set all CSR bits",
-        f"test_{test_data.test_count}:",
         gen_csr_read_sigupd(check_reg, csr_name, test_data),
         test_data.add_testcase(f"{csr_name}_csrrc_all", coverpoint, covergroup),
         f"\tCSRC({csr_name}, x{temp_reg})    # Clear all CSR bits",
-        f"test_{test_data.test_count}:",
         gen_csr_read_sigupd(check_reg, csr_name, test_data),
         f"\tCSRW({csr_name}, x{save_reg})       # Restore CSR",
     ]
@@ -124,7 +120,6 @@ def csr_walk_test(test_data: TestData, csr_name: str, covergroup: str, coverpoin
                 f"    CSRW({csr_name}, zero)    # clear all bits",
                 f"    CSRS({csr_name}, x{walk_reg})      # set walking 1 in column {i}",
                 test_data.add_testcase(f"{csr_name}_set_bit_{i}", coverpoint, covergroup),
-                f"test_{test_data.test_count}:",
                 gen_csr_read_sigupd(check_reg, csr_name, test_data),
                 f"    slli x{walk_reg}, x{walk_reg}, 1      # walk the 1",
             ]
@@ -138,7 +133,6 @@ def csr_walk_test(test_data: TestData, csr_name: str, covergroup: str, coverpoin
                 f"    CSRW({csr_name}, zero)    # clear all bits",
                 f"    CSRS({csr_name}, x{walk_reg})      # set walking 1 in column {i}",
                 test_data.add_testcase(f"{csr_name}_set_bit_{i}", coverpoint, covergroup),
-                f"test_{test_data.test_count}:",
                 gen_csr_read_sigupd(check_reg, csr_name, test_data),
                 f"    slli x{walk_reg}, x{walk_reg}, 1      # walk the 1",
             ]
@@ -153,7 +147,6 @@ def csr_walk_test(test_data: TestData, csr_name: str, covergroup: str, coverpoin
                 f"    CSRW({csr_name}, x{temp_reg})      # set all bits",
                 f"    CSRC({csr_name}, x{walk_reg})      # clear walking 1 in column {i}",
                 test_data.add_testcase(f"{csr_name}_clr_bit_{i}", coverpoint, covergroup),
-                f"test_{test_data.test_count}:",
                 gen_csr_read_sigupd(check_reg, csr_name, test_data),
                 f"    slli x{walk_reg}, x{walk_reg}, 1      # walk the 1",
             ]
@@ -167,7 +160,6 @@ def csr_walk_test(test_data: TestData, csr_name: str, covergroup: str, coverpoin
                 f"    CSRW({csr_name}, x{temp_reg})    # set all bits",
                 f"    CSRC({csr_name}, x{walk_reg})    # clear walking 1 in column {i}",
                 test_data.add_testcase(f"{csr_name}_clr_bit_{i}", coverpoint, covergroup),
-                f"test_{test_data.test_count}:",
                 gen_csr_read_sigupd(check_reg, csr_name, test_data),
                 f"    slli x{walk_reg}, x{walk_reg}, 1      # walk the 1",
             ]

--- a/generators/testgen/src/testgen/asm/helpers.py
+++ b/generators/testgen/src/testgen/asm/helpers.py
@@ -85,7 +85,7 @@ def write_sigupd(check_reg: int, test_data: TestData, sig_type: Literal["int", "
         return (
             f"\t# Check if x{check_reg} contains the expected result. x{sig_reg} is the signature ptr, "
             + f"x{link_reg} is the link ptr, x{temp_reg} is a temp reg.\n"
-            + f"\tRVTEST_SIGUPD(x{sig_reg}, x{link_reg}, x{temp_reg}, x{check_reg}, test_{test_data.test_count}, test_{test_data.test_count}_str)"
+            + f"\tRVTEST_SIGUPD(x{sig_reg}, x{link_reg}, x{temp_reg}, x{check_reg}, {test_data.current_testcase_label}, {test_data.current_testcase_label}_str)"
         )
     elif sig_type == "float":
         if test_data.flen > test_data.xlen:
@@ -96,7 +96,7 @@ def write_sigupd(check_reg: int, test_data: TestData, sig_type: Literal["int", "
             f"\t# Check if f{check_reg} contains the expected result. Also checks fflags. "
             + f"x{sig_reg} is the signature ptr, x{link_reg} is the link ptr, x{temp_reg} "
             + f"is a temp reg, f{fp_temp_reg} is a floating point temp reg.\n"
-            + f"\tRVTEST_SIGUPD_F(x{sig_reg}, x{link_reg}, x{temp_reg}, f{fp_temp_reg}, f{check_reg}, test_{test_data.test_count}, test_{test_data.test_count}_str)"
+            + f"\tRVTEST_SIGUPD_F(x{sig_reg}, x{link_reg}, x{temp_reg}, f{fp_temp_reg}, f{check_reg}, {test_data.current_testcase_label}, {test_data.current_testcase_label}_str)"
         )
     else:
         raise ValueError(f"Unknown sig_type: {sig_type}")

--- a/generators/testgen/src/testgen/asm/helpers.py
+++ b/generators/testgen/src/testgen/asm/helpers.py
@@ -27,6 +27,7 @@ def comment_banner(title: str, description: str | None = None) -> str:
     """
     lines = [
         "",
+        "",
         "/////////////////////////////////",
         f"// {title}",
     ]

--- a/generators/testgen/src/testgen/coverpoints/cmp_fp_regs.py
+++ b/generators/testgen/src/testgen/coverpoints/cmp_fp_regs.py
@@ -32,12 +32,7 @@ def make_cmp_fd_fs1(instr_name: str, instr_type: str, coverpoint: str, test_data
         test_data.float_regs.consume_registers([reg])
         params = generate_random_params(test_data, instr_type, fd=reg, fs1=reg)
         desc = f"{coverpoint} (Test fd = fs1 = f{reg})"
-        test_lines.extend(
-            [
-                test_data.add_testcase(f"b{reg}", coverpoint),
-                format_single_test(instr_name, instr_type, test_data, params, desc),
-            ]
-        )
+        test_lines.extend([format_single_test(instr_name, instr_type, test_data, params, desc, f"b{reg}", coverpoint)])
         return_test_regs(test_data, params)
 
     return test_lines
@@ -61,12 +56,7 @@ def make_cmp_fd_fs2(instr_name: str, instr_type: str, coverpoint: str, test_data
         test_data.float_regs.consume_registers([reg])
         params = generate_random_params(test_data, instr_type, fd=reg, fs2=reg)
         desc = f"{coverpoint} (Test fd = fs2 = f{reg})"
-        test_lines.extend(
-            [
-                test_data.add_testcase(f"b{reg}", coverpoint),
-                format_single_test(instr_name, instr_type, test_data, params, desc),
-            ]
-        )
+        test_lines.extend([format_single_test(instr_name, instr_type, test_data, params, desc, f"b{reg}", coverpoint)])
         return_test_regs(test_data, params)
 
     return test_lines
@@ -90,12 +80,7 @@ def make_cmp_fd_fs3(instr_name: str, instr_type: str, coverpoint: str, test_data
         test_data.float_regs.consume_registers([reg])
         params = generate_random_params(test_data, instr_type, fd=reg, fs3=reg)
         desc = f"{coverpoint} (Test fd = fs3 = f{reg})"
-        test_lines.extend(
-            [
-                test_data.add_testcase(f"b{reg}", coverpoint),
-                format_single_test(instr_name, instr_type, test_data, params, desc),
-            ]
-        )
+        test_lines.extend([format_single_test(instr_name, instr_type, test_data, params, desc, f"b{reg}", coverpoint)])
         return_test_regs(test_data, params)
 
     return test_lines
@@ -119,12 +104,7 @@ def make_cmp_fs1_fs2(instr_name: str, instr_type: str, coverpoint: str, test_dat
         test_data.float_regs.consume_registers([reg])
         params = generate_random_params(test_data, instr_type, fs1=reg, fs2=reg)
         desc = f"{coverpoint} (Test fs1 = fs2 = f{reg})"
-        test_lines.extend(
-            [
-                test_data.add_testcase(f"b{reg}", coverpoint),
-                format_single_test(instr_name, instr_type, test_data, params, desc),
-            ]
-        )
+        test_lines.extend([format_single_test(instr_name, instr_type, test_data, params, desc, f"b{reg}", coverpoint)])
         return_test_regs(test_data, params)
 
     return test_lines
@@ -148,12 +128,7 @@ def make_cmp_fd_fs1_fs2(instr_name: str, instr_type: str, coverpoint: str, test_
         test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, fd=reg, fs1=reg, fs2=reg)
         desc = f"{coverpoint} (Test fd = fs1 = fs2 = f{reg})"
-        test_lines.extend(
-            [
-                test_data.add_testcase(f"b{reg}", coverpoint),
-                format_single_test(instr_name, instr_type, test_data, params, desc),
-            ]
-        )
+        test_lines.extend([format_single_test(instr_name, instr_type, test_data, params, desc, f"b{reg}", coverpoint)])
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cmp_regs.py
+++ b/generators/testgen/src/testgen/coverpoints/cmp_regs.py
@@ -38,14 +38,13 @@ def make_cmp_rd_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data
 
     # Generate tests
     for reg in regs:
-        test_lines.append(test_data.add_testcase(f"b{reg}", coverpoint))
         if is_pair:
             test_lines.append(test_data.int_regs.consume_register_pair(reg))
         else:
             test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rd=reg, rs1=reg)
         desc = f"{coverpoint} (Test rd = rs1 = x{reg})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{reg}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines
@@ -75,14 +74,13 @@ def make_cmp_rd_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data
 
     # Generate tests
     for reg in regs:
-        test_lines.append(test_data.add_testcase(f"b{reg}", coverpoint))
         if is_pair:
             test_lines.append(test_data.int_regs.consume_register_pair(reg))
         else:
             test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rd=reg, rs2=reg)
         desc = f"{coverpoint} (Test rd = rs2 = x{reg})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{reg}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines
@@ -112,14 +110,13 @@ def make_cmp_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_dat
 
     # Generate tests
     for reg in regs:
-        test_lines.append(test_data.add_testcase(f"b{reg}", coverpoint))
         if is_pair:
             test_lines.append(test_data.int_regs.consume_register_pair(reg))
         else:
             test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rs1=reg, rs2=reg)
         desc = f"{coverpoint} (Test rs1 = rs2 = x{reg})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{reg}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines
@@ -147,14 +144,13 @@ def make_cmp_rd_rs1_rs2(instr_name: str, instr_type: str, coverpoint: str, test_
 
     # Generate tests
     for reg in regs:
-        test_lines.append(test_data.add_testcase(f"b{reg}", coverpoint))
         if is_pair:
             test_lines.append(test_data.int_regs.consume_register_pair(reg))
         else:
             test_lines.append(test_data.int_regs.consume_registers([reg]))
         params = generate_random_params(test_data, instr_type, rd=reg, rs1=reg, rs2=reg)
         desc = f"{coverpoint} (Test rd = rs1 = rs2 = x{reg})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{reg}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_bs.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_bs.py
@@ -25,10 +25,9 @@ def make_cp_bs(instr_name: str, instr_type: str, coverpoint: str, test_data: Tes
 
     test_lines: list[str] = []
     for bs in bs_vals:
-        test_lines.append(test_data.add_testcase(f"b{bs}", coverpoint))
         params = generate_random_params(test_data, instr_type, immval=bs)
         desc = f"{coverpoint}: bs={bs}"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{bs}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_csr_frm.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_csr_frm.py
@@ -24,11 +24,12 @@ def make_frm(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
     frm_modes = (("rmm", 4), ("rup", 3), ("rdn", 2), ("rtz", 1), ("rne", 0))
     test_lines: list[str] = []
     for frm_name, frm_mode in frm_modes:
-        test_lines.append(test_data.add_testcase(f"{frm_name}", coverpoint))
         test_lines.append(f"\nfsrmi 0x{frm_mode:x} # set fcsr.frm to mode {frm_mode}\n")
         params = generate_random_params(test_data, instr_type, exclude_regs=[0])
         desc = f"{coverpoint} (Test dynamic frm, fcsr.frm = {frm_mode})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"{frm_name}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_fli.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_fli.py
@@ -27,12 +27,7 @@ def make_fs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
     for val in range(32):
         params = generate_random_params(test_data, instr_type, rs1=val)
         desc = f"{coverpoint} (val 'rs1' = {val})"
-        test_lines.extend(
-            [
-                test_data.add_testcase(f"b{val}", coverpoint),
-                format_single_test(instr_name, instr_type, test_data, params, desc),
-            ]
-        )
+        test_lines.extend([format_single_test(instr_name, instr_type, test_data, params, desc, f"b{val}", coverpoint)])
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_fp_NaNBox.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_fp_NaNBox.py
@@ -24,10 +24,10 @@ def make_NaNBox(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
     else:
         raise ValueError(f"Unsupported coverpoint for NaN-Box test: {coverpoint} for instr {instr_name}.")
 
-    test_lines = [test_data.add_testcase("NaNBox", coverpoint)]
+    test_lines: list[str] = []
     params = generate_random_params(test_data, instr_type, exclude_regs=[0], fp_load_type=load_size)
     desc = f"{coverpoint} (Test NaN-Boxed inputs)"
-    test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+    test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, "NaNBox", coverpoint))
     return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_fp_badNB.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_fp_badNB.py
@@ -32,12 +32,13 @@ def make_fs1_badNB(instr_name: str, instr_type: str, coverpoint: str, test_data:
 
     test_lines: list[str] = []
     for edge_val in edges:
-        test_lines.append(test_data.add_testcase(f"b{edge_val:#x}", coverpoint))
         params = generate_random_params(
             test_data, instr_type, exclude_regs=[0], fs1val=edge_val, fp_load_type=load_size
         )
         desc = f"{coverpoint} (Test source fs1 value = {test_data.flen_format_str.format(edge_val)})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines
@@ -60,12 +61,13 @@ def make_fs2_badNB(instr_name: str, instr_type: str, coverpoint: str, test_data:
 
     test_lines: list[str] = []
     for edge_val in edges:
-        test_lines.append(test_data.add_testcase(f"b{edge_val:#x}", coverpoint))
         params = generate_random_params(
             test_data, instr_type, exclude_regs=[0], fs2val=edge_val, fp_load_type=load_size
         )
         desc = f"{coverpoint} (Test source fs2 value = {test_data.flen_format_str.format(edge_val)})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines
@@ -84,16 +86,17 @@ def make_fs3_badNB(instr_name: str, instr_type: str, coverpoint: str, test_data:
         edges = FLOAT_EDGES.bad_NaN_single_half
         load_size = "single"
     else:
-        raise ValueError(f"Unsupported coverpoint for fs1 bad NaN-Box tests: {coverpoint} for instr {instr_name}.")
+        raise ValueError(f"Unsupported coverpoint for fs3 bad NaN-Box tests: {coverpoint} for instr {instr_name}.")
 
     test_lines: list[str] = []
     for edge_val in edges:
-        test_lines.append(test_data.add_testcase(f"b{edge_val:#x}", coverpoint))
         params = generate_random_params(
             test_data, instr_type, exclude_regs=[0], fs3val=edge_val, fp_load_type=load_size
         )
         desc = f"{coverpoint} (Test source fs3 value = {test_data.flen_format_str.format(edge_val)})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_fp_reg_edges.py
@@ -34,12 +34,10 @@ def make_fs1_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
     test_lines: list[str] = []
     for edge_val in edges:
         for frm_mode in frm_modes:
-            test_lines.append(
-                test_data.add_testcase(f"b{edge_val:#x}{f'_{frm_mode}' if frm_mode is not None else ''}", coverpoint)
-            )
             params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs1val=edge_val, frm=frm_mode)
+            bin_name = f"b{edge_val:#x}{f'_{frm_mode}' if frm_mode is not None else ''}"
             desc = f"{coverpoint} (Test source fs1 value = {test_data.flen_format_str.format(edge_val)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
-            test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+            test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint))
             return_test_regs(test_data, params)
 
     return test_lines
@@ -59,10 +57,11 @@ def make_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
 
     test_lines: list[str] = []
     for edge_val in edges:
-        test_lines.append(test_data.add_testcase(f"b{edge_val:#x}", coverpoint))
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs2val=edge_val)
         desc = f"{coverpoint} (Test source fs2 value = {test_data.flen_format_str.format(edge_val)})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines
@@ -82,10 +81,11 @@ def make_fs3_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
 
     test_lines: list[str] = []
     for edge_val in edges:
-        test_lines.append(test_data.add_testcase(f"b{edge_val:#x}", coverpoint))
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], fs3val=edge_val)
         desc = f"{coverpoint} (Test source fs3 value = {test_data.flen_format_str.format(edge_val)})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"b{edge_val:#x}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_fp_regs.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_fp_regs.py
@@ -32,12 +32,7 @@ def make_fd(instr_name: str, instr_type: str, coverpoint: str, test_data: TestDa
         test_data.float_regs.consume_registers([fd])
         params = generate_random_params(test_data, instr_type, fd=fd)
         desc = f"{coverpoint} (Test destination fd = f{fd})"
-        test_lines.extend(
-            [
-                test_data.add_testcase(f"b{fd}", coverpoint),
-                format_single_test(instr_name, instr_type, test_data, params, desc),
-            ]
-        )
+        test_lines.extend([format_single_test(instr_name, instr_type, test_data, params, desc, f"b{fd}", coverpoint)])
         return_test_regs(test_data, params)
 
     return test_lines
@@ -61,12 +56,7 @@ def make_fs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
         test_data.float_regs.consume_registers([fs1])
         params = generate_random_params(test_data, instr_type, fs1=fs1)
         desc = f"{coverpoint} (Test source fs1 = f{fs1})"
-        test_lines.extend(
-            [
-                test_data.add_testcase(f"b{fs1}", coverpoint),
-                format_single_test(instr_name, instr_type, test_data, params, desc),
-            ]
-        )
+        test_lines.extend([format_single_test(instr_name, instr_type, test_data, params, desc, f"b{fs1}", coverpoint)])
         return_test_regs(test_data, params)
 
     return test_lines
@@ -74,7 +64,7 @@ def make_fs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
 
 @add_coverpoint_generator("cp_fs2")
 def make_fs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
-    """Generate tests for source floating-point register 1 coverpoints."""
+    """Generate tests for source floating-point register 2 coverpoints."""
     # Determine which fs2 registers to test based on coverpoint variant
     if coverpoint == "cp_fs2":
         fs2_regs = range(test_data.float_regs.reg_count)
@@ -90,12 +80,7 @@ def make_fs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
         test_data.float_regs.consume_registers([fs2])
         params = generate_random_params(test_data, instr_type, fs2=fs2)
         desc = f"{coverpoint} (Test source fs2 = f{fs2})"
-        test_lines.extend(
-            [
-                test_data.add_testcase(f"b{fs2}", coverpoint),
-                format_single_test(instr_name, instr_type, test_data, params, desc),
-            ]
-        )
+        test_lines.extend([format_single_test(instr_name, instr_type, test_data, params, desc, f"b{fs2}", coverpoint)])
         return_test_regs(test_data, params)
 
     return test_lines
@@ -103,7 +88,7 @@ def make_fs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
 
 @add_coverpoint_generator("cp_fs3")
 def make_fs3(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
-    """Generate tests for source floating-point register 1 coverpoints."""
+    """Generate tests for source floating-point register 3 coverpoints."""
     # Determine which fs3 registers to test based on coverpoint variant
     if coverpoint == "cp_fs3":
         fs3_regs = range(test_data.float_regs.reg_count)
@@ -118,13 +103,8 @@ def make_fs3(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
     for fs3 in fs3_regs:
         test_data.float_regs.consume_registers([fs3])
         params = generate_random_params(test_data, instr_type, fs3=fs3)
-        desc = f"{coverpoint} (Test source fs2 = f{fs3})"
-        test_lines.extend(
-            [
-                test_data.add_testcase(f"b{fs3}", coverpoint),
-                format_single_test(instr_name, instr_type, test_data, params, desc),
-            ]
-        )
+        desc = f"{coverpoint} (Test source fs3 = f{fs3})"
+        test_lines.extend([format_single_test(instr_name, instr_type, test_data, params, desc, f"b{fs3}", coverpoint)])
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_frm.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_frm.py
@@ -23,10 +23,11 @@ def make_frm(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
     frm_modes = ("dyn", "rdn", "rmm", "rne", "rtz", "rup")
     test_lines: list[str] = []
     for frm_mode in frm_modes:
-        test_lines.append(test_data.add_testcase(frm_mode, coverpoint))
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], frm=frm_mode)
         desc = f"{coverpoint} (Test frm, mode = {frm_mode})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"b{frm_mode}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_imm_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_imm_edges.py
@@ -33,10 +33,11 @@ def make_cp_imm_edges(instr_name: str, instr_type: str, coverpoint: str, test_da
     test_lines: list[str] = []
 
     for edge_val in edges_imm:
-        test_lines.append(test_data.add_testcase(f"{edge_val:#x}", coverpoint))
         params = generate_random_params(test_data, instr_type, immval=edge_val, exclude_regs=[0])
         desc = f"{coverpoint} (imm = {edge_val})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"{edge_val:#x}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_imm_edges_branch.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_imm_edges_branch.py
@@ -17,16 +17,17 @@ from testgen.formatters.params import generate_random_params
 @add_coverpoint_generator("cp_imm_edges_branch")
 def make_cp_imm_edges_branch(instr_name: str, instr_type: str, coverpoint: str, test_data: TestData) -> list[str]:
     """Generate tests for branch immediate edge values."""
-    test_lines: list[str] = [test_data.add_testcase("all", coverpoint), "# Testcase cp_imm_edges_branch"]
+    test_lines: list[str] = []
     params = generate_random_params(test_data, instr_type, exclude_regs=[0])
     assert params.rs1 is not None and params.rs2 is not None and params.temp_reg is not None
     test_lines.extend(
         [
+            "# Testcase cp_imm_edges_branch",
             load_int_reg("branch check value", params.temp_reg, 4096, test_data),
             f"LI(x{params.rs1}, 1)",
             f"LI(x{params.rs2}, {1 if instr_name in ['beq', 'bge', 'bgeu'] else 2}) # setup for taken branch",
             "",
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("all", coverpoint),
             f"{instr_name} x{params.rs1}, x{params.rs2}, 1f # branch forward by 4",
             "# offset too small to modify counter for checking",
             "1: nop",

--- a/generators/testgen/src/testgen/coverpoints/cp_imm_edges_jal.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_imm_edges_jal.py
@@ -56,13 +56,12 @@ def make_cp_imm_edges_jal(instr_name: str, instr_type: str, coverpoint: str, tes
 
         test_lines.extend(
             [
-                test_data.add_testcase(f"b_{align}", coverpoint),
                 f"# {coverpoint}: forward jump by {1 << align}",
                 f"{li_instr} x{params.temp_reg}, 1 # success code"
                 if not skip_check
                 else "# offset too small, skipping self-check",
                 f".align {align}",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(f"b_{align}", coverpoint),
                 f"{instr_name} {f'x{params.rd},' if instr_name == 'jal' else ''} {coverpoint}_fwd_{bin_name}",
                 f"{li_instr} x{params.temp_reg}, -1 # failure code"
                 if not skip_check
@@ -86,14 +85,13 @@ def make_cp_imm_edges_jal(instr_name: str, instr_type: str, coverpoint: str, tes
 
         test_lines.extend(
             [
-                test_data.add_testcase(f"b_m{align}", coverpoint),
                 f"# {coverpoint}: backward jump by {1 << align}",
                 f"{li_instr} x{params.temp_reg}, 1 # success code"
                 if not skip_check
                 else "# offset too small, skipping self-check",
                 f".align {align + 1}",
                 # Jump over the target
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(f"b_m{align}", coverpoint),
                 f"{instr_name} {f'x{params.rd},' if instr_name == 'jal' else ''} {coverpoint}_skip_{bin_name}",
                 # Align target to 2^align boundary
                 f".align {align}",

--- a/generators/testgen/src/testgen/coverpoints/cp_imm_mul.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_imm_mul.py
@@ -35,10 +35,9 @@ def make_cp_uimm(instr_name: str, instr_type: str, coverpoint: str, test_data: T
         raise ValueError(f"Unknown cp_uimm coverpoint variant: {coverpoint} for {instr_name}")
     test_lines: list[str] = []
     for imm in imm_mul:
-        test_lines.append(test_data.add_testcase(f"b{imm:#x}", coverpoint))
         params = generate_random_params(test_data, instr_type, immval=imm, exclude_regs=exclude_regs)
         desc = f"{coverpoint}: imm={imm}"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{imm:#x}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_memval.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_memval.py
@@ -31,7 +31,6 @@ def make_memval(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
 
     test_lines: list[str] = []
     for val in memvals:
-        test_lines.append(test_data.add_testcase(f"{val:#x}", coverpoint))
         if instr_type == "S":
             params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs2val=val)
         elif instr_type == "L":
@@ -39,7 +38,7 @@ def make_memval(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
         else:
             raise ValueError(f"cp_memval coverpoint not supported for instruction type: {instr_type} in {instr_name}")
         desc = f"{coverpoint} (memory value = {val:#x})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"{val:#x}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_rbox.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_rbox.py
@@ -24,10 +24,9 @@ def make_cp_rnum(instr_name: str, instr_type: str, coverpoint: str, test_data: T
 
     test_lines: list[str] = []
     for rnum in rnum_vals:
-        test_lines.append(test_data.add_testcase(f"b{rnum}", coverpoint))
         params = generate_random_params(test_data, instr_type, immval=rnum)
         desc = f"{coverpoint}: rnum={rnum}"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{rnum}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_reg_edges.py
@@ -27,10 +27,11 @@ def make_rs1_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
 
     test_lines: list[str] = []
     for edge_val in edges:
-        test_lines.append(test_data.add_testcase(f"{edge_val:#x}", coverpoint))
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs1val=edge_val)
         desc = f"{coverpoint} (Test source rs1 value = {test_data.xlen_format_str.format(edge_val)})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"{edge_val:#x}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines
@@ -46,10 +47,11 @@ def make_rs2_edges(instr_name: str, instr_type: str, coverpoint: str, test_data:
 
     test_lines: list[str] = []
     for edge_val in edges:
-        test_lines.append(test_data.add_testcase(f"{edge_val:#x}", coverpoint))
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs2val=edge_val)
         desc = f"{coverpoint} (Test source rs2 value = {test_data.xlen_format_str.format(edge_val)})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"{edge_val:#x}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_regs.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_regs.py
@@ -36,14 +36,13 @@ def make_rd(instr_name: str, instr_type: str, coverpoint: str, test_data: TestDa
 
     # Generate tests
     for rd in rd_regs:
-        test_lines.append(test_data.add_testcase(f"b{rd}", coverpoint))
         if is_pair:
             test_lines.append(test_data.int_regs.consume_register_pair(rd))
         else:
             test_lines.append(test_data.int_regs.consume_registers([rd]))
         params = generate_random_params(test_data, instr_type, rd=rd)
         desc = f"{coverpoint} (Test destination rd = x{rd})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{rd}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines
@@ -74,14 +73,13 @@ def make_rs1(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
 
     # Generate tests
     for rs1 in rs1_regs:
-        test_lines.append(test_data.add_testcase(f"b{rs1}", coverpoint))
         if is_pair:
             test_lines.append(test_data.int_regs.consume_register_pair(rs1))
         else:
             test_lines.append(test_data.int_regs.consume_registers([rs1]))
         params = generate_random_params(test_data, instr_type, rs1=rs1)
         desc = f"{coverpoint} (Test source rs1 = x{rs1})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{rs1}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines
@@ -109,14 +107,13 @@ def make_rs2(instr_name: str, instr_type: str, coverpoint: str, test_data: TestD
 
     # Generate tests
     for rs2 in rs2_regs:
-        test_lines.append(test_data.add_testcase(f"b{rs2}", coverpoint))
         if is_pair:
             test_lines.append(test_data.int_regs.consume_register_pair(rs2))
         else:
             test_lines.append(test_data.int_regs.consume_registers([rs2]))
         params = generate_random_params(test_data, instr_type, rs2=rs2)
         desc = f"{coverpoint} (Test source rs2 = x{rs2})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{rs2}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_sbox.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_sbox.py
@@ -24,7 +24,6 @@ def make_cp_sbox(instr_name: str, instr_type: str, coverpoint: str, test_data: T
 
     test_lines: list[str] = []
     for sbox in sbox_vals:
-        test_lines.append(test_data.add_testcase(f"b{sbox}", coverpoint))
         # repeat sbox value in each byte
         if test_data.xlen == 32:
             s = sbox | sbox << 8 | sbox << 16 | sbox << 24
@@ -33,7 +32,7 @@ def make_cp_sbox(instr_name: str, instr_type: str, coverpoint: str, test_data: T
 
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs1val=s, rs2val=s)
         desc = f"{coverpoint} = {sbox}"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, f"b{sbox}", coverpoint))
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cp_uimm.py
+++ b/generators/testgen/src/testgen/coverpoints/cp_uimm.py
@@ -28,10 +28,11 @@ def make_cp_uimm(instr_name: str, instr_type: str, coverpoint: str, test_data: T
 
     test_lines: list[str] = []
     for uimm in uimm_vals:
-        test_lines.append(test_data.add_testcase(f"uimm{uimm}", coverpoint))
         params = generate_random_params(test_data, instr_type, immval=uimm)
         desc = f"{coverpoint}: imm={uimm}"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"uimm{uimm}", coverpoint)
+        )
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cr_fp_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cr_fp_reg_edges.py
@@ -40,24 +40,15 @@ def make_cr_fs1_fs2_edges(instr_name: str, instr_type: str, coverpoint: str, tes
         for edge_val2 in edges2:
             # Explicit rounding modes (if needed)
             for frm_mode in frm_modes:
-                test_lines.append(
-                    test_data.add_testcase(f"rs1val={edge_val1:#x}, rs2val={edge_val2:#x}, frm={frm_mode}", coverpoint)
-                )
                 params = generate_random_params(
                     test_data, instr_type, exclude_regs=[0], fs1val=edge_val1, fs2val=edge_val2, frm=frm_mode
                 )
+                bin_name = f"fs1val={edge_val1:#x}, fs2val={edge_val2:#x}, frm={frm_mode}"
                 desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs2 = {test_data.flen_format_str.format(edge_val2)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
-                test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+                test_lines.append(
+                    format_single_test(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
+                )
                 return_test_regs(test_data, params)
-            # Dynamic rounding modes
-            # if cross_frm:
-            #     for frm_mode in (4, 3, 2, 1, 0):  # csr frm modes 0-4, end at 0 so the rest of the test continues in rne
-            #         test_data.add_testcase(f"rs1val={edge_val1:#x}, rs2val={edge_val2:#x}, frm_dyn={frm_mode}", coverpoint)
-            #         test_lines.append(f"\nfsrmi 0x{frm_mode:x} # set fcsr.frm to mode {frm_mode}\n")
-            #         params = generate_random_params(test_data, instr_type, exclude_regs=[0])
-            #         desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs2 = {test_data.flen_format_str.format(edge_val2)}, fcsr.frm = {frm_mode})"
-            #         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-            #         return_test_regs(test_data, params)
 
     return test_lines
 
@@ -87,23 +78,14 @@ def make_cr_fs1_fs3_edges(instr_name: str, instr_type: str, coverpoint: str, tes
         for edge_val2 in edges2:
             # Explicit rounding modes (if needed)
             for frm_mode in frm_modes:
-                test_lines.append(
-                    test_data.add_testcase(f"fs1val={edge_val1:#x}, fs3val={edge_val2:#x}, frm={frm_mode}", coverpoint)
-                )
                 params = generate_random_params(
                     test_data, instr_type, exclude_regs=[0], fs1val=edge_val1, fs3val=edge_val2, frm=frm_mode
                 )
                 desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs3 = {test_data.flen_format_str.format(edge_val2)}{f', frm = {frm_mode}' if frm_mode is not None else ''})"
-                test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+                bin_name = f"fs1val={edge_val1:#x}, fs3val={edge_val2:#x}, frm={frm_mode}"
+                test_lines.append(
+                    format_single_test(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint)
+                )
                 return_test_regs(test_data, params)
-            # Dynamic rounding modes
-            # if cross_frm:
-            #     for frm_mode in (4, 3, 2, 1, 0):  # csr frm modes 0-4, end at 0 so the rest of the test continues in rne
-            #         test_data.add_testcase(f"fs1val={edge_val1:#x}, fs3val={edge_val2:#x}, frm_dyn={frm_mode}", coverpoint)
-            #         test_lines.append(f"\nfsrmi 0x{frm_mode:x} # set fcsr.frm to mode {frm_mode}\n")
-            #         params = generate_random_params(test_data, instr_type, exclude_regs=[0])
-            #         desc = f"{coverpoint} (Test source fs1 = {test_data.flen_format_str.format(edge_val1)} fs3 = {test_data.flen_format_str.format(edge_val2)}, fcsr.frm = {frm_mode})"
-            #         test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
-            #         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cr_reg_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cr_reg_edges.py
@@ -27,10 +27,10 @@ def make_cr_rs1_rs2_edges(instr_name: str, instr_type: str, coverpoint: str, tes
     test_lines: list[str] = []
     for edge_val1 in edges1:
         for edge_val2 in edges2:
-            test_lines.append(test_data.add_testcase(f"rs1val={edge_val1:#x}, rs2val={edge_val2:#x}", coverpoint))
             params = generate_random_params(test_data, instr_type, exclude_regs=[0], rs1val=edge_val1, rs2val=edge_val2)
+            bin_name = f"rs1val={edge_val1:#x}, rs2val={edge_val2:#x}"
             desc = f"{coverpoint} (Test source rs1 = {test_data.xlen_format_str.format(edge_val1)} rs2 = {test_data.xlen_format_str.format(edge_val2)})"
-            test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+            test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint))
             return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/cr_rs1_imm_edges.py
+++ b/generators/testgen/src/testgen/coverpoints/cr_rs1_imm_edges.py
@@ -38,12 +38,12 @@ def make_cr_rs1_imm_edges(instr_name: str, instr_type: str, coverpoint: str, tes
 
     for reg_edge_val in edges_reg:
         for imm_edge_val in edges_imm:
-            test_lines.append(test_data.add_testcase(f"rs1val={reg_edge_val:#x}, immval={imm_edge_val:#x}", coverpoint))
             params = generate_random_params(
                 test_data, instr_type, exclude_regs=[0], rs1val=reg_edge_val, immval=imm_edge_val
             )
             desc = f"{coverpoint} (rs1 = {test_data.xlen_format_str.format(reg_edge_val)}, imm = {imm_edge_val})"
-            test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+            bin_name = f"rs1val={reg_edge_val:#x}, immval={imm_edge_val:#x}"
+            test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc, bin_name, coverpoint))
             return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/special/cp_align.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_align.py
@@ -28,7 +28,6 @@ def make_align(instr_name: str, instr_type: str, coverpoint: str, test_data: Tes
     test_lines: list[str] = []
 
     for alignment in alignments:
-        test_lines.append(test_data.add_testcase(f"b{alignment}", coverpoint))
         if instr_type == "L":
             params = generate_random_params(test_data, instr_type, exclude_regs=[0], immval=alignment)
             assert params.rs1 is not None, "rs1 must be provided for L-type instruction"
@@ -44,7 +43,7 @@ def make_align(instr_name: str, instr_type: str, coverpoint: str, test_data: Tes
                     load_int_reg("temp_reg", params.temp_reg, params.temp_val, test_data),
                     f"SREG x{params.temp_reg}, 0(x{params.rs1}) # store test value to memory",
                     f"SREG x{params.temp_reg}, REGWIDTH(x{params.rs1}) # store test value to memory",
-                    f"test_{test_data.test_count}:",
+                    test_data.add_testcase(f"b{alignment}", coverpoint),
                     f"{instr_name} x{params.rd}, {params.immval}(x{params.rs1}) # perform load",
                     write_sigupd(params.rd, test_data, "int"),
                     "",
@@ -66,7 +65,7 @@ def make_align(instr_name: str, instr_type: str, coverpoint: str, test_data: Tes
                 [
                     f"# Testcase: {coverpoint} (imm[2:0] = {params.immval:03b})",
                     load_int_reg("rs2", params.rs2, params.rs2val, test_data),
-                    f"test_{test_data.test_count}:",
+                    test_data.add_testcase(f"b{alignment}", coverpoint),
                     f"{instr_name} x{params.rs2}, {params.immval}(x{test_data.int_regs.sig_reg}) # perform store",
                     f"addi x{test_data.int_regs.sig_reg}, x{test_data.int_regs.sig_reg}, {offset} # increment signature pointer",
                     "#ifdef RVTEST_SELFCHECK",
@@ -118,7 +117,7 @@ def make_align(instr_name: str, instr_type: str, coverpoint: str, test_data: Tes
                     f"LA(x{params.rs1}, scratch) # load base address into rs1",
                     f"addi x{params.rs1}, x{params.rs1}, {alignment} # adjust for alignment",
                     f"{store_instr} x{params.temp_reg}, 0(x{params.rs1}) # store value into memory at address in rs1",
-                    f"test_{test_data.test_count}:",
+                    test_data.add_testcase(f"b{alignment}", coverpoint),
                     f"{instr_name} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation",
                     write_sigupd(params.rd, test_data, "int"),
                     f"{load_instr} x{params.rs1}, 0(x{params.rs1}) # Load the updated value from memory",

--- a/generators/testgen/src/testgen/coverpoints/special/cp_asm_count.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_asm_count.py
@@ -16,8 +16,8 @@ def make_asm_count(instr_name: str, instr_type: str, coverpoint: str, test_data:
     Used for counting instruction execution in simulation.
     """
     test_lines = [
-        test_data.add_testcase("count", coverpoint),
         "# Testcase cp_asm_count",
+        test_data.add_testcase("count", coverpoint),
         f"{instr_name}",
     ]
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/special/cp_cntr.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_cntr.py
@@ -59,17 +59,14 @@ def gen_cntr_test(instr_name: str, cntr: str, r1: int, r2: int, r3: int, test_da
         slt = f"slti x{r1}, x{r1}, {mindiff} # set fail code if difference < {mindiff}"
     else:
         slt = ""  # for minstret, the difference should be exact.  High counters should be exactly zero.
-    lines = [
-        test_data.add_testcase(cntr, "cp_cntr"),
-        f"# Testcase: cp_cntr ({cntr})",
-    ]
+    lines = [f"# Testcase: cp_cntr ({cntr})"]
     if cntr == "time":
         lines.extend(
             [
                 "# Loop until time increments, or fail if it does not",
                 f"{instr_name} x{r1}, {cntr}, x0 # read {cntr} initial value",
                 f"li x{r3}, 2000 # timeout counter to prevent infinite loop if counter doesn't increment",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(cntr, "cp_cntr"),
                 f"1: {instr_name} x{r2}, {cntr}, x0 # read {cntr} new value",
                 f"addi x{r3}, x{r3}, -1 # decrement timeout counter",
                 f"beqz x{r3}, 2f # if timeout counter reaches zero, fail",
@@ -89,7 +86,7 @@ def gen_cntr_test(instr_name: str, cntr: str, r1: int, r2: int, r3: int, test_da
                 f"addi x{r2}, x{r2}, 1 # delay a bit",
                 f"addi x{r2}, x{r2}, 1 # delay a bit",
                 f"{instr_name} x{r2}, {cntr}, x0",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(cntr, "cp_cntr"),
                 f"{instr_name} x{r2}, {cntr}, x0 # read again to increase delay a bit more",
             ]
         )

--- a/generators/testgen/src/testgen/coverpoints/special/cp_custom_fence_i.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_custom_fence_i.py
@@ -43,13 +43,12 @@ def make_custom_fence_i(instr_name: str, instr_type: str, coverpoint: str, test_
 
         test_lines.extend(
             [
-                test_data.add_testcase(desc, "cp_custom_fencei"),
                 f"# Testcase: {desc}",
                 f"LI(x{reg1}, 3)",
                 f"LA(x{reg3}, {label})",
                 load_int_reg(f"addi x{reg1}, x{reg1}, {add_val}", reg2, encoded_instr, test_data),
                 f"sw x{reg2}, 0(x{reg3})",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(desc, "cp_custom_fencei"),
                 f"{fence_instr} # {desc}",
                 f"{label}:",
                 f"addi x{reg1}, x{reg1}, 1 # original code",

--- a/generators/testgen/src/testgen/coverpoints/special/cp_custom_lr.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_custom_lr.py
@@ -39,10 +39,9 @@ def make_custom_lr(instr_name: str, instr_type: str, coverpoint: str, test_data:
 
         test_lines.extend(
             [
-                test_data.add_testcase(suffix, "cp_custom_aqrl"),
                 f"# Testcase: cp_custom_aqrl with suffix '{suffix}'",
                 f"addi x{params.rs1}, x{test_data.int_regs.data_reg}, 0 # copy data_ptr to rs1",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(suffix, "cp_custom_aqrl"),
                 f"{instr_name}{suffix} x{params.rd}, (x{params.rs1}) # perform load ({to_hex(params.temp_val, test_data.xlen)})",
                 write_sigupd(params.rd, test_data, "int"),
                 f"addi x{test_data.int_regs.data_reg}, x{test_data.int_regs.data_reg}, SIG_STRIDE # increment data_ptr",
@@ -55,10 +54,11 @@ def make_custom_lr(instr_name: str, instr_type: str, coverpoint: str, test_data:
     # cp_custom_rd_edges
     edges = [0, 1, -1]
     for edge_val in edges:
-        test_lines.append(test_data.add_testcase(f"{edge_val}", "cp_custom_rd_edges"))
         params = generate_random_params(test_data, instr_type, exclude_regs=[0], temp_val=edge_val)
         desc = f"cp_custom_rd_edges (Test source rs1 value = {test_data.xlen_format_str.format(edge_val)})"
-        test_lines.append(format_single_test(instr_name, instr_type, test_data, params, desc))
+        test_lines.append(
+            format_single_test(instr_name, instr_type, test_data, params, desc, f"{edge_val}", "cp_custom_rd_edges")
+        )
         return_test_regs(test_data, params)
 
     return test_lines

--- a/generators/testgen/src/testgen/coverpoints/special/cp_custom_sc.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_custom_sc.py
@@ -36,12 +36,11 @@ def make_custom_sc(instr_name: str, instr_type: str, coverpoint: str, test_data:
         )
         test_lines.extend(
             [
-                test_data.add_testcase(suffix, "cp_custom_aqrl"),
                 f"# Testcase: cp_custom_aqrl with suffix '{suffix}'",
                 load_int_reg("rs2", params.rs2, params.rs2val, test_data),
                 f"LA(x{params.rs1}, scratch) # rs1 = base address",
                 f"{lr_insn} x0, (x{params.rs1}) # establish reservation",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(suffix, "cp_custom_aqrl"),
                 f"{instr_name}{suffix} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation",
                 write_sigupd(params.rd, test_data),
                 f"LA(x{params.rs1}, scratch) # reload base address",
@@ -66,12 +65,11 @@ def make_custom_sc(instr_name: str, instr_type: str, coverpoint: str, test_data:
         )
         test_lines.extend(
             [
-                test_data.add_testcase(f"prev_lr_{lr_insn}", "cp_custom_sc_lrsc"),
                 "# Testcase: cp_custom_sc_lrsc",
                 load_int_reg("rs2", params.rs2, params.rs2val, test_data),
                 f"LA(x{params.rs1}, scratch) # rs1 = base address",
                 f"{lr_insn} x0, (x{params.rs1}) # establish reservation",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(f"prev_lr_{lr_insn}", "cp_custom_sc_lrsc"),
                 f"{instr_name} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation",
                 write_sigupd(params.rd, test_data),
                 f"LA(x{params.rs1}, scratch) # reload base address",
@@ -94,13 +92,12 @@ def make_custom_sc(instr_name: str, instr_type: str, coverpoint: str, test_data:
     )
     test_lines.extend(
         [
-            test_data.add_testcase("true", "cp_custom_sc_after_sc"),
             "# Testcase: cp_custom_sc_after_sc (should fail because of intervening sc)",
             load_int_reg("rs2", params.rs2, params.rs2val, test_data),
             load_int_reg("temp_reg", params.temp_reg, params.temp_val, test_data),
             f"LA(x{params.rs1}, scratch) # rs1 = base address",
             f"{lr_insn} x0, (x{params.rs1}) # establish reservation",
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("true", "cp_custom_sc_after_sc"),
             f"{instr_name} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation",
             f"{instr_name} x{params.temp_reg}, x{params.temp_reg}, (x{params.rs1}) # perform operation again, should fail",
             "# Check destination of both sc instructions:",
@@ -137,14 +134,13 @@ def make_custom_sc(instr_name: str, instr_type: str, coverpoint: str, test_data:
         )
         test_lines.extend(
             [
-                test_data.add_testcase(store_insn, "cp_custom_sc_after_store"),
                 f"# Testcase: cp_custom_sc_after_store ({store_insn})",
                 load_int_reg("rs2", params.rs2, params.rs2val, test_data),
                 load_int_reg("temp_reg", params.temp_reg, params.temp_val, test_data),
                 f"LA(x{params.rs1}, scratch) # rs1 = base address",
                 f"{lr_insn} x0, (x{params.rs1}) # establish reservation",
                 f"{store_insn} x{params.temp_reg}, {offset}(x{params.rs1}) # intervening store",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(store_insn, "cp_custom_sc_after_store"),
                 f"{instr_name} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation",
                 write_sigupd(params.rd, test_data),
                 f"LA(x{params.rs1}, scratch) # reload base address",
@@ -191,14 +187,13 @@ def make_custom_sc(instr_name: str, instr_type: str, coverpoint: str, test_data:
         )
         test_lines.extend(
             [
-                test_data.add_testcase(f"{load_insn}_offset_{offset}", "cp_custom_sc_after_load"),
                 f"# Testcase: cp_custom_sc_after_load ({load_insn}, offset = {offset})",
                 load_int_reg("rs2", params.rs2, params.rs2val, test_data),
                 load_int_reg("temp_reg", params.temp_reg, params.temp_val, test_data),
                 f"LA(x{params.rs1}, scratch) # rs1 = base address",
                 f"{lr_insn} x0, (x{params.rs1}) # establish reservation",
                 f"{load_insn} x{params.temp_reg}, {offset}(x{params.rs1}) # intervening load",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(f"{load_insn}_offset_{offset}", "cp_custom_sc_after_load"),
                 f"{instr_name} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation",
                 write_sigupd(params.rd, test_data),
                 f"LA(x{params.rs1}, scratch) # reload base address",
@@ -224,15 +219,14 @@ def make_custom_sc(instr_name: str, instr_type: str, coverpoint: str, test_data:
             )
             test_lines.extend(
                 [
-                    test_data.add_testcase(
-                        f"prev_lr_{lr_insn} & address_difference_{addr_diff}", "cp_custom_sc_addresses"
-                    ),
                     f"# Testcase: cp_custom_sc_addresses (address difference of {addr_diff})",
                     load_int_reg("rs2", params.rs2, params.rs2val, test_data),
                     f"LA(x{params.temp_reg}, scratch) # rs1 = base address",
                     f"addi x{params.rs1}, x{params.temp_reg}, {addr_diff} # offset rs1 by {addr_diff}",
                     f"{lr_insn} x0, (x{params.temp_reg}) # establish reservation",
-                    f"test_{test_data.test_count}:",
+                    test_data.add_testcase(
+                        f"prev_lr_{lr_insn} & address_difference_{addr_diff}", "cp_custom_sc_addresses"
+                    ),
                     f"{instr_name} x{params.rd}, x{params.rs2}, (x{params.rs1}) # perform operation",
                     write_sigupd(params.rd, test_data),
                     f"LA(x{params.rs1}, scratch) # reload base address",

--- a/generators/testgen/src/testgen/coverpoints/special/cp_misalign.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_misalign.py
@@ -43,13 +43,12 @@ def make_misalign(instr_name: str, instr_type: str, coverpoint: str, test_data: 
         )
 
     for alignment in alignments:
-        test_lines.append(test_data.add_testcase(f"{alignment}", coverpoint))
         if instr_type == "L":
             test_lines.extend(
                 [
                     f"# Testcase: {coverpoint} (imm[2:0] = {alignment:03b})",
                     f"LA(x{r1}, scratch) # load base address",
-                    f"test_{test_data.test_count}:",
+                    test_data.add_testcase(f"{alignment}", coverpoint),
                     f"{instr_name} x{r2}, {alignment}(x{r1}) # perform load",
                     write_sigupd(r2, test_data, "int"),
                     "",
@@ -60,7 +59,7 @@ def make_misalign(instr_name: str, instr_type: str, coverpoint: str, test_data: 
                 [
                     f"# Testcase: {coverpoint} (imm[2:0] = {alignment:03b})",
                     f"LA(x{r1}, scratch) # load base address",
-                    f"test_{test_data.test_count}:",
+                    test_data.add_testcase(f"{alignment}", coverpoint),
                     f"{instr_name} f{r2}, {alignment}(x{r1}) # perform load",
                     write_sigupd(r2, test_data, "float"),
                     "",
@@ -72,7 +71,7 @@ def make_misalign(instr_name: str, instr_type: str, coverpoint: str, test_data: 
                     f"# Testcase: {coverpoint} (addr[2:0] = {alignment:03b})",
                     f"LA(x{r1}, scratch) # load base address",
                     f"addi x{r1}, x{r1}, {alignment} # adjust for alignment",
-                    f"test_{test_data.test_count}:",
+                    test_data.add_testcase(f"{alignment}", coverpoint),
                     f"{instr_name} x{r2}, 0(x{r1}) # perform load",
                     write_sigupd(r2, test_data, "int"),
                     "",
@@ -85,7 +84,7 @@ def make_misalign(instr_name: str, instr_type: str, coverpoint: str, test_data: 
                     test_data.int_regs.consume_registers([2]),
                     "LA(sp, scratch) # load base address",
                     f"addi sp, sp, {alignment} # adjust for alignment",
-                    f"test_{test_data.test_count}:",
+                    test_data.add_testcase(f"{alignment}", coverpoint),
                     f"{instr_name} x{r2}, 0(sp) # perform load",
                     write_sigupd(r2, test_data, "int"),
                     "",
@@ -115,14 +114,14 @@ def make_misalign(instr_name: str, instr_type: str, coverpoint: str, test_data: 
             if instr_type == "S":
                 test_lines.extend(
                     [
-                        f"test_{test_data.test_count}:",
+                        test_data.add_testcase(f"{alignment}", coverpoint),
                         f"{instr_name} x{r2}, {alignment}(x{r1}) # perform store to scratch memory",
                     ]
                 )
             elif instr_type == "FS":
                 test_lines.extend(
                     [
-                        f"test_{test_data.test_count}:",
+                        test_data.add_testcase(f"{alignment}", coverpoint),
                         f"{instr_name} f{r2}, {alignment}(x{r1}) # perform store to scratch memory",
                     ]
                 )
@@ -130,7 +129,7 @@ def make_misalign(instr_name: str, instr_type: str, coverpoint: str, test_data: 
                 test_lines.extend(
                     [
                         f"addi x{r1}, x{r1}, {alignment} # adjust for alignment",
-                        f"test_{test_data.test_count}:",
+                        test_data.add_testcase(f"{alignment}", coverpoint),
                         f"{instr_name} x{r2}, 0(x{r1}) # perform store",
                         f"addi x{r1}, x{r1}, {-alignment} # restore base address",
                     ]
@@ -141,7 +140,7 @@ def make_misalign(instr_name: str, instr_type: str, coverpoint: str, test_data: 
                         test_data.int_regs.consume_registers([2]),
                         "LA(sp, scratch) # load base address",
                         f"addi sp, sp, {alignment} # adjust for alignment",
-                        f"test_{test_data.test_count}:",
+                        test_data.add_testcase(f"{alignment}", coverpoint),
                         f"{instr_name} x{r2}, 0(sp) # perform store",
                     ]
                 )

--- a/generators/testgen/src/testgen/coverpoints/special/cp_offset.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cp_offset.py
@@ -25,8 +25,6 @@ def make_offset(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
     else:
         params = generate_random_params(test_data, instr_type)
 
-    test_lines.append(test_data.add_testcase("neg", coverpoint))
-
     if instr_type in ["B", "CB"]:
         assert params.rs1 is not None and params.temp_reg is not None and params.temp_val is not None
         if instr_type == "B":
@@ -46,7 +44,7 @@ def make_offset(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
                 "j 2f # jump past backward branch target",
                 f"1: addi x{params.temp_reg}, x{params.temp_reg}, 4 # backward branch target, increment check value",
                 "j 3f # jump past backward branch",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase("neg", coverpoint),
                 f"2: {instr_name} x{params.rs1}, {f'x{params.rs2},' if params.rs2 is not None else ''} 1b # backward branch",
                 f"addi x{params.temp_reg}, x{params.temp_reg}, -2 # branch not taken, decrement check value",
                 "3:  # done with sequence",
@@ -67,7 +65,7 @@ def make_offset(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
                 f"1: addi x{params.temp_reg}, x{params.temp_reg}, 4 # backward jump target, increment check value",
                 "j 3f # jump past backward jump",
                 f"2: LA(x{params.rs1}, 1b) # load backward jump target",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase("neg", coverpoint),
                 f"{instr_name} x{params.rd}, x{params.rs1}, 0 # backward jump"
                 if instr_type == "JR"
                 else f"{instr_name} x{params.rs1} # backward jump",
@@ -88,7 +86,7 @@ def make_offset(instr_name: str, instr_type: str, coverpoint: str, test_data: Te
                 "j 2f # jump past backward jump target",
                 f"1: addi x{params.temp_reg}, x{params.temp_reg}, 4 # backward jump target, increment check value",
                 "j 3f # jump past backward jump",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase("neg", coverpoint),
                 f"2: {instr_name} 1b # backward jump",
                 f"addi x{params.temp_reg}, x{params.temp_reg}, -2 # jump not taken, decrement check value",
                 "3:  # done with sequence",
@@ -123,7 +121,6 @@ def make_offset_lsbs(instr_name: str, instr_type: str, test_data: TestData) -> l
                     and params.temp_val is not None
                 )
                 label = f"jalrlsb_{rs1_lsb}{imm_lsb}"
-                test_lines.append(test_data.add_testcase(f"{rs1_lsb}_{imm_lsb}", "cp_offset_lsbs"))
                 imm_val = -1 if (rs1_lsb == 1 and imm_lsb == 1) else imm_lsb
                 test_lines.extend(
                     [
@@ -132,7 +129,7 @@ def make_offset_lsbs(instr_name: str, instr_type: str, test_data: TestData) -> l
                         load_int_reg("jump check value", params.temp_reg, params.temp_val, test_data),
                         f"LA(x{params.rs1}, {label}) # load address of label",
                         f"addi x{params.rs1}, x{params.rs1}, {rs1_lsb} # set rs1 LSB to {rs1_lsb}",
-                        f"test_{test_data.test_count}:",
+                        test_data.add_testcase(f"{rs1_lsb}_{imm_lsb}", "cp_offset_lsbs"),
                         f"{instr_name} x{params.rd}, x{params.rs1}, {imm_val} # jump with imm LSB = {imm_lsb}",
                         f"addi x{params.temp_reg}, x{params.temp_reg}, -4  # should not execute; branch not taken",
                         f"{label}: addi x{params.temp_reg}, x{params.temp_reg}, 2 # should execute; branch taken",
@@ -158,7 +155,6 @@ def make_offset_lsbs(instr_name: str, instr_type: str, test_data: TestData) -> l
                 and params.temp_val is not None
             )
             label = f"jalrlsb_{rs1_lsbs}"
-            test_lines.append(test_data.add_testcase(f"{rs1_lsbs:02b}", "cp_offset_lsbs"))
             test_lines.extend(
                 [
                     "",
@@ -166,7 +162,7 @@ def make_offset_lsbs(instr_name: str, instr_type: str, test_data: TestData) -> l
                     load_int_reg("jump check value", params.temp_reg, params.temp_val, test_data),
                     f"LA(x{params.rs1}, {label}) # load address of label",
                     f"addi x{params.rs1}, x{params.rs1}, {rs1_lsbs} # set rs1 LSB to {rs1_lsbs}",
-                    f"test_{test_data.test_count}:",
+                    test_data.add_testcase(f"{rs1_lsbs:02b}", "cp_offset_lsbs"),
                     f"{instr_name} x{params.rs1} # jump",
                     f"addi x{params.temp_reg}, x{params.temp_reg}, -4  # should not execute; branch not taken",
                     ".align 2",

--- a/generators/testgen/src/testgen/coverpoints/special/cr_reg_edges_offset.py
+++ b/generators/testgen/src/testgen/coverpoints/special/cr_reg_edges_offset.py
@@ -30,12 +30,11 @@ def make_cr_rs1_rs2_edges_offset(instr_name: str, instr_type: str, coverpoint: s
             assert params.rs1val is not None and params.rs2val is not None
             test_lines.extend(
                 [
-                    test_data.add_testcase(f"rs1val={edge_val1:#x}, rs2val={edge_val2:#x}", coverpoint),
                     f"# {coverpoint} (Test source rs1 = {test_data.xlen_format_str.format(edge_val1)} rs2 = {test_data.xlen_format_str.format(edge_val2)})",
                     load_int_reg("rs1", params.rs1, params.rs1val, test_data),
                     load_int_reg("rs2", params.rs2, params.rs2val, test_data),
                     "0: # destination for backwards branch that is never taken",
-                    f"test_{test_data.test_count}:",
+                    test_data.add_testcase(f"rs1val={edge_val1:#x}, rs2val={edge_val2:#x}", coverpoint),
                     f"{instr_name} x{params.rs1}, x{params.rs2}, 3f # forward branch, if taken",
                     "1: # goes here if not taken",
                     f"{instr_name} x{params.rs1}, x{params.rs2}, 0b # backward branch, never taken",

--- a/generators/testgen/src/testgen/data/state.py
+++ b/generators/testgen/src/testgen/data/state.py
@@ -157,17 +157,17 @@ class TestData:
         """Get the list of test data strings to be stored in .data section."""
         return self._test_data_strings
 
-    def add_testcase(self, bin_name: str = "", coverpoint: str = "", covergroup: str | None = None) -> str:
+    def add_testcase(self, bin_name: str, coverpoint: str, covergroup: str | None = None) -> str:
         """
         Add a test data string and return the testcase label line. Also increments test count.
 
         Args:
-            cp: The coverpoint name
-            covergroup: Optional covergroup name. Defaults to '{extension}_{instr_name}_cg'.
             bin_name: Optional bin name to append to the coverpoint name.
+            coverpoint: The coverpoint name
+            covergroup: Optional covergroup name. Defaults to '{extension}_{instr_name}_cg'.
 
         Returns:
-            Label line string in format '{covergroup}_{coverpoint}_{bin_name}}:'
+            Label line string in format '{covergroup}_{coverpoint}_{bin_name}:'
         """
         self.increment_test_count()
 
@@ -185,7 +185,7 @@ class TestData:
 
         # Add testcase string to test data strings (keep original names for debugging)
         self._test_data_strings.append(
-            f'test_{self.test_count}_str: .string "\\"test: {self.test_count}; cg: {covergroup}; cp: {coverpoint}; bin: {bin_name}\\""'
+            f'{label}_str: .string "\\"test: {self.test_count}; cg: {covergroup}; cp: {coverpoint}; bin: {bin_name}\\""'
         )
 
         # Return label

--- a/generators/testgen/src/testgen/data/state.py
+++ b/generators/testgen/src/testgen/data/state.py
@@ -171,7 +171,7 @@ class TestData:
         Add a test data string and return the testcase label line. Also increments test count.
 
         Args:
-            bin_name: Optional bin name to append to the coverpoint name.
+            bin_name: Bin name to append to the coverpoint name.
             coverpoint: The coverpoint name
             covergroup: Optional covergroup name. Defaults to '{extension}_{instr_name}_cg'.
 

--- a/generators/testgen/src/testgen/data/state.py
+++ b/generators/testgen/src/testgen/data/state.py
@@ -24,10 +24,13 @@ class TestData:
 
     Attributes:
         config: Immutable test configuration (xlen, flen, register file type)
+        instr_name: Instruction this test is exercising
         int_regs: Integer register file for allocation
         float_regs: Floating-point register file for allocation
         sigupd_count: Running count of integer signature updates
+        test_count: Running count of testcases generated
         test_data_values: List of values to be stored in test_data section
+        test_data_strings: List of debug strings to be stored in test_data section
     """
 
     def __init__(self, test_config: TestConfig, instr_name: str | None = None) -> None:
@@ -46,6 +49,7 @@ class TestData:
         self._test_count = 0
         self._test_data_values: list[int] = []  # List of integer values
         self._test_data_strings: list[str] = []  # List of string values
+        self._current_testcase_label = ""
 
     def __repr__(self) -> str:
         return f"TestData(config={self._config}, int_regs={self._int_regs}, float_regs={self._float_regs}, sigupd_count={self._sigupd_count}, test_count={self._test_count})"
@@ -97,6 +101,11 @@ class TestData:
     @sigupd_count.setter
     def sigupd_count(self, value: int) -> None:
         self._sigupd_count = value
+
+    @property
+    def current_testcase_label(self) -> str:
+        """Get the current testcase label."""
+        return self._current_testcase_label
 
     # Read-only properties delegated to config
     @property
@@ -189,7 +198,8 @@ class TestData:
         )
 
         # Return label
-        return f"\n{label}:"
+        self._current_testcase_label = label
+        return f"{label}:"
 
     def copy(self) -> TestData:
         """Create a deep copy of the TestData object."""

--- a/generators/testgen/src/testgen/formatters/registry.py
+++ b/generators/testgen/src/testgen/formatters/registry.py
@@ -141,7 +141,13 @@ def format_instruction(
 
 
 def format_single_test(
-    instr_name: str, instr_type: str, test_data: TestData, params: InstructionParams, desc: str
+    instr_name: str,
+    instr_type: str,
+    test_data: TestData,
+    params: InstructionParams,
+    desc: str,
+    bin_name: str = "",
+    coverpoint: str = "",
 ) -> str:
     """
     Generate a complete single-instruction test with setup and signature update.
@@ -158,7 +164,8 @@ def format_single_test(
         test_data: Test data context
         params: Instruction parameters
         desc: Test description (e.g., "cp_rd (Test destination rd = x5)")
-
+        bin_name: Coverpoint bin covered by this test case
+        coverpoint: Coverpoint name
     Returns:
         Complete test case as a string
     """
@@ -166,6 +173,13 @@ def format_single_test(
 
     # Add test and signature update lines
     setup, test, check = format_instruction(instr_name, instr_type, test_data, params)
-    test_lines.extend([setup, f"test_{test_data.test_count}:", test, check])
+    test_lines.extend(
+        [
+            setup,
+            test_data.add_testcase(bin_name, coverpoint),
+            test,
+            check,
+        ]
+    )
 
     return "\n".join(test_lines)

--- a/generators/testgen/src/testgen/formatters/registry.py
+++ b/generators/testgen/src/testgen/formatters/registry.py
@@ -171,12 +171,15 @@ def format_single_test(
     """
     test_lines = [f"# Testcase {desc}"]
 
+    # Register the testcase label first so SIGUPD references the current test's label
+    label_line = test_data.add_testcase(bin_name, coverpoint)
+
     # Add test and signature update lines
     setup, test, check = format_instruction(instr_name, instr_type, test_data, params)
     test_lines.extend(
         [
             setup,
-            test_data.add_testcase(bin_name, coverpoint),
+            label_line,
             test,
             check,
         ]

--- a/generators/testgen/src/testgen/formatters/registry.py
+++ b/generators/testgen/src/testgen/formatters/registry.py
@@ -146,8 +146,8 @@ def format_single_test(
     test_data: TestData,
     params: InstructionParams,
     desc: str,
-    bin_name: str = "",
-    coverpoint: str = "",
+    bin_name: str,
+    coverpoint: str,
 ) -> str:
     """
     Generate a complete single-instruction test with setup and signature update.

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -59,7 +59,7 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     test_data.int_regs.return_register(1)
 
     # Produce actual test file
-    extra_defines = [*get_priv_test_defines(testsuite), "RVTEST_PRIV_TEST"]
+    extra_defines = [*get_priv_test_defines(testsuite), "#define RVTEST_PRIV_TEST"]
     write_test_file(
         test_data,
         body_lines,

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -59,9 +59,10 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     test_data.int_regs.return_register(1)
 
     # Produce actual test file
+    extra_defines = [*get_priv_test_defines(testsuite), "RVTEST_PRIV_TEST"]
     write_test_file(
         test_data,
         body_lines,
         output_path,
-        extra_defines=get_priv_test_defines(testsuite),
+        extra_defines=extra_defines,
     )

--- a/generators/testgen/src/testgen/priv/extensions/ExceptionsZc.py
+++ b/generators/testgen/src/testgen/priv/extensions/ExceptionsZc.py
@@ -28,7 +28,6 @@ def _add_load_test(
     is_float = op.startswith("c.f")
     is_sp = op.endswith("sp")
     t_lines = []
-    t_lines.append(test_data.add_testcase(f"{op.lower()}_off{offset}", coverpoint, covergroup))
 
     # Load address and apply offset
     if is_sp:
@@ -44,14 +43,14 @@ def _add_load_test(
     sig_reg = fp_reg if is_float else check_reg
 
     if is_sp:
-        t_lines.append(f"test_{test_data.test_count}:")
+        t_lines.append(test_data.add_testcase(f"{op.lower()}_off{offset}", coverpoint, covergroup))
         t_lines.append(f" {op} {reg_str}, 0(sp)")
         t_lines.append("# Trap handler skips the next 4 bytes; two c.nops provide 4 bytes")
         t_lines.append("c.nop")
         t_lines.append("c.nop")
         t_lines.append(f" mv sp, x{base_reg}")  # Restore sp immediately
     else:
-        t_lines.append(f"test_{test_data.test_count}:")
+        t_lines.append(test_data.add_testcase(f"{op.lower()}_off{offset}", coverpoint, covergroup))
         t_lines.append(f" {op} {reg_str}, 0(x{addr_reg})")
         t_lines.append(
             "# Load access may throw a trap and the trap handler skips over the next 4 bytes. Two c.nops are used to get 4 bytes of instructions"
@@ -79,7 +78,6 @@ def _add_store_test(
     is_float = op.startswith("c.f")
     is_sp = op.endswith("sp")
     t_lines = []
-    t_lines.append(test_data.add_testcase(f"{op.lower()}_off{offset}", coverpoint, covergroup))
 
     # Initialize store register to a known value before setting up address
     if is_float:
@@ -104,14 +102,14 @@ def _add_store_test(
     reg_str = f"f{fp_reg}" if is_float else f"x{check_reg}"
 
     if is_sp:
-        t_lines.append(f"test_{test_data.test_count}:")
+        t_lines.append(test_data.add_testcase(f"{op.lower()}_off{offset}", coverpoint, covergroup))
         t_lines.append(f" {op} {reg_str}, 0(sp)")
         t_lines.append("# Trap handler skips the next 4 bytes; two c.nops provide 4 bytes")
         t_lines.append("c.nop")
         t_lines.append("c.nop")
         t_lines.append(f" mv sp, x{base_reg}")  # Restore sp immediately
     else:
-        t_lines.append(f"test_{test_data.test_count}:")
+        t_lines.append(test_data.add_testcase(f"{op.lower()}_off{offset}", coverpoint, covergroup))
         t_lines.append(f" {op} {reg_str}, 0(x{addr_reg})")
         t_lines.append("c.nop")
         t_lines.append("c.nop")
@@ -147,14 +145,12 @@ def _add_load_fault(
     t_lines = []
     test_label = f"{op.lower()}_fault"
 
-    t_lines.append(test_data.add_testcase(test_label, coverpoint, covergroup))
-
     reg_str = f"f{fp_reg}" if is_float else f"x{check_reg}"
 
     if is_sp:
         t_lines.append(f" mv x{base_reg}, sp")
         t_lines.append(" li sp, RVMODEL_ACCESS_FAULT_ADDRESS")
-        t_lines.append(f"test_{test_data.test_count}:")
+        t_lines.append(test_data.add_testcase(test_label, coverpoint, covergroup))
         t_lines.append(f" {op} {reg_str}, 0(sp)")
         t_lines.append("# Trap handler skips the next 4 bytes; two c.nops provide 4 bytes")
         t_lines.append("c.nop")
@@ -162,7 +158,7 @@ def _add_load_fault(
         t_lines.append(f" mv sp, x{base_reg}")
     else:
         t_lines.append(f" li x{addr_reg}, RVMODEL_ACCESS_FAULT_ADDRESS")
-        t_lines.append(f"test_{test_data.test_count}:")
+        t_lines.append(test_data.add_testcase(test_label, coverpoint, covergroup))
         t_lines.append(f" {op} {reg_str}, 0(x{addr_reg})")
         t_lines.append(
             "# Load access may throw a trap and the trap handler skips over the next 4 bytes. Two c.nops are used to get 4 bytes of instructions"
@@ -190,14 +186,12 @@ def _add_store_fault(
     t_lines = []
     test_label = f"{op.lower()}_fault"
 
-    t_lines.append(test_data.add_testcase(test_label, coverpoint, covergroup))
-
     reg_str = f"f{fp_reg}" if is_float else f"x{check_reg}"
 
     if is_sp:
         t_lines.append(f" mv x{base_reg}, sp")
         t_lines.append(" li sp, RVMODEL_ACCESS_FAULT_ADDRESS")
-        t_lines.append(f"test_{test_data.test_count}:")
+        t_lines.append(test_data.add_testcase(test_label, coverpoint, covergroup))
         t_lines.append(f" {op} {reg_str}, 0(sp)")
         t_lines.append("# Trap handler skips the next 4 bytes; two c.nops provide 4 bytes")
         t_lines.append("c.nop")
@@ -205,7 +199,7 @@ def _add_store_fault(
         t_lines.append(f" mv sp, x{base_reg}")
     else:
         t_lines.append(f" li x{addr_reg}, RVMODEL_ACCESS_FAULT_ADDRESS")
-        t_lines.append(f"test_{test_data.test_count}:")
+        t_lines.append(test_data.add_testcase(test_label, coverpoint, covergroup))
         t_lines.append(f" {op} {reg_str}, 0(x{addr_reg})")
         t_lines.append(
             "# Store access may throw a trap and the trap handler skips over the next 4 bytes. Two c.nops are used to get 4 bytes of instructions"
@@ -382,7 +376,6 @@ def _generate_breakpoint_tests(test_data: TestData) -> list[str]:
     lines = [
         comment_banner(coverpoint, "Breakpoint"),
         test_data.add_testcase("c_ebreak", coverpoint, covergroup),
-        f"test_{test_data.test_count}:",
         " c.ebreak",
         "# Breakpoint may throw a trap and the trap handler skips over the next 4 bytes. Two c.nops are used to get 4 bytes of instructions",
         "c.nop",
@@ -401,7 +394,6 @@ def _generate_illegal_instruction_tests(test_data: TestData) -> list[str]:
         # Align to ensure proper instruction fetch and trap handling"
         " .align 2",  # Add alignment
         test_data.add_testcase("illegal0", coverpoint, covergroup),
-        f"test_{test_data.test_count}:",
         " .insn 0x00",  # use two byte for instruction alignment when trapping
         " # Illegal instruction may throw a trap and the trap handler skips over the next 4 bytes. Two c.nops are used to get 4 bytes of instructions",
         " c.nop",

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -36,6 +36,7 @@ def _generate_mcause_tests(test_data: TestData) -> list[str]:
             continue
         lines.extend(
             [
+                "",
                 f"    LI(x{check_reg}, {i})           # exception cause {i}",
                 test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 gen_csr_write_sigupd(check_reg, "mcause", test_data),
@@ -60,6 +61,7 @@ def _generate_mcause_tests(test_data: TestData) -> list[str]:
             continue
         lines.extend(
             [
+                "",
                 f"    LI(x{check_reg}, {i})           # interrupt cause {i}",
                 f"    or x{check_reg}, x{check_reg}, x{temp_reg}          # set interrupt bit",
                 test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
@@ -105,6 +107,7 @@ def _generate_mstatus_sd_tests(test_data: TestData) -> list[str]:
                     binname = f"sd_{sd}_fs_{fs:02b}_xs_{xs:02b}_vs_{vs:02b}"
                     fields = fs << 13 | xs << 15 | vs << 9
                     test_lines = [
+                        "",
                         f"    LI(x{check_reg}, 0x{fields:08x})  # fs = {fs:02b} xs = {xs:02b} vs = {vs:02b}",
                     ]
                     if sd == 1:
@@ -136,12 +139,14 @@ def _generate_priv_inst_tests(test_data: TestData) -> list[str]:
             "cp_mprvinst",
             "Execute ecall and ebreak\nShould cause an exception",
         ),
+        "",
         # ecall test
         f"    li x{check_reg}, 1    # success code",
         test_data.add_testcase("ecall", coverpoint, covergroup),
         "    ecall                 # test ecall instruction",
         f"    li x{check_reg}, -1   # trap handler skips following instruction so this should not be executed",
         write_sigupd(check_reg, test_data),
+        "",
         # ebreak test
         f"    li x{check_reg}, 1    # success code",
         test_data.add_testcase("ebreak", coverpoint, covergroup),
@@ -184,6 +189,7 @@ def _generate_mret_tests(test_data: TestData) -> list[str]:
 
                     lines.extend(
                         [
+                            "",
                             # Test the write value
                             f"    LI(x{check_reg}, 0x{fields:08x})  # mpp = {mpp:02b} mprv = {mprv} mpie = {mpie} mie = {mie}",
                             f"    or x{check_reg}, x{check_reg}, x{reg1}          # value to write to mstatus with MPP/MPRV/MPIE/MIE bits set/clear",
@@ -240,6 +246,7 @@ def _generate_sret_tests(test_data: TestData) -> list[str]:
 
                         lines.extend(
                             [
+                                "",
                                 # Test the write value
                                 f"    LI(x{check_reg}, 0x{fields:08x}) # mprv = {mprv} spp = {spp} spie = {spie} sie = {sie} tsr = {tsr}",
                                 f"    or x{check_reg}, x{check_reg}, x{reg1}          # value to write to mstatus with MPRV/SPP/SPIE/SIE/TSR bits set/clear",
@@ -394,6 +401,7 @@ def _generate_mcsr_tests(test_data: TestData) -> list[str]:
     for csr in range(0x7B0, 0x7C0):
         lines.extend(
             [
+                "",
                 # Test the write value
                 test_data.add_testcase(f"{csr}", coverpoint, covergroup),
                 f"\tCSRR(t0, 0x{csr:03x})    # attempt to read debug-mode CSR {csr:03x}; should get illegal instruction",
@@ -411,12 +419,13 @@ def _generate_mcsr_tests(test_data: TestData) -> list[str]:
         ),
     )
 
-    lines.append("\tLI(t0, -1)          # t0 = all 1s\n")
+    lines.append("\tLI(t0, -1)          # t0 = all 1s")
     for csr in range(0xC00, 0x1000):
         lines.extend(
             [
+                "",
                 test_data.add_testcase(f"{csr}", coverpoint, covergroup),
-                f"\tCSRW(0x{csr:03x}, t0)    # attempt to write read-only CSR {csr:03x}; should get illegal instruction\n",
+                f"\tCSRW(0x{csr:03x}, t0)    # attempt to write read-only CSR {csr:03x}; should get illegal instruction",
             ]
         )
 
@@ -585,6 +594,7 @@ def _generate_mcsr_cntr_tests(test_data: TestData) -> list[str]:
             f"\tsub x{r2}, x{r2}, x{r1}          # difference should be small",
             f"\tslti x{r2}, x{r2}, 10          # signature is 1 if difference < 10",
             write_sigupd(r2, test_data),
+            "",
             "#if __riscv_xlen == 32",
             f"\tLI(x{r1}, 67)        # value to write to mtimeh",
             f"\tLA(x{r2}, RVMODEL_MTIME_ADDRESS)        # load address of mtimeh",

--- a/generators/testgen/src/testgen/priv/extensions/Sm.py
+++ b/generators/testgen/src/testgen/priv/extensions/Sm.py
@@ -36,9 +36,8 @@ def _generate_mcause_tests(test_data: TestData) -> list[str]:
             continue
         lines.extend(
             [
-                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 f"    LI(x{check_reg}, {i})           # exception cause {i}",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 gen_csr_write_sigupd(check_reg, "mcause", test_data),
             ]
         )
@@ -61,10 +60,9 @@ def _generate_mcause_tests(test_data: TestData) -> list[str]:
             continue
         lines.extend(
             [
-                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 f"    LI(x{check_reg}, {i})           # interrupt cause {i}",
                 f"    or x{check_reg}, x{check_reg}, x{temp_reg}          # set interrupt bit",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 gen_csr_write_sigupd(check_reg, "mcause", test_data),
             ]
         )
@@ -107,7 +105,6 @@ def _generate_mstatus_sd_tests(test_data: TestData) -> list[str]:
                     binname = f"sd_{sd}_fs_{fs:02b}_xs_{xs:02b}_vs_{vs:02b}"
                     fields = fs << 13 | xs << 15 | vs << 9
                     test_lines = [
-                        test_data.add_testcase(binname, coverpoint, covergroup),
                         f"    LI(x{check_reg}, 0x{fields:08x})  # fs = {fs:02b} xs = {xs:02b} vs = {vs:02b}",
                     ]
                     if sd == 1:
@@ -115,7 +112,7 @@ def _generate_mstatus_sd_tests(test_data: TestData) -> list[str]:
                     test_lines.extend(
                         [
                             f"    or x{check_reg}, x{check_reg}, x{reg3}   # value to write to mstatus with SD/FS/XS/VS bits set/clear",
-                            f"test_{test_data.test_count}:",
+                            test_data.add_testcase(binname, coverpoint, covergroup),
                             gen_csr_write_sigupd(check_reg, "mstatus", test_data),
                         ]
                     )
@@ -140,16 +137,14 @@ def _generate_priv_inst_tests(test_data: TestData) -> list[str]:
             "Execute ecall and ebreak\nShould cause an exception",
         ),
         # ecall test
-        test_data.add_testcase("ecall", coverpoint, covergroup),
         f"    li x{check_reg}, 1    # success code",
-        f"test_{test_data.test_count}:",
+        test_data.add_testcase("ecall", coverpoint, covergroup),
         "    ecall                 # test ecall instruction",
         f"    li x{check_reg}, -1   # trap handler skips following instruction so this should not be executed",
         write_sigupd(check_reg, test_data),
         # ebreak test
-        test_data.add_testcase("ebreak", coverpoint, covergroup),
         f"    li x{check_reg}, 1    # success code",
-        f"test_{test_data.test_count}:",
+        test_data.add_testcase("ebreak", coverpoint, covergroup),
         "    ebreak                # test ebreak instruction",
         f"    li x{check_reg}, -1   # trap handler skips following instruction so this should not be executed",
         write_sigupd(check_reg, test_data),
@@ -190,20 +185,18 @@ def _generate_mret_tests(test_data: TestData) -> list[str]:
                     lines.extend(
                         [
                             # Test the write value
-                            test_data.add_testcase(f"{binname}_wval", coverpoint, covergroup),
                             f"    LI(x{check_reg}, 0x{fields:08x})  # mpp = {mpp:02b} mprv = {mprv} mpie = {mpie} mie = {mie}",
                             f"    or x{check_reg}, x{check_reg}, x{reg1}          # value to write to mstatus with MPP/MPRV/MPIE/MIE bits set/clear",
                             f"    LA(x{reg3}, 1f)             # return address after mret",
                             f"    CSRW(mepc, x{reg3})          # set mepc to return address",
                             f"    CSRW(mstatus, x{check_reg})       # write mstatus with MPP/MPRV/MPIE/MIE bits set/clear",
-                            f"test_{test_data.test_count}:",
+                            test_data.add_testcase(f"{binname}_wval", coverpoint, covergroup),
                             "    mret                   # test mret instruction",
                             f"    li x{check_reg}, -1              # should not be executed",
                             "1:                         # mret should return to here",
                             write_sigupd(check_reg, test_data),
                             # Test the read value
                             test_data.add_testcase(f"{binname}_rval", coverpoint, covergroup),
-                            f"test_{test_data.test_count}:",
                             gen_csr_read_sigupd(check_reg, "mstatus", test_data),
                         ]
                     )
@@ -248,13 +241,12 @@ def _generate_sret_tests(test_data: TestData) -> list[str]:
                         lines.extend(
                             [
                                 # Test the write value
-                                test_data.add_testcase(f"{binname}_wval", coverpoint, covergroup),
                                 f"    LI(x{check_reg}, 0x{fields:08x}) # mprv = {mprv} spp = {spp} spie = {spie} sie = {sie} tsr = {tsr}",
                                 f"    or x{check_reg}, x{check_reg}, x{reg1}          # value to write to mstatus with MPRV/SPP/SPIE/SIE/TSR bits set/clear",
                                 f"    LA(x{reg3}, 1f)             # return address after sret",
                                 f"    CSRW(sepc, x{reg3})          # set sepc to return address. Note that sepc might not exist if S-mode is not implemented, and this test will break if writing it hangs",
                                 f"    CSRW(mstatus, x{check_reg})       # write mstatus with MPRV/SPP/SPIE/SIE/TSR bits set/clear",
-                                f"test_{test_data.test_count}:",
+                                test_data.add_testcase(f"{binname}_wval", coverpoint, covergroup),
                                 "    sret                   # test sret instruction",
                                 f"    li x{check_reg}, -1              # should not be executed",
                                 "1:                         # sret should return to here",
@@ -262,7 +254,6 @@ def _generate_sret_tests(test_data: TestData) -> list[str]:
                                 "    RVTEST_GOTO_MMODE      # make sure we return to machine mode",
                                 # Test the read value
                                 test_data.add_testcase(f"{binname}_rval", coverpoint, covergroup),
-                                f"test_{test_data.test_count}:",
                                 gen_csr_read_sigupd(check_reg, "mstatus", test_data),
                             ]
                         )
@@ -405,7 +396,6 @@ def _generate_mcsr_tests(test_data: TestData) -> list[str]:
             [
                 # Test the write value
                 test_data.add_testcase(f"{csr}", coverpoint, covergroup),
-                f"test_{test_data.test_count}:",
                 f"\tCSRR(t0, 0x{csr:03x})    # attempt to read debug-mode CSR {csr:03x}; should get illegal instruction",
             ]
         )
@@ -426,7 +416,6 @@ def _generate_mcsr_tests(test_data: TestData) -> list[str]:
         lines.extend(
             [
                 test_data.add_testcase(f"{csr}", coverpoint, covergroup),
-                f"test_{test_data.test_count}:",
                 f"\tCSRW(0x{csr:03x}, t0)    # attempt to write read-only CSR {csr:03x}; should get illegal instruction\n",
             ]
         )
@@ -544,12 +533,11 @@ def _generate_mcsr_cntr_tests(test_data: TestData) -> list[str]:
     )
     lines.extend(
         [
-            test_data.add_testcase("", coverpoint, covergroup),
             f"\tLI(x{r1}, 0b1)        # inhibit mcycle",
             f"\tCSRW(mcountinhibit, x{r1})        # inhibit mcycle",
             f"\tCSRR(x{r1}, mcycle)        # read mcycle",
             "\tnop\n\tnop\n\tnop\n\tnop\n\tnop\n\tnop # wait a bit",
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("", coverpoint, covergroup),
             f"\tCSRR(x{r2}, mcycle)        # read mcycle again",
             f"\tsub x{r2}, x{r2}, x{r1}          # difference should be 0",
             write_sigupd(r2, test_data),
@@ -567,12 +555,11 @@ def _generate_mcsr_cntr_tests(test_data: TestData) -> list[str]:
     )
     lines.extend(
         [
-            test_data.add_testcase("", coverpoint, covergroup),
             f"\tLI(x{r1}, 0b100)        # inhibit minstret",
             f"\tCSRW(mcountinhibit, x{r1})        # inhibit minstret",
             f"\tCSRR(x{r1}, minstret)        # read minstret",
             "\tnop\n\tnop\n\tnop\n\tnop\n\tnop\n\tnop # wait a bit",
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("", coverpoint, covergroup),
             f"\tCSRR(x{r2}, minstret)        # read minstret again",
             f"\tsub x{r2}, x{r2}, x{r1}          # difference should be 0",
             write_sigupd(r2, test_data),
@@ -590,21 +577,19 @@ def _generate_mcsr_cntr_tests(test_data: TestData) -> list[str]:
     )
     lines.extend(
         [
-            test_data.add_testcase("", coverpoint, covergroup),
             f"\tLI(x{r1}, 42)        # value to write to mtime",
             f"\tLA(x{r2}, RVMODEL_MTIME_ADDRESS)        # load address of mtime",
             f"\tSREG x{r1}, 0(x{r2})        # write mtime = 42 using memory-mapped I/O",
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("", coverpoint, covergroup),
             f"\tCSRR(x{r2}, time)        # read time",
             f"\tsub x{r2}, x{r2}, x{r1}          # difference should be small",
             f"\tslti x{r2}, x{r2}, 10          # signature is 1 if difference < 10",
             write_sigupd(r2, test_data),
             "#if __riscv_xlen == 32",
-            test_data.add_testcase("h", coverpoint, covergroup),
             f"\tLI(x{r1}, 67)        # value to write to mtimeh",
             f"\tLA(x{r2}, RVMODEL_MTIME_ADDRESS)        # load address of mtimeh",
             f"\tSREG x{r1}, 4(x{r2})        # write mtimeh = 67 using memory-mapped I/O",
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("h", coverpoint, covergroup),
             f"\tCSRR(x{r2}, timeh)        # read timeh",
             f"\tsub x{r2}, x{r2}, x{r1}          # difference should be zero",
             write_sigupd(r2, test_data),

--- a/generators/testgen/src/testgen/priv/extensions/ZicsrF.py
+++ b/generators/testgen/src/testgen/priv/extensions/ZicsrF.py
@@ -77,9 +77,8 @@ def _generate_fcsr_write(test_data: TestData) -> list[str]:
     for i in range(8):
         lines.extend(
             [
-                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 f"    LI(x{r1}, {i << 5})           # write value {i << 5}",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 gen_csr_write_sigupd(r1, "fcsr", test_data),
                 gen_csr_read_sigupd(r1, "frm", test_data),
             ]
@@ -99,9 +98,8 @@ def _generate_fcsr_write(test_data: TestData) -> list[str]:
     for i in range(32):
         lines.extend(
             [
-                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 f"    LI(x{r1}, {i})           # write value {i}",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 gen_csr_write_sigupd(r1, "fcsr", test_data),
                 gen_csr_read_sigupd(r1, "fflags", test_data),
             ]
@@ -121,9 +119,8 @@ def _generate_fcsr_write(test_data: TestData) -> list[str]:
     for i in range(8):
         lines.extend(
             [
-                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 f"    LI(x{r1}, {i})           # write value {i}",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 gen_csr_write_sigupd(r1, "frm", test_data),
                 gen_csr_read_sigupd(r1, "fcsr", test_data),
             ]
@@ -142,9 +139,8 @@ def _generate_fcsr_write(test_data: TestData) -> list[str]:
     for i in range(32):
         lines.extend(
             [
-                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 f"    LI(x{r1}, {i})           # write value {i}",
-                f"test_{test_data.test_count}:",
+                test_data.add_testcase(f"b_{i}", coverpoint, covergroup),
                 gen_csr_write_sigupd(r1, "fflags", test_data),
                 gen_csr_read_sigupd(r1, "fcsr", test_data),
             ]
@@ -167,9 +163,8 @@ def make_op(
 ) -> list[str]:
     """Helper to generate a fp instruction with a comment and check flags."""
     lines = [
-        test_data.add_testcase(coverbin, coverpoint, covergroup),
         "\tcsrwi fflags, 0 # reset flags",
-        f"test_{test_data.test_count}:",
+        test_data.add_testcase(coverbin, coverpoint, covergroup),
         f"\t{mnemonic} f7, f{fs1}, f{fs2}           # {comment}",
         write_sigupd(7, test_data, "float"),
     ]
@@ -221,41 +216,36 @@ def _generate_instr_tests(test_data: TestData) -> list[str]:
 
     lines.extend(
         [
-            test_data.add_testcase("fmadd", "cp_underflow_after_rounding_fma_s_rdn", covergroup),
             "\tcsrwi fflags, 0 # reset flags",
             load_float_reg("a", 10, 0x3F00FBFF, test_data, "single"),
             load_float_reg("b", 11, 0x80000001, test_data, "single"),
             load_float_reg("c", 12, 0x807FFFFF, test_data, "single"),
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("fmadd", "cp_underflow_after_rounding_fma_s_rdn", covergroup),
             "\tfmadd.s f13, f10, f11, f12, rdn",
             write_sigupd(13, test_data, "float"),
-            test_data.add_testcase("fmul", "cp_underflow_after_rounding_fmul_s_rup", covergroup),
             "\tcsrwi fflags, 0 # reset flags",
             load_float_reg("a", 10, 0x00800001, test_data, "single"),
             load_float_reg("b", 11, 0x3F7FFFFE, test_data, "single"),
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("fmul", "cp_underflow_after_rounding_fmul_s_rup", covergroup),
             "\tfmul.s f13, f10, f11, rup",
             write_sigupd(13, test_data, "float"),
             "\n#ifdef D_SUPPORTED",
-            test_data.add_testcase("fmadd", "cp_underflow_after_rounding_fma_d_rup", covergroup),
             "\tcsrwi fflags, 0 # reset flags",
             load_float_reg("a", 10, 0x802FFFFFFFBFFEFF, test_data, "double"),
             load_float_reg("b", 11, 0x000FFFFFFFFFFFFE, test_data, "double"),
             load_float_reg("c", 12, 0x0010000000000000, test_data, "double"),
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("fmadd", "cp_underflow_after_rounding_fma_d_rup", covergroup),
             "\tfmadd.d f13, f10, f11, f12, rup",
             write_sigupd(13, test_data, "float"),
-            test_data.add_testcase("fmul", "cp_underflow_after_rounding_fmul_d_rdn", covergroup),
             "\tcsrwi fflags, 0 # reset flags",
             load_float_reg("a", 10, 0x0010000000000001, test_data, "double"),
             load_float_reg("b", 11, 0xBFEFFFFFFFFFFFFE, test_data, "double"),
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("fmul", "cp_underflow_after_rounding_fmul_d_rdn", covergroup),
             "\tfmul.d f13, f10, f11, rdn",
             write_sigupd(13, test_data, "float"),
-            test_data.add_testcase("fcvt", "cp_underflow_after_rounding_fcvt_s_d_rne", covergroup),
             "\tcsrwi fflags, 0 # reset flags",
             load_float_reg("a", 10, 0xB80FFFFFFFFDFEFF, test_data, "double"),
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("fcvt", "cp_underflow_after_rounding_fcvt_s_d_rne", covergroup),
             "\tfcvt.s.d f13, f10, rne",
             write_sigupd(13, test_data, "float"),
             "#else",
@@ -265,25 +255,22 @@ def _generate_instr_tests(test_data: TestData) -> list[str]:
             # Quads are not yet supported by Sail.  load_float_reg is only writing out 8 bytes
             # (without Q supported).  Comment out until support is ready.
             # f"\n#ifdef Q_SUPPORTED",
-            # test_data.add_testcase("fmadd", "cp_underflow_after_rounding_fma_q_rdn", covergroup),
             # f"\tcsrwi fflags, 0 # reset flags",
             # load_float_reg("a", 10, 0x3F9800000000000001FFFFFFFF7FFFFE, test_data, "quad"),
             # load_float_reg("b", 11, 0x00000000000000000000000000000001, test_data, "quad"),
             # load_float_reg("c", 12, 0x80010000000000000000000000000000, test_data, "quad"),
-            # f"test_{test_data.test_count}:",
+            # test_data.add_testcase("fmadd", "cp_underflow_after_rounding_fma_q_rdn", covergroup),
             # f"\tfmadd.q f13, f10, f11, f12, rdn",
             # write_sigupd(13, test_data, "float"),
-            # test_data.add_testcase("fmul", "cp_underflow_after_rounding_fmul_q_rne", covergroup),
             # f"\tcsrwi fflags, 0 # reset flags",
             # load_float_reg("a", 10, 0x0000FFFFFFFFFFFFFFFFFFFFFFFFFFFF, test_data, "quad"),
             # load_float_reg("b", 11, 0x3FFF0000000000000000000000000001, test_data, "quad"),
-            # f"test_{test_data.test_count}:",
+            # test_data.add_testcase("fmul", "cp_underflow_after_rounding_fmul_q_rne", covergroup),
             # f"\tfmul.q f13, f10, f11, rne",
             # write_sigupd(13, test_data, "float"),
-            # test_data.add_testcase("fcvt", "cp_underflow_after_rounding_fcvt_s_q_rup", covergroup),
             # f"\tcsrwi fflags, 0 # reset flags",
             # load_float_reg("a", 10, 0x3F80FFFFFFFE0000000000FFFFFFFFFF, test_data, "quad"),
-            # f"test_{test_data.test_count}:",
+            # test_data.add_testcase("fcvt", "cp_underflow_after_rounding_fcvt_s_q_rup", covergroup),
             # f"\tfcvt.s.q f13, f10, rup",
             # write_sigupd(13, test_data, "float"),
             # f"#else",
@@ -291,19 +278,17 @@ def _generate_instr_tests(test_data: TestData) -> list[str]:
             # f"\taddi {test_data.int_regs.data_reg}, {test_data.int_regs.data_reg}, {6*test_data.flen}",
             # f"#endif",
             "\n#ifdef ZFH_SUPPORTED",
-            test_data.add_testcase("fmadd", "cp_underflow_after_rounding_fma_h_rne", covergroup),
             "\tcsrwi fflags, 0 # reset flags",
             load_float_reg("a", 10, 0x0BC7, test_data, "half"),
             load_float_reg("b", 11, 0x03FF, test_data, "half"),
             load_float_reg("c", 12, 0x8400, test_data, "half"),
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("fmadd", "cp_underflow_after_rounding_fma_h_rne", covergroup),
             "\tfmadd.h f13, f10, f11, f12, rne",
             write_sigupd(13, test_data, "float"),
-            test_data.add_testcase("fmul", "cp_underflow_after_rounding_fmul_h_rup", covergroup),
             "\tcsrwi fflags, 0 # reset flags",
             load_float_reg("a", 10, 0x0401, test_data, "half"),
             load_float_reg("b", 11, 0x3BF8, test_data, "half"),
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("fmul", "cp_underflow_after_rounding_fmul_h_rup", covergroup),
             "\tfmul.h f13, f10, f11, rup",
             write_sigupd(13, test_data, "float"),
             "#else",
@@ -311,10 +296,9 @@ def _generate_instr_tests(test_data: TestData) -> list[str]:
             f"\taddi {test_data.int_regs.data_reg}, {test_data.int_regs.data_reg}, {5 * test_data.flen}",
             "#endif",
             "\n#if defined(ZFHMIN_SUPPORTED) || defined(ZFH_SUPPORTED)",
-            test_data.add_testcase("fcvt", "cp_underflow_after_rounding_fcvt_h_s_rne", covergroup),
             "\tcsrwi fflags, 0 # reset flags",
             load_float_reg("a", 10, 0x387FF000, test_data, "single"),
-            f"test_{test_data.test_count}:",
+            test_data.add_testcase("fcvt", "cp_underflow_after_rounding_fcvt_h_s_rne", covergroup),
             "\tfcvt.h.s f13, f10, rne",
             write_sigupd(13, test_data, "float"),
             "#else",

--- a/tests/env/failure_code.h
+++ b/tests/env/failure_code.h
@@ -594,7 +594,7 @@
     regstr:
         .string "RVCP: Register: "
     badvalstr:
-        .string "RVCP: Bad Value: "
+        .string "RVCP: Bad Value:      "
     expvalstr:
         .string "RVCP: Expected Value: "
     endstr:

--- a/tests/env/failure_code.h
+++ b/tests/env/failure_code.h
@@ -584,8 +584,13 @@
         .string "\n"
     inststr:
         .string "RVCP: Instruction: "
+#ifdef RVTEST_PRIV_TEST
+    addrstr:
+        .string "RVCP: Address of start of testcase (failure is likely after this): "
+#else
     addrstr:
         .string "RVCP: Address: "
+#endif
     regstr:
         .string "RVCP: Register: "
     badvalstr:

--- a/tests/env/failure_code.h
+++ b/tests/env/failure_code.h
@@ -586,7 +586,7 @@
         .string "RVCP: Instruction: "
 #ifdef RVTEST_PRIV_TEST
     addrstr:
-        .string "RVCP: Address of start of testcase (failure is likely after this): "
+        .string "RVCP: Approximate address (failure may be slightly after this): "
 #else
     addrstr:
         .string "RVCP: Address: "


### PR DESCRIPTION
- Remove `test_num` labels and use existing coverpoint based labels instead.
- Move coverpoint based labels to immediately precede the instruction of interest instead of being at the beginning of the testcase.
- Update failure logging code.