### PR TITLE
Release MC100 rev0.1 and RVI20 rev0.6 CRDs

### DIFF
--- a/docs/crd/src/extension_defs.adoc
+++ b/docs/crd/src/extension_defs.adoc
@@ -141,6 +141,24 @@ Microcontroller compressed instructions
 Description::
 Additional compressed instructions for microcontrollers including push/pop and table jump.
 
+[[extension:Smepmp]]
+=== Extension Smepmp
+
+Long Name::
+Enhanced PMP
+
+Description::
+Original PMP with additional features such as guards against additional attack vectors.
+
+[[extension:Smpmp]]
+=== Extension Smpmp
+
+Long Name::
+Original PMP
+
+Description::
+Original PMP as defined in the "Physical Memory Protection" section of the RISC-V Privileged Architecture Machine-mode chapter, without the additional features of Smepmp.
+
 [[extension:Zicntr]
 === Extension Zicntr
 

--- a/docs/crd/src/extension_defs.adoc
+++ b/docs/crd/src/extension_defs.adoc
@@ -59,7 +59,7 @@ All Machine-mode features defined as mandatory by the RISC-V Privileged Architec
 .RV32/64 mandatory CSRs (many can be read-only zero)
 [%autowidth]
 |===
-| CSR name | Normative rule definining CSR as mandatory | Notes
+| CSR name | Normative rule defining CSR as mandatory | Notes
 
 | misa | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#misa_always_rd[misa_always_rd] |
 | mvendorid | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mvendorid_always_rd[mvendorid_always_rd] |
@@ -87,7 +87,7 @@ All Machine-mode features defined as mandatory by the RISC-V Privileged Architec
 .Additional RV32-only mandatory CSRs (many can be read-only zero)
 [%autowidth]
 |===
-| CSR name | Normative rule definining CSR as mandatory | Notes
+| CSR name | Normative rule defining CSR as mandatory | Notes
 
 | mstatush | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mstatush_acc[mstatush_acc] | Mentioned as mandatory in the Priv ISA manual "Preface to Version 20211203"
 | mcycleh | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mcycleh_op[mcycleh_op] |
@@ -101,7 +101,7 @@ All Machine-mode features defined as mandatory by the RISC-V Privileged Architec
 .Memory-mapped registers (not CSRs)
 [%autowidth]
 |===
-| Register name | Normative rule definining register as mandatory | Notes
+| Register name | Normative rule defining register as mandatory | Notes
 
 | mtime | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mtime_acc[mtime_acc] |
 | mtimecmp | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mtimecmp_sz[mtimecmp_sz] |
@@ -110,13 +110,13 @@ All Machine-mode features defined as mandatory by the RISC-V Privileged Architec
 .Instructions
 [%autowidth]
 |===
-| Instruction name | Normative rule definining instruction as mandatory | Notes
+| Instruction name | Normative rule defining instruction as mandatory | Notes
 
-| ecall | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#ecall_op[ecall_op] | Implicity mandatory
-| ebreak | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#ebreak_op[ebreak_op] | Implicity mandatory
-| c.ebreak | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#c-ebreak_op[c-ebreak_op] | Implicity mandatory
+| ecall | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#ecall_op[ecall_op] | Implicitlymandatory
+| ebreak | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#ebreak_op[ebreak_op] | Implicitlymandatory
+| c.ebreak | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#c-ebreak_op[c-ebreak_op] | Implicitlymandatory
 | mret | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mret_presence[mret_presence] |
-| wfi | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#wfi_op[wfi_op] | Implicity mandatory
+| wfi | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#wfi_op[wfi_op] | Implicitlymandatory
 |===
 
 .PMAs (Physical Memory Attributes)
@@ -159,7 +159,7 @@ Original PMP
 Description::
 Original PMP as defined in the "Physical Memory Protection" section of the RISC-V Privileged Architecture Machine-mode chapter, without the additional features of Smepmp.
 
-[[extension:Zicntr]
+[[extension:Zicntr]]
 === Extension Zicntr
 
 Long Name::

--- a/docs/crd/src/extension_defs.adoc
+++ b/docs/crd/src/extension_defs.adoc
@@ -2,40 +2,177 @@
 [[extension_defs]]
 == Extension Definitions
 
-[cols="15%,35%,50%"]
+[[extension:A]]
+=== Extension A
+
+Long Name::
+Atomic Instructions
+
+Description::
+Atomic instructions from the Zaamo and Zalrsc extensions
+
+[[extension:C]]
+=== Extension C
+
+Long Name::
+Compressed instructions
+
+Description::
+Always includes Zca, includes Zcf if F is present (RV32 only), and includes Zcd if D is present
+
+[[extension:D]]
+=== Extension D
+
+Long Name::
+Double-Precision Floating-Point
+
+Description::
+Double-precision floating-point instructions and CSRs. Requires F.
+
+[[extension:F]]
+=== Extension F
+
+Long Name::
+Single-Precision Floating-Point
+
+Description::
+Single-precision floating-point instructions and CSRs
+
+[[extension:M]]
+=== Extension M
+
+Long Name::
+Multiply
+
+Description::
+Integer multiply and divide instructions
+
+[[extension:Sm]]
+=== Extension Sm
+
+Long Name::
+Minimal Machine Mode
+
+Description::
+All Machine-mode features defined as mandatory by the RISC-V Privileged Architectures specification.
+
+.RV32/64 mandatory CSRs (many can be read-only zero)
+[%autowidth]
 |===
-| Extension | Long Name | Note
+| CSR name | Normative rule definining CSR as mandatory | Notes
 
-| [#extension:A]#A#
-| Atomic instructions
-| Comprised of instructions from the Zaamo and Zalrsc extensions
-
-| [#extension:C]#C#
-| Compressed instructions
-| Always includes Zca, includes Zcf if F is present (RV32 only), and includes Zcd if D is present
-
-| [#extension:D]#D#
-| Double-precision floating-point
-|
-
-| [#extension:F]#F#
-| Single-precision floating-point
-|
-
-| [#extension:M]#M#
-| Integer multiply and divide
-|
-
-| [#extension:Zicntr]#Zicntr#
-| Base Counters and Timers
-|
-
-| [#extension:Zifencei]#Zifencei#
-| Instruction fence
-|
-
-| [#extension:Zihpm]#Zihpm#
-| Hardware Performance Counters
-| The number of counters is platform-specific.
-
+| misa | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#misa_always_rd[misa_always_rd] |
+| mvendorid | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mvendorid_always_rd[mvendorid_always_rd] |
+| marchid | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#marchid_always_rd[marchid_always_rd] |
+| mimpid | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mimpid_always_rd[mimpid_always_rd] |
+| mhartid | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mhartid_always_rd[mhartid_always_rd] |
+| mstatus | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mstatus_acc[mstatus_acc] | closest rule requiring CSR to be implemented, seems implicitly required
+| mtvec | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mtvec_mandatory[mtvec_mandatory] |
+| mip | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mip_acc[mip_acc] | closest rule requiring CSR to be implemented, seems implicitly required
+| mie | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mie_acc[mie_acc] | closest rule requiring CSR to be implemented, seems implicitly required
+| mcycle | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#m_mode_perf_monitoring[m_mode_perf_monitoring] |
+| minstret | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#m_mode_perf_monitoring[m_mode_perf_monitoring] |
+| mhpmcounter3-mhpmcounter31 | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mhpmcounter_mandatory[mhpmcounter_mandatory] |
+| mscratch | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mscratch_sz_acc[mscratch_sz_acc] | closest rule requiring CSR to be implemented, seems implicitly required
+| mepc | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mepc_op[mepc_op] | closest rule requiring CSR to be implemented, seems implicitly required
+| mcause | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mcause_op[mcause_op] | closest rule requiring CSR to be implemented, seems implicitly required
+| mtval | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mtval_op[mtval_op] | closest rule requiring CSR to be implemented, seems implicitly required
+| mconfigptr |https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mconfigptr_mandatory[mconfigptr_mandatory] |
+| cycle | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#cycle_op[cycle_op] | read-only shadow of mcycle[31:0]
+| time | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#time_op[time_op] | read-only shadow of mtime[31:0] memory-mapped register, only exists if TIME_CSR_HW_SUPPORT parameter is true
+| instret | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#instret_op[instret_op] | read-only shadow of minstret[31:0]
+| hpmcounter3-hpmcounter31 | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#hpmcounter_op[hpmcounter_op] |
 |===
+
+.Additional RV32-only mandatory CSRs (many can be read-only zero)
+[%autowidth]
+|===
+| CSR name | Normative rule definining CSR as mandatory | Notes
+
+| mstatush | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mstatush_acc[mstatush_acc] | Mentioned as mandatory in the Priv ISA manual "Preface to Version 20211203"
+| mcycleh | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mcycleh_op[mcycleh_op] |
+| minstreth | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#minstreth_op[minstreth_op] |
+| mhpmcounter3h-mhpmcounter31h | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mhpmcounterh_op[mhpmcounterh_op] |
+| cycleh | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#cycleh_op[cycleh_op] |
+| timeh | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#timeh_op[timeh_op] | read-only shadow of mtime[63:32] memory-mapped register, only exists if TIME_CSR_HW_SUPPORT parameter is true
+| instreth | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#instreth_op[instreth_op] |
+|===
+
+.Memory-mapped registers (not CSRs)
+[%autowidth]
+|===
+| Register name | Normative rule definining register as mandatory | Notes
+
+| mtime | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mtime_acc[mtime_acc] |
+| mtimecmp | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mtimecmp_sz[mtimecmp_sz] |
+|===
+
+.Instructions
+[%autowidth]
+|===
+| Instruction name | Normative rule definining instruction as mandatory | Notes
+
+| ecall | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#ecall_op[ecall_op] | Implicity mandatory
+| ebreak | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#ebreak_op[ebreak_op] | Implicity mandatory
+| c.ebreak | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#c-ebreak_op[c-ebreak_op] | Implicity mandatory
+| mret | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#mret_presence[mret_presence] |
+| wfi | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#wfi_op[wfi_op] | Implicity mandatory
+|===
+
+.PMAs (Physical Memory Attributes)
+[%autowidth]
+|===
+| PMA | Normative rule or Implementation-defined behavior
+
+| Main-memory PMAs | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#pma_mm_vs_io_def[pma_mm_vs_io_def]
+| Support read and write of all access widths required by the attached devices | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#pma_mm_rw[pma_mm_rw]
+| Support instruction fetch if PMA_MM_IFETCH is true for the PMA region | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#PMA_MM_IFETCH[PMA_MM_IFETCH]
+| Support atomics if PMA_CACHE_MM_ALL_ATOMICS is true for the PMA region | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#PMA_CACHE_MM_ALL_ATOMICS[PMA_CACHE_MM_ALL_ATOMICS]
+| AMO support levels | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#pma_amo_levels[pma_amo_levels]
+| Size support per AMO level | https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#pma_amo_sz_support[pma_amo_sz_support]
+|===
+
+[[extension:Zce]]
+=== Extension Zce
+
+Long Name::
+Microcontroller compressed instructions
+
+Description::
+Additional compressed instructions for microcontrollers including push/pop and table jump.
+
+[[extension:Zicntr]
+=== Extension Zicntr
+
+Long Name::
+Base Counters and Timers
+
+Description::
+Base counters and timers including the time/timeh, cycle/cycleh, and instret/instreth CSRs.
+
+[[extension:Zicsr]]
+=== Extension Zicsr
+
+Long Name::
+Control and Status Register Instructions
+
+Description::
+Instructions for reading and writing control and status registers.
+
+[[extension:Zifencei]]
+=== Extension Zifencei
+
+Long Name::
+Instruction Fence
+
+Description::
+Instruction fence instructions and related CSRs.
+
+[[extension:Zihpm]]
+=== Extension Zihpm
+
+Long Name::
+Hardware Performance Counters
+
+Description::
+The number of counters is platform-specific.

--- a/docs/crd/src/extensions_intro.adoc
+++ b/docs/crd/src/extensions_intro.adoc
@@ -1,0 +1,6 @@
+Any RISC-V extensions not listed in this section are OUT-OF-SCOPE
+and the associated certificate doesn't cover their behaviors.
+
+Please refer to the <<extension_defs,Extension Definitions>> appendix for more information about the extensions listed in this section or click on the extension names in the table below to jump to their definitions.
+
+Note that the syntax `~>` for version numbers in the tables below means "version or later backwards-compatible version".

--- a/docs/crd/src/mc100_crd.adoc
+++ b/docs/crd/src/mc100_crd.adoc
@@ -20,6 +20,11 @@ History of documentation changes that eventually lead to releases.
 | TBD
 | 0.1
 a| * Copied from RVI20 CRD rev 0.4 as a starting point
+   * What is left:
+   ** Merge content from https://riscv.atlassian.net/wiki/spaces/PRMT/pages/1307639809/WARL+WLRL+legal+value+schema[WARL/WLRL Legal Value Schema] into the CSR field types section
+   ** List each possible WARL/WLRL field and use the "WARL/WLRL Legal Value Schema" to assign the required behavior of WARL/WLRL fields in order to obtain a certificate
+   ** Define additional parameters for extensions in MC100 not present in RVI20
+
 |===
 
 include::glossary.adoc[]
@@ -88,6 +93,8 @@ include::extensions_intro.adoc[]
 
 | REQ-EXT-A | <<extension:A,A>> | ~> 2.1
 | REQ-EXT-M | <<extension:M,M>> | ~> 2.0
+| REQ-EXT-Smepmp | <<extension:Smepmp,Enhanced PMP (Smepmp)>> | ~> 1.13
+| REQ-EXT-Smpmp | <<extension:Smpmp,Original PMP>> | ~> 1.13
 | REQ-EXT-Zicntr | <<extension:Zicntr,Zicntr>> | ~> 2.0
 | REQ-EXT-Zifencei | <<extension:Zifencei,Zifencei>> | ~> 2.0
 | REQ-EXT-Zihpm | <<extension:Zihpm,Zihpm>> | ~> 2.0

--- a/docs/crd/src/mc100_crd.adoc
+++ b/docs/crd/src/mc100_crd.adoc
@@ -17,7 +17,7 @@ History of documentation changes that eventually lead to releases.
 |===
 | Date | Revision | Changes
 
-| TBD
+| Mar 3, 2026
 | 0.1
 a| * Copied from RVI20 CRD rev 0.4 as a starting point
    * What is left:

--- a/docs/crd/src/mc100_crd.adoc
+++ b/docs/crd/src/mc100_crd.adoc
@@ -64,14 +64,20 @@ execution environments to handle such exceptions.
 <<<
 == Extensions
 
-Any RISC-V extensions not listed in this section are OUT-OF-SCOPE
-and the MC100 certificate doesn't cover their behaviors.
-
-Please refer to the <<extension_defs,Extension Definitions>> appendix for more information about the extensions listed in this section or click on the extension names in the table below to jump to their definitions.
+include::extensions_intro.adoc[]
 
 === Mandatory Extensions
 
-None
+.Mandatory Extensions
+[%autowidth]
+|===
+| Requirement ID | Extension | Version
+
+| REQ-EXT-C | <<extension:C,C>> | ~> 2.0
+| REQ-EXT-Zicsr | <<extension:Zicsr,Zicsr>> | ~> 2.0
+| REQ-EXT-Sm | <<extension:Sm,Minimal Machine Mode>> | ~> 1.13
+
+|===
 
 === Optional Extensions
 
@@ -80,37 +86,12 @@ None
 |===
 | Requirement ID | Extension | Version
 
-| REQ-EXT-A
-| <<extension:A,A>>
-| ~> 2.1
-
-| REQ-EXT-C
-| <<extension:C,C>>
-| ~> 2.0
-
-| REQ-EXT-D
-| <<extension:D,D>>
-| ~> 2.2
-
-| REQ-EXT-F
-| <<extension:F,F>>
-| ~> 2.2
-
-| REQ-EXT-M
-| <<extension:M,M>>
-| ~> 2.0
-
-| REQ-EXT-Zicntr
-| <<extension:Zicntr,Zicntr>>
-| ~> 2.0
-
-| REQ-EXT-Zifencei
-| <<extension:Zifencei,Zifencei>>
-| ~> 2.0
-
-| REQ-EXT-Zihpm
-| <<extension:Zihpm,Zihpm>>
-| ~> 2.0
+| REQ-EXT-A | <<extension:A,A>> | ~> 2.1
+| REQ-EXT-M | <<extension:M,M>> | ~> 2.0
+| REQ-EXT-Zicntr | <<extension:Zicntr,Zicntr>> | ~> 2.0
+| REQ-EXT-Zifencei | <<extension:Zifencei,Zifencei>> | ~> 2.0
+| REQ-EXT-Zihpm | <<extension:Zihpm,Zihpm>> | ~> 2.0
+| REQ-EXT-Zce | <<extension:Zce,Zce>> | ~> 1.0
 
 |===
 

--- a/docs/crd/src/rvi20_crd.adoc
+++ b/docs/crd/src/rvi20_crd.adoc
@@ -95,7 +95,7 @@ execution environments to handle such exceptions.
 <<<
 == Extensions
 
-:include::extensions_intro.adoc[]
+include::extensions_intro.adoc[]
 
 === Mandatory Extensions
 

--- a/docs/crd/src/rvi20_crd.adoc
+++ b/docs/crd/src/rvi20_crd.adoc
@@ -1,4 +1,4 @@
-= RVI20 Certification Requirements Document (rev 0.5)
+= RVI20 Certification Requirements Document (rev 0.6)
 :description: RVI20 CRD (Certificate Requirements Document)
 include::../../common/adoc_common.adoc[]
 
@@ -17,6 +17,10 @@ History of documentation changes that eventually lead to releases.
 [cols="1,1,5"]
 |===
 | Date | Revision | Changes
+
+| Mar 5, 2026
+| 0.6
+a| * Removed MISALIGNED_ATOMICITY_GRANULE_SIZE parameter due to https://github.com/riscv/riscv-isa-manual/issues/2726
 
 | Mar 4, 2026
 | 0.5
@@ -91,10 +95,7 @@ execution environments to handle such exceptions.
 <<<
 == Extensions
 
-Any RISC-V extensions not listed in this section are OUT-OF-SCOPE
-and the RVI20 certificate doesn't cover their behaviors.
-
-Please refer to the <<extension_defs,Extension Definitions>> appendix for more information about the extensions listed in this section or click on the extension names in the table below to jump to their definitions.
+:include::extensions_intro.adoc[]
 
 === Mandatory Extensions
 
@@ -107,38 +108,14 @@ None
 |===
 | Requirement ID | Extension | Version
 
-| REQ-EXT-A
-| <<extension:A,A>>
-| ~> 2.1
-
-| REQ-EXT-C
-| <<extension:C,C>>
-| ~> 2.0
-
-| REQ-EXT-D
-| <<extension:D,D>>
-| ~> 2.2
-
-| REQ-EXT-F
-| <<extension:F,F>>
-| ~> 2.2
-
-| REQ-EXT-M
-| <<extension:M,M>>
-| ~> 2.0
-
-| REQ-EXT-Zicntr
-| <<extension:Zicntr,Zicntr>>
-| ~> 2.0
-
-| REQ-EXT-Zifencei
-| <<extension:Zifencei,Zifencei>>
-| ~> 2.0
-
-| REQ-EXT-Zihpm
-| <<extension:Zihpm,Zihpm>>
-| ~> 2.0
-
+| REQ-EXT-A | <<extension:A,A>> | ~> 2.1
+| REQ-EXT-C | <<extension:C,C>> | ~> 2.0
+| REQ-EXT-D | <<extension:D,D>> | ~> 2.2
+| REQ-EXT-F | <<extension:F,F>> | ~> 2.2
+| REQ-EXT-M | <<extension:M,M>> | ~> 2.0
+| REQ-EXT-Zicntr | <<extension:Zicntr,Zicntr>> | ~> 2.0
+| REQ-EXT-Zifencei | <<extension:Zifencei,Zifencei>> | ~> 2.0
+| REQ-EXT-Zihpm | <<extension:Zihpm,Zihpm>> | ~> 2.0
 |===
 
 <<<
@@ -163,16 +140,6 @@ include::in_scope_param_intro.adoc[]
 | True, False
 | Misaligned load/store instructions are only IN-SCOPE if this parameter is true
 and if any restrictions on misaligned load/store instructions expressed by other parameters are met.
-
-| <<param:MISALIGNED_ATOMICITY_GRANULE_SIZE,MISALIGNED_ATOMICITY_GRANULE_SIZE>>
-| Any
-a|
-NOTE: This parameter might be removed from this CRD. See GitHub Issue https://github.com/riscv/riscv-arch-test/issues/1037.
-
-Zero:: Misaligned AMO instructions are OUT-OF-SCOPE.
-Non-zero:: Misaligned AMO atomic instructions and
-misaligned load/store instructions are IN-SCOPE if within the NAPOT byte region assuming that
-any restrictions on misaligned supported expressed by other parameters are met.
 
 | <<param:TIME_CSR_HW_SUPPORT,TIME_CSR_HW_SUPPORT>>
 | Any


### PR DESCRIPTION
Getting ready for CSC F2F tomorrow and vote on RVI20 rev 0.6 CRD for next CSC requirements WG meeting (a week from tomorrow).