### PR TITLE
Update CV32E20 rvmodel macros

### DIFF
--- a/config/cores/cve2/cv32e20/rvmodel_macros.h
+++ b/config/cores/cve2/cv32e20/rvmodel_macros.h
@@ -67,9 +67,9 @@
 
 ##### Machine Timer #####
 
-#define RVMODEL_MTIME_ADDRESS     0x0200bff8  
+#define RVMODEL_MTIME_ADDRESS     0x0200bff8  // sail.json configuration
 
-#define RVMODEL_MTIMECMP_ADDRESS  0x02004000  
+#define RVMODEL_MTIMECMP_ADDRESS  0x02004000  // sail.json configuration
 
 ##### Machine Interrupts #####
 

--- a/config/cores/cve2/cv32e20/rvmodel_macros.h
+++ b/config/cores/cve2/cv32e20/rvmodel_macros.h
@@ -67,10 +67,9 @@
 
 ##### Machine Timer #####
 
-#define RVMODEL_MTIME_ADDRESS     0x0200bff8  // sail.json configuration
+#define RVMODEL_MTIME_ADDRESS  /* unimplemented */
 
-#define RVMODEL_MTIMECMP_ADDRESS  0x02004000  // sail.json configuration
-
+#define RVMODEL_MTIMECMP_ADDRESS   /* unimplemented */
 ##### Machine Interrupts #####
 
 #define RVMODEL_SET_MEXT_INT(_R1, _R2)

--- a/config/cores/cve2/cv32e20/rvmodel_macros.h
+++ b/config/cores/cve2/cv32e20/rvmodel_macros.h
@@ -67,28 +67,28 @@
 
 ##### Machine Timer #####
 
-#define RVMODEL_MTIME_ADDRESS /* unimplemented */
+#define RVMODEL_MTIME_ADDRESS     0x0200bff8  
 
-#define RVMODEL_MTIMECMP_ADDRESS /* unimplemented */
+#define RVMODEL_MTIMECMP_ADDRESS  0x02004000  
 
 ##### Machine Interrupts #####
 
-#define RVMODEL_SET_MEXT_INT
+#define RVMODEL_SET_MEXT_INT(_R1, _R2)
 
-#define RVMODEL_CLR_MEXT_INT
+#define RVMODEL_CLR_MEXT_INT(_R1, _R2)
 
-#define RVMODEL_SET_MSW_INT
+#define RVMODEL_SET_MSW_INT(_R1, _R2)
 
-#define RVMODEL_CLR_MSW_INT
+#define RVMODEL_CLR_MSW_INT(_R1, _R2)
 
 ##### Supervisor Interrupts #####
 
-#define RVMODEL_SET_SEXT_INT
+#define RVMODEL_SET_SEXT_INT(_R1, _R2)
 
-#define RVMODEL_CLR_SEXT_INT
+#define RVMODEL_CLR_SEXT_INT(_R1, _R2)
 
-#define RVMODEL_SET_SSW_INT
+#define RVMODEL_SET_SSW_INT(_R1, _R2)
 
-#define RVMODEL_CLR_SSW_INT
+#define RVMODEL_CLR_SSW_INT(_R1, _R2)
 
 #endif // _COMPLIANCE_MODEL_H


### PR DESCRIPTION
Correctly defined parametre macros and added RVMODEL_MTIME_ADDRESS and  RVMODEL_MTIMECMP_ADDRESS according to sail.json configuration