### PR TITLE
Add comparison operators for test param constraints

### DIFF
--- a/framework/src/act/act.py
+++ b/framework/src/act/act.py
@@ -76,10 +76,13 @@ def run_act(
         selected_tests = select_tests(
             full_test_dict, implemented_extensions, config_params, include_priv_tests=config.include_priv_tests
         )
+        mxlen = config_params["MXLEN"]
+        if not isinstance(mxlen, int):
+            raise TypeError(f"MXLEN must be an integer, got {type(mxlen)}: {mxlen!r}")
         configs.append(
             {
                 "config": config,
-                "xlen": config_params["MXLEN"],
+                "xlen": mxlen,
                 "e_ext": "E" in implemented_extensions,
                 "selected_tests": selected_tests,
             }

--- a/framework/src/act/parse_test_constraints.py
+++ b/framework/src/act/parse_test_constraints.py
@@ -8,7 +8,6 @@
 ##################################
 
 from pathlib import Path
-from typing import Any
 
 from pydantic import BaseModel, Field, FilePath
 from ruamel.yaml import YAML
@@ -21,7 +20,7 @@ class TestMetadata(BaseModel):
     required_extensions: set[str] = Field(alias="REQUIRED_EXTENSIONS", min_length=1)
     march: str = Field(alias="MARCH", pattern=r"rv(?:32|64|\$\{XLEN\})[ieg].*")
     config_dependent: bool = Field(alias="CONFIG_DEPENDENT")
-    params: dict[str, Any] = Field(default_factory=dict)
+    params: dict[str, int | bool | str] = Field(default_factory=dict)
 
     model_config = {"extra": "forbid", "frozen": True}
 
@@ -32,7 +31,8 @@ class TestMetadata(BaseModel):
     @property
     def mxlen(self) -> int | None:
         """Get MXLEN parameter if present."""
-        return self.params.get("MXLEN")
+        value = self.params.get("MXLEN")
+        return value if isinstance(value, int) else None
 
     @property
     def flen(self) -> str:

--- a/framework/src/act/parse_udb_config.py
+++ b/framework/src/act/parse_udb_config.py
@@ -12,7 +12,6 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
 
 import rich
 from ruamel.yaml import YAML
@@ -53,7 +52,7 @@ def validate_udb_config(udb_config_file: Path) -> None:
         sys.exit(1)
 
 
-def get_config_params(udb_config_file: Path) -> dict[str, Any]:
+def get_config_params(udb_config_file: Path) -> dict[str, int | bool | str | list[int | str | bool]]:
     yaml = YAML(typ="safe", pure=True)
     udb_config = yaml.load(udb_config_file.read_text())
     config_params = udb_config["params"]

--- a/framework/src/act/select_tests.py
+++ b/framework/src/act/select_tests.py
@@ -7,17 +7,54 @@
 # Select tests to run based on UDB config and test list
 ##################################
 
-from typing import Any
+import re
 
 from act.parse_test_constraints import TestMetadata
 
 PRIV_EXTENSIONS = {"Sm", "S", "U"}
 
+# Type alias
+ConfigParamValue = int | bool | str | list[int | str | bool]
 
-def check_test_params(test_params: dict[str, Any], config_params: dict[str, Any]) -> bool:
+# Parameter constraint comparison operators
+_COMPARISON_RE = re.compile(r"^(>=|<=|!=|==|>|<)\s*(\d+)$")
+
+
+def _compare_param(test_value: object, config_value: object) -> bool:
+    """Compare a test parameter requirement against a config parameter value.
+
+    Supports comparison operator prefixes on string values:
+    '>=128', '<= 64', '> 0', '<256', '!=0', '==64'.
+    Falls back to exact equality for all other values.
+    """
+    if isinstance(test_value, str):
+        match = _COMPARISON_RE.match(test_value)
+        if match:
+            op, required_val = match.groups()
+            required_val = int(required_val)
+            if not isinstance(config_value, int):
+                return False
+            if op == ">=":
+                return config_value >= required_val
+            if op == "<=":
+                return config_value <= required_val
+            if op == ">":
+                return config_value > required_val
+            if op == "<":
+                return config_value < required_val
+            if op == "!=":
+                return config_value != required_val
+            if op == "==":
+                return config_value == required_val
+    return test_value == config_value
+
+
+def check_test_params(test_params: dict[str, int | bool | str], config_params: dict[str, ConfigParamValue]) -> bool:
     """Check if all parameters in test_params match those in config_params."""
     for param, value in test_params.items():
-        if param not in config_params or config_params[param] != value:
+        if param not in config_params:
+            return False
+        if not _compare_param(value, config_params[param]):
             return False
     return True
 
@@ -25,7 +62,7 @@ def check_test_params(test_params: dict[str, Any], config_params: dict[str, Any]
 def select_tests(
     test_dict: dict[str, TestMetadata],
     implemented_extensions: set[str],
-    config_params: dict[str, Any],
+    config_params: dict[str, ConfigParamValue],
     *,
     include_priv_tests: bool = True,
 ) -> dict[str, TestMetadata]:

--- a/framework/src/act/select_tests.py
+++ b/framework/src/act/select_tests.py
@@ -24,7 +24,7 @@ def _compare_param(test_value: object, config_value: object) -> bool:
     """Compare a test parameter requirement against a config parameter value.
 
     Supports comparison operator prefixes on string values:
-    '>=128', '<= 64', '> 0', '<256', '!=0', '==64'.
+    e.g. '>=128', '<= 64', '> 0', '<256', '!=0', '==64'.
     Falls back to exact equality for all other values.
     """
     if isinstance(test_value, str):
@@ -32,7 +32,7 @@ def _compare_param(test_value: object, config_value: object) -> bool:
         if match:
             op, required_val = match.groups()
             required_val = int(required_val)
-            if not isinstance(config_value, int):
+            if type(config_value) is not int:
                 return False
             if op == ">=":
                 return config_value >= required_val

--- a/framework/src/act/select_tests.py
+++ b/framework/src/act/select_tests.py
@@ -17,21 +17,21 @@ PRIV_EXTENSIONS = {"Sm", "S", "U"}
 ConfigParamValue = int | bool | str | list[int | str | bool]
 
 # Parameter constraint comparison operators
-_COMPARISON_RE = re.compile(r"^(>=|<=|!=|==|>|<)\s*(\d+)$")
+_COMPARISON_RE = re.compile(r"^(>=|<=|!=|==|>|<)\s*(0[xX][0-9a-fA-F]+|\d+)$")
 
 
 def _compare_param(test_value: object, config_value: object) -> bool:
     """Compare a test parameter requirement against a config parameter value.
 
-    Supports comparison operator prefixes on string values:
-    e.g. '>=128', '<= 64', '> 0', '<256', '!=0', '==64'.
-    Falls back to exact equality for all other values.
+    Supports comparison operator prefixes on strings with decimal or hex values.
+    e.g. '>=128', '<= 64', '> 0', '<256', '!=0', '==64', '>=0x80', '<0xFF'.
+    Falls back to exact equality if there is no comparison operator prefix.
     """
     if isinstance(test_value, str):
         match = _COMPARISON_RE.match(test_value)
         if match:
             op, required_val = match.groups()
-            required_val = int(required_val)
+            required_val = int(required_val, 0)
             if type(config_value) is not int:
                 return False
             if op == ">=":

--- a/generators/testgen/src/testgen/data/config.py
+++ b/generators/testgen/src/testgen/data/config.py
@@ -30,6 +30,7 @@ class TestConfig:
                              If None, extensions are parsed from testsuite name.
         march_extensions: Optional list of extensions to use for building the march string.
                           If None, march is built from required_extensions.
+        extra_params: Optional list of extra parameter requirements for the test.
     """
 
     xlen: int
@@ -39,6 +40,7 @@ class TestConfig:
     config_dependent: bool = False
     required_extensions: list[str] | None = None
     march_extensions: list[str] | None = None
+    extra_params: list[str] | None = None
 
     @property
     def xlen_format_str(self) -> str:

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -19,6 +19,7 @@ from testgen.priv.registry import (
     get_priv_test_defines,
     get_priv_test_generator,
     get_priv_test_march_extensions,
+    get_priv_test_params,
     get_priv_test_required_extensions,
 )
 
@@ -45,6 +46,7 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
         config_dependent=True,
         required_extensions=get_priv_test_required_extensions(testsuite),
         march_extensions=get_priv_test_march_extensions(testsuite),
+        extra_params=get_priv_test_params(testsuite),
     )
 
     # Create test data

--- a/generators/testgen/src/testgen/io/templates.py
+++ b/generators/testgen/src/testgen/io/templates.py
@@ -41,6 +41,8 @@ def insert_header_template(
     E_ext = test_config.E_ext
     required_extensions = test_config.required_extensions
     ext_components, params = canonicalize_extensions(testsuite, xlen, E_ext, required_extensions)
+    if test_config.extra_params:
+        params.extend(test_config.extra_params)
     march_extensions = test_config.march_extensions
     if march_extensions is not None:
         march_ext_components, _ = canonicalize_extensions(testsuite, xlen, E_ext, march_extensions)

--- a/generators/testgen/src/testgen/priv/registry.py
+++ b/generators/testgen/src/testgen/priv/registry.py
@@ -33,8 +33,11 @@ class MissingPrivGeneratorError(MissingRegistryItemError):
         self.testsuite = testsuite
 
 
-# Registry: dict mapping testsuite name to (priv_test_generator, extra_defines, required_extensions, march_extensions)
-_PRIV_TEST_GENERATORS: dict[str, tuple[PrivTestGenerator, list[str], list[str] | None, list[str] | None]] = {}
+# Registry: dict mapping testsuite name to
+# (priv_test_generator, extra_defines, required_extensions, march_extensions, params)
+_PRIV_TEST_GENERATORS: dict[
+    str, tuple[PrivTestGenerator, list[str], list[str] | None, list[str] | None, list[str] | None]
+] = {}
 
 
 def add_priv_test_generator(
@@ -43,6 +46,7 @@ def add_priv_test_generator(
     extra_defines: list[str] | None = None,
     required_extensions: list[str] | None = None,
     march_extensions: list[str] | None = None,
+    params: list[str] | None = None,
 ) -> Callable[[PrivTestGenerator], PrivTestGenerator]:
     """
     Decorator to register a privileged test generator.
@@ -55,12 +59,14 @@ def add_priv_test_generator(
                              Used for generating the march string and header defines.
         march_extensions: Optional list of extensions to use for the march string.
                           If None, march is built from required_extensions.
+        params: Optional list of parameter constraints for the test (e.g., ["NUM_PMP_ENTRIES: '>=16'"]).
+                These are included in the test YAML header for test selection.
     """
     if extra_defines is None:
         extra_defines = []
 
     def decorator(func: PrivTestGenerator) -> PrivTestGenerator:
-        _PRIV_TEST_GENERATORS[testsuite] = (func, extra_defines, required_extensions, march_extensions)
+        _PRIV_TEST_GENERATORS[testsuite] = (func, extra_defines, required_extensions, march_extensions, params)
         return func
 
     return decorator
@@ -97,6 +103,13 @@ def get_priv_test_march_extensions(testsuite: str) -> list[str] | None:
     if testsuite not in _PRIV_TEST_GENERATORS:
         raise MissingPrivGeneratorError(testsuite, list(_PRIV_TEST_GENERATORS.keys()))
     return _PRIV_TEST_GENERATORS[testsuite][3]
+
+
+def get_priv_test_params(testsuite: str) -> list[str] | None:
+    """Get the parameter constraints for a priv testsuite."""
+    if testsuite not in _PRIV_TEST_GENERATORS:
+        raise MissingPrivGeneratorError(testsuite, list(_PRIV_TEST_GENERATORS.keys()))
+    return _PRIV_TEST_GENERATORS[testsuite][4]
 
 
 def _discover_and_import_priv_generators() -> None:


### PR DESCRIPTION
Tests can now specify that a DUT parameter must be >=, <=, >, <, !=, or == to a value for a test to be selected.

This will be needed to get PMP tests working correctly.