### PR TITLE
fix(arch_test.h): guard resto_edeleg csrw with rvtest_strap_routine

### DIFF
--- a/tests/env/arch_test.h
+++ b/tests/env/arch_test.h
@@ -1879,12 +1879,14 @@ resto_\__MODE__\()edeleg:
 #endif
 .ifnc \__MODE__ , S
   .ifnc \__MODE__ , V
+#ifdef rvtest_strap_routine
         csrw    CSR_XEDELEG,  T2
     .ifc \_MODE__ , M   // TODO: Remove this .ifc when sail supports hedelegh (if Smstateen is supported, set mstateen0.P1P13)
       #if (XLEN==32)
         csrw    CSR_XEDELEGH, T4
       #endif
     .endif
+#endif
   .endif
 .endif
 

--- a/tests/env/arch_test.h
+++ b/tests/env/arch_test.h
@@ -1872,6 +1872,9 @@ exit_\__MODE__\()cleanup:                       // if you enter here from the ab
       .endif
 
 //----------------------
+// Guard below must match init_edeleg. If init skips the csrw (e.g. no S-mode),
+// restore must skip it too. Mismatch causes infinite trap loop on configs where
+// the CSR does not exist. See issue #1050.
 resto_\__MODE__\()edeleg:
         LREG    T2,   xedeleg_sv_off(T1)        // get saved xedeleg
 #if (XLEN==32)


### PR DESCRIPTION
On M+U-only (no S-mode) harts, medeleg is not implemented and any access raises illegal-instruction. The resto_edeleg macro in cleanup epilogs unconditionally wrote CSR_XEDELEG, causing an infinite trap loop: the faulting instruction sits past rvtest_code_end, so the trap handler's mepc bounds check fires abort_test, which jumps back to cleanup_epilogs, repeating forever.

The init_edeleg macro already guards the CSR access with #ifdef rvtest_strap_routine (which is only defined when S-mode is present). This commit restores the same guard on resto_edeleg, matching the pre-PR#843 behaviour.

Verified: Sm-00 now exits with SUCCESS (HTIF exit) on an RV32IMC+U+Sm configuration with S-mode disabled in Sail.

Fixes regression introduced by commit 4e467ae2 ("(ACT4) New Trap Handler").