### PR TITLE
Remove unnecessary .tohost section from linker scripts

### DIFF
--- a/config/cores/cve2/cv32e20/link.ld
+++ b/config/cores/cve2/cv32e20/link.ld
@@ -5,8 +5,6 @@ SECTIONS
 {
   . = 0x00002000;
   .text : { *(.text.init) *(.text) }
-  . = ALIGN(0x1000);
-  .tohost : { *(.tohost) }
   . = ALIGN(0x4000);
   .bss : { *(.bss) }
   . = ALIGN(0x1000);

--- a/config/cores/cvw/cvw-rv64gc/link.ld
+++ b/config/cores/cvw/cvw-rv64gc/link.ld
@@ -5,8 +5,6 @@ SECTIONS
 {
   . = 0x80000000;
   .text : { *(.text.init) *(.text) }
-  . = ALIGN(0x1000);
-  .tohost : { *(.tohost) }
   . = ALIGN(0x4000);
   .bss : { *(.bss) }
   . = ALIGN(0x1000);

--- a/config/sail/sail-rv64-max/link.ld
+++ b/config/sail/sail-rv64-max/link.ld
@@ -5,8 +5,6 @@ SECTIONS
 {
   . = 0x80000000;
   .text : { *(.text.init) *(.text) }
-  . = ALIGN(0x1000);
-  .tohost : { *(.tohost) }
   . = ALIGN(0x4000);
   .bss : { *(.bss) }
   . = ALIGN(0x1000);

--- a/config/spike/spike-rv64-max/link.ld
+++ b/config/spike/spike-rv64-max/link.ld
@@ -5,8 +5,6 @@ SECTIONS
 {
   . = 0x80000000;
   .text : { *(.text.init) *(.text) }
-  . = ALIGN(0x1000);
-  .tohost : { *(.tohost) }
   . = ALIGN(0x4000);
   .bss : { *(.bss) }
   . = ALIGN(0x1000);


### PR DESCRIPTION
The `.tohost` section only needs to be defined in the header file, not in the linker script.
