### PR TITLE
Add `include_priv_tests` option to `test_config.yaml`

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -81,13 +81,7 @@ jobs:
         run: make tests --jobs $(nproc)
 
       - name: Compile and run tests on Sail
-        run: |
-          # NOTE: RVI20U must not select 'Sm' tests. Therefore, 'Sm' is excluded until the test selector is fixed.
-          if [[ "${{ matrix.config }}" == *"RVI20U"* ]]; then
-              DOCKER=1 FAST=True CONFIG_FILES="config/${{ matrix.config }}/test_config.yaml" EXTENSIONS="" EXCLUDE_EXTENSIONS="Sm" make --jobs $(nproc)
-          else
-              DOCKER=1 FAST=True CONFIG_FILES="config/${{ matrix.config }}/test_config.yaml" EXTENSIONS="" make --jobs $(nproc)
-          fi
+        run: DOCKER=1 FAST=True CONFIG_FILES="config/${{ matrix.config }}/test_config.yaml" EXTENSIONS="" make --jobs $(nproc)
 
   spike:
     name: Spike Regression (${{ matrix.name }})
@@ -175,6 +169,7 @@ jobs:
           | sudo tar xvJ --directory=/usr/local --strip-components=1
 
       - name: Build ELFs
+        # TODO: Priv tests mismatch due to config issues. Atomics failure still needs to be diagnosed.
         run: |
           DOCKER=1 \
           FAST=True \
@@ -265,6 +260,7 @@ jobs:
           | sudo tar xvJ --directory=/usr/local --strip-components=1
 
       - name: Build ELFs
+        # TODO: Priv tests mismatch due to config issues. Atomics failure still needs to be diagnosed.
         run: |
           DOCKER=1 \
           FAST=True \

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ It should contain the following fields:
 - `udb_config`: Path to UDB YAML file; interpreted relative to framework config file
 - `linker_script`: Path to linker script; interpreted relative to framework config file
 - `dut_include_dir`: Directory containing `rvmodel_macros.h`; interpreted relative to framework config file (use `.` for same directory as config file)
+- `include_priv_tests`: Optional; defaults to `True`; if set to `False`, all tests that rely on privilege modes will be skipped
 
 See [test_config.yaml](./config/cores/cvw/cvw-rv64gc/test_config.yaml) for an example framework config file.
 

--- a/config/sail/sail-RVI20U32/test_config.yaml
+++ b/config/sail/sail-RVI20U32/test_config.yaml
@@ -5,3 +5,4 @@ ref_model_exe: sail_riscv_sim # executable name on $PATH or full path to executa
 udb_config: sail-RVI20U32.yaml
 linker_script: link.ld
 dut_include_dir: . # Directory containing DUT specific rvmodel_macros.h header
+include_priv_tests: False

--- a/config/sail/sail-RVI20U64/test_config.yaml
+++ b/config/sail/sail-RVI20U64/test_config.yaml
@@ -5,3 +5,4 @@ ref_model_exe: sail_riscv_sim # executable name on $PATH or full path to executa
 udb_config: sail-RVI20U64.yaml
 linker_script: link.ld
 dut_include_dir: . # Directory containing DUT specific rvmodel_macros.h header
+include_priv_tests: False

--- a/config/sail/sail-rv32e/test_config.yaml
+++ b/config/sail/sail-rv32e/test_config.yaml
@@ -5,3 +5,4 @@ ref_model_exe: sail_riscv_sim # executable name on $PATH or full path to executa
 udb_config: sail-rv32e.yaml
 linker_script: link.ld
 dut_include_dir: . # Directory containing DUT specific rvmodel_macros.h header
+include_priv_tests: False

--- a/config/spike/spike-RVI20U32/test_config.yaml
+++ b/config/spike/spike-RVI20U32/test_config.yaml
@@ -5,3 +5,4 @@ ref_model_exe: sail_riscv_sim # executable name on $PATH or full path to executa
 udb_config: spike-RVI20U32.yaml
 linker_script: link.ld
 dut_include_dir: . # Directory containing DUT-specific config headers (e.g., rvmodel_macros.h, rvtest_config.h)
+include_priv_tests: False

--- a/config/spike/spike-RVI20U64/test_config.yaml
+++ b/config/spike/spike-RVI20U64/test_config.yaml
@@ -5,3 +5,4 @@ ref_model_exe: sail_riscv_sim # executable name on $PATH or full path to executa
 udb_config: spike-RVI20U64.yaml
 linker_script: link.ld
 dut_include_dir: . # Directory containing config-specific test headers (e.g. rvmodel_macros.h, rvtest_config.h)
+include_priv_tests: False

--- a/framework/src/act/act.py
+++ b/framework/src/act/act.py
@@ -73,7 +73,9 @@ def run_act(
         config_params = get_config_params(udb_config_file)
 
         # Select tests for config
-        selected_tests = select_tests(full_test_dict, implemented_extensions, config_params)
+        selected_tests = select_tests(
+            full_test_dict, implemented_extensions, config_params, include_priv_tests=config.include_priv_tests
+        )
         configs.append(
             {
                 "config": config,

--- a/framework/src/act/config.py
+++ b/framework/src/act/config.py
@@ -44,6 +44,7 @@ class Config(BaseModel):
     objdump_exe: Path | None = None
     ref_model_type: RefModelType = RefModelType.SAIL
     ref_model_exe: Path
+    include_priv_tests: bool = True
 
     model_config = {"frozen": True}
 

--- a/framework/src/act/select_tests.py
+++ b/framework/src/act/select_tests.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from act.parse_test_constraints import TestMetadata
 
+PRIV_EXTENSIONS = {"Sm", "S", "U"}
+
 
 def check_test_params(test_params: dict[str, Any], config_params: dict[str, Any]) -> bool:
     """Check if all parameters in test_params match those in config_params."""
@@ -21,13 +23,20 @@ def check_test_params(test_params: dict[str, Any], config_params: dict[str, Any]
 
 
 def select_tests(
-    test_dict: dict[str, TestMetadata], implemented_extensions: set[str], config_params: dict[str, Any]
+    test_dict: dict[str, TestMetadata],
+    implemented_extensions: set[str],
+    config_params: dict[str, Any],
+    *,
+    include_priv_tests: bool = True,
 ) -> dict[str, TestMetadata]:
     """Select tests that match the UDB configuration."""
     selected_tests: dict[str, TestMetadata] = {}
     for test_name, test_metadata in test_dict.items():
+        # Skip privileged tests if disabled
+        if not include_priv_tests and not test_metadata.required_extensions.isdisjoint(PRIV_EXTENSIONS):
+            continue
         # Check if all required extensions are implemented
-        if (test_metadata.required_extensions).issubset(implemented_extensions):
+        if test_metadata.required_extensions.issubset(implemented_extensions):
             # Check if all parameters match
             test_params = test_metadata.params
             if check_test_params(test_params, config_params):


### PR DESCRIPTION
When `include_priv_tests` is False, all tests that require Sm/S/U are skipped. This is set to false in the RVI20 configs.