### PR TITLE
Add tests for Sspmp extension 

### DIFF
--- a/coverage/Sspmp/rv64_sspmp.cgf
+++ b/coverage/Sspmp/rv64_sspmp.cgf
@@ -1,0 +1,168 @@
+# SPMP (S-mode Physical Memory Protection) Coverage Configuration
+# Extension: Sspmp (requires Sscsrind for indirect CSR access)
+#
+# SPMP provides physical memory protection for S-mode and U-mode software,
+# configured via indirect CSR access mechanism.
+#
+# Register Layout (each spmpcfg is SXLEN bits):
+#   Bit 0: R (read permission)
+#   Bit 1: W (write permission)
+#   Bit 2: X (execute permission)
+#   Bits [4:3]: A (address matching mode)
+#     00 = OFF (disabled)
+#     01 = TOR (Top of Range)
+#     10 = NA4 (Naturally aligned 4-byte)
+#     11 = NAPOT (Naturally aligned power-of-2)
+#   Bits [6:5]: Reserved (WPRI)
+#   Bit 7: L (lock)
+#   Bit 8: U (user mode access)
+#   Bit 9: S (shared region)
+#   Bits [SXLEN-1:10]: Reserved (WPRI)
+
+# SPMP Configuration Permission Combinations
+SPMP_CFG_R:     0x01    # Read only
+SPMP_CFG_W:     0x02    # Write only (invalid without R in most cases)
+SPMP_CFG_X:     0x04    # Execute only
+SPMP_CFG_RW:    0x03    # Read + Write
+SPMP_CFG_RX:    0x05    # Read + Execute
+SPMP_CFG_WX:    0x06    # Write + Execute (invalid without R in most cases)
+SPMP_CFG_RWX:   0x07    # Read + Write + Execute
+
+# SPMP Address Matching Modes
+SPMP_CFG_OFF:   0x00    # Disabled
+SPMP_CFG_TOR:   0x08    # Top of Range
+SPMP_CFG_NA4:   0x10    # Naturally aligned 4-byte
+SPMP_CFG_NAPOT: 0x18    # Naturally aligned power-of-2
+
+# SPMP Special Bits
+SPMP_CFG_L:     0x80    # Lock bit
+SPMP_CFG_U:     0x100   # User mode access
+SPMP_CFG_S:     0x200   # Shared region
+
+# Combined configurations
+SPMP_CFG_LRWX:  0x87    # Locked + RWX
+SPMP_CFG_LRX:   0x85    # Locked + RX
+SPMP_CFG_LRW:   0x83    # Locked + RW
+SPMP_CFG_LR:    0x81    # Locked + R
+SPMP_CFG_LX:    0x84    # Locked + X
+
+# ============================================================================
+# SPMP Configuration Register Access Tests
+# ============================================================================
+SPMP_CFG_access:
+  config:
+    - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (Sspmp['implemented']); verify (Sscsrind['implemented']);
+  mnemonics:
+    "{csrrw, csrrs, csrrc, csrrwi, csrrsi, csrrci}" : 0
+  csr_comb:
+    # Verify siselect can be set to SPMP range (0x100-0x13F)
+    (siselect >= 0x100) and (siselect <= 0x13F): 0
+    # Verify sireg2 access for spmpcfg
+    (siselect >= 0x100) and (siselect <= 0x13F) and (sireg2 != old_csr_val("sireg2")): 0
+
+# ============================================================================
+# SPMP Address Matching Mode Tests
+# ============================================================================
+SPMP_CFG_A_modes:
+  config:
+    - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (Sspmp['implemented']); verify (Sscsrind['implemented']);
+  mnemonics:
+    "{csrrw, csrrs, csrrc}" : 0
+  csr_comb:
+    # Test all address matching modes via sireg2
+    # OFF mode (A=00)
+    (siselect >= 0x100) and ((sireg2 & 0x18) == ${SPMP_CFG_OFF}): 0
+    # TOR mode (A=01)
+    (siselect >= 0x100) and ((sireg2 & 0x18) == ${SPMP_CFG_TOR}): 0
+    # NA4 mode (A=10)
+    (siselect >= 0x100) and ((sireg2 & 0x18) == ${SPMP_CFG_NA4}): 0
+    # NAPOT mode (A=11)
+    (siselect >= 0x100) and ((sireg2 & 0x18) == ${SPMP_CFG_NAPOT}): 0
+
+# ============================================================================
+# SPMP Permission Combinations
+# ============================================================================
+SPMP_CFG_permissions:
+  config:
+    - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (Sspmp['implemented']); verify (Sscsrind['implemented']);
+  mnemonics:
+    "{csrrw, csrrs, csrrc}" : 0
+  csr_comb:
+    # Test permission combinations
+    # R only
+    (siselect >= 0x100) and ((sireg2 & 0x07) == ${SPMP_CFG_R}): 0
+    # R+W
+    (siselect >= 0x100) and ((sireg2 & 0x07) == ${SPMP_CFG_RW}): 0
+    # R+X
+    (siselect >= 0x100) and ((sireg2 & 0x07) == ${SPMP_CFG_RX}): 0
+    # R+W+X
+    (siselect >= 0x100) and ((sireg2 & 0x07) == ${SPMP_CFG_RWX}): 0
+    # X only
+    (siselect >= 0x100) and ((sireg2 & 0x07) == ${SPMP_CFG_X}): 0
+
+# ============================================================================
+# SPMP Special Bits Tests
+# ============================================================================
+SPMP_CFG_special_bits:
+  config:
+    - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (Sspmp['implemented']); verify (Sscsrind['implemented']);
+  mnemonics:
+    "{csrrw, csrrs, csrrc}" : 0
+  csr_comb:
+    # Test U (user mode) bit
+    (siselect >= 0x100) and ((sireg2 & ${SPMP_CFG_U}) != 0): 0
+    # Test S (shared) bit
+    (siselect >= 0x100) and ((sireg2 & ${SPMP_CFG_S}) != 0): 0
+    # Test L (lock) bit
+    (siselect >= 0x100) and ((sireg2 & ${SPMP_CFG_L}) != 0): 0
+    # Test U + S combination
+    (siselect >= 0x100) and ((sireg2 & 0x300) == 0x300): 0
+
+# ============================================================================
+# SPMP Address Register Access Tests
+# ============================================================================
+SPMP_ADDR_access:
+  config:
+    - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (Sspmp['implemented']); verify (Sscsrind['implemented']);
+  mnemonics:
+    "{csrrw, csrrs, csrrc}" : 0
+  csr_comb:
+    # Verify sireg access for spmpaddr
+    (siselect >= 0x100) and (siselect <= 0x13F) and (sireg != old_csr_val("sireg")): 0
+    # Test writing all ones (for granularity detection)
+    (siselect >= 0x100) and (sireg == -1): 0
+    # Test writing zeros
+    (siselect >= 0x100) and (sireg == 0): 0
+
+# ============================================================================
+# SPMP Multiple Entry Tests
+# ============================================================================
+SPMP_multiple_entries:
+  config:
+    - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (Sspmp['implemented']); verify (Sscsrind['implemented']);
+  mnemonics:
+    "{csrrw, csrrs, csrrc}" : 0
+  csr_comb:
+    # Test entry 0
+    (siselect == 0x100): 0
+    # Test entry 1
+    (siselect == 0x101): 0
+    # Test entry 63 (max)
+    (siselect == 0x13F): 0
+    # Test siselect transitions
+    (old_csr_val("siselect") != siselect) and (siselect >= 0x100) and (siselect <= 0x13F): 0
+
+# ============================================================================
+# SPMP Granularity Detection
+# ============================================================================
+SPMP_granularity:
+  config:
+    - check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (Sspmp['implemented']); verify (Sscsrind['implemented']);
+  mnemonics:
+    "{csrrw, csrrs, csrrc}" : 0
+  csr_comb:
+    # Granularity detection: write -1 to spmpaddr with spmpcfg.A=OFF, read back
+    (siselect >= 0x100) and ((sireg2 & 0x18) == 0) and (sireg == -1): 0
+    # Check address bits behavior in NAPOT mode vs OFF mode
+    (siselect >= 0x100) and ((sireg2 & 0x18) == ${SPMP_CFG_NAPOT}): 0
+    (siselect >= 0x100) and ((sireg2 & 0x18) == ${SPMP_CFG_OFF}): 0

--- a/riscv-test-suite/env/encoding.h
+++ b/riscv-test-suite/env/encoding.h
@@ -325,6 +325,26 @@
 #define PMP_NA4   0x10
 #define PMP_NAPOT 0x18
 
+/* SPMP (S-mode Physical Memory Protection) Configuration Fields */
+/* Each spmpcfg register is SXLEN bits (one per entry, not packed like PMP) */
+/* Access via indirect CSR mechanism: siselect = 0x100 + i, sireg2 = spmpcfg[i] */
+#define SPMP_R          0x01    /* Read permission */
+#define SPMP_W          0x02    /* Write permission */
+#define SPMP_X          0x04    /* Execute permission */
+#define SPMP_A          0x18    /* Address matching mode mask */
+#define SPMP_A_OFF      0x00    /* Address matching: OFF (disabled) */
+#define SPMP_A_TOR      0x08    /* Address matching: TOR (Top of Range) */
+#define SPMP_A_NA4      0x10    /* Address matching: NA4 (Naturally aligned 4-byte) */
+#define SPMP_A_NAPOT    0x18    /* Address matching: NAPOT (Naturally aligned power-of-2) */
+#define SPMP_L          0x80    /* Lock bit */
+#define SPMP_U          0x100   /* User mode access */
+#define SPMP_S          0x200   /* Shared region (SHARED bit) */
+#define SPMP_SHIFT      2       /* Address shift for granularity */
+
+/* SPMP siselect base value for indirect access */
+#define SPMP_SELECT_BASE    0x100   /* siselect = 0x100 + entry_index (0..63) */
+#define SPMP_SELECT_END     0x13F   /* Last valid siselect for SPMP */
+
 #define IRQ_U_SOFT   0
 /* Define PMP Configuration Fields */
 #define PMP0_CFG_SHIFT  0

--- a/riscv-test-suite/rv64i_s/Sspmp/src/spmp_addr.S
+++ b/riscv-test-suite/rv64i_s/Sspmp/src/spmp_addr.S
@@ -1,0 +1,326 @@
+// --------------------------------------------------------------------------------
+// Title       : SPMP Address Register Test via Indirect Access
+// Authors     : Ported from riscv-tests SPMP test suite
+//
+// Description : This test verifies the functionality of SPMP address registers
+//               (spmpaddr*) via indirect access mechanism (Sscsrind).
+//
+//               According to SPMP specification:
+//               - SPMP registers are accessed ONLY via indirect access mechanism
+//               - siselect = 0x100 + i selects SPMP entry i (i = 0..63)
+//               - sireg accesses spmpaddr[i]
+//               - sireg2 accesses spmpcfg[i]
+//
+//               This test verifies:
+//               - Indirect access to spmpaddr registers works correctly
+//               - Address granularity detection
+//               - Read/write behavior of spmpaddr via sireg
+//               - Address bit behavior in different modes (OFF vs NAPOT)
+//
+// Notes       : - Requires Sscsrind extension for indirect CSR access
+//               - Requires Sspmp extension implementation
+//
+// Coverpoints : SPMP address register access and granularity
+//
+// Test Cases  : - siselect write verification
+//               - Granularity detection via spmpaddr
+//               - Address bit behavior in NAPOT mode
+//               - Address bit behavior in OFF mode
+//               - Mode switching effects on address bits
+//
+// Dependencies: model_test.h, arch_test.h
+// --------------------------------------------------------------------------------
+
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV64I_Zicsr_Sscsrind_Sspmp")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (Sspmp['implemented']); verify (Sscsrind['implemented']); def TEST_CASE_1=True",spmp_addr)
+
+#ifdef TEST_CASE_1
+RVTEST_SIGBASE(x13, signature_x13_1)
+    .attribute unaligned_access, 0
+    .attribute stack_align, 16
+    .align 3
+    .option norvc
+
+main:
+    RVTEST_GOTO_MMODE
+
+#ifdef rvtest_strap_routine
+    csrw satp, zero                // Disable address translation.
+#endif
+
+    // =========================================================================
+    // Test 1: Select SPMP entry 0 and verify siselect write
+    // =========================================================================
+test1:
+    // Select SPMP entry 0 (siselect = 0x100)
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+
+    // Verify siselect was written correctly
+    csrr t1, CSR_SISELECT
+
+    // Store siselect readback value
+    RVTEST_SIGUPD(x13, t1)
+
+    // =========================================================================
+    // Test 2: Detect SPMP granularity
+    // =========================================================================
+    // Software may determine the SPMP granularity by:
+    // 1. Writing zero to spmpcfg[i] (via sireg2)
+    // 2. Writing all ones to spmpaddr[i] (via sireg)
+    // 3. Reading back spmpaddr[i]
+    // If G is the index of the least-significant bit set, the granularity is 2^(G+2) bytes.
+test2:
+    // Clear spmpcfg[0] via sireg2
+    csrw CSR_SIREG2, zero
+
+    // Write all ones to spmpaddr[0] via sireg
+    li t0, -1
+    csrw CSR_SIREG, t0
+
+    // Read back spmpaddr[0] via sireg
+    csrr t0, CSR_SIREG
+
+    // Store spmpaddr readback value (will show implemented bits)
+    RVTEST_SIGUPD(x13, t0)
+
+    // Isolate the least significant bit set
+    neg t1, t0
+    and a7, t0, t1
+
+    // a7 now contains only the lowest 1 that was set in spmpaddr[0]
+    // Store granularity indicator
+    RVTEST_SIGUPD(x13, a7)
+
+    // =========================================================================
+    // Test 3: Verify granularity is valid (not >= XLEN)
+    // =========================================================================
+test3:
+    // If a7 is 0 then G is >= XLEN which this test does not support.
+    // Store a7 value for verification
+    RVTEST_SIGUPD(x13, a7)
+
+    // If granularity is 0, skip to pass (test cannot continue)
+    beqz a7, test_complete
+
+    // Shift so the G-1 bit is set.
+    srl a7, a7, 1
+
+    // Store shifted granularity mask
+    RVTEST_SIGUPD(x13, a7)
+
+    // If no bits are set now then G is 0, which trivially passes.
+    beqz a7, test_complete
+
+    // a7 is now SPMPADDR_Gm1_MASK (G-1 bit mask)
+
+    // =========================================================================
+    // Test 4: Bit is writable in NAPOT mode - clear it
+    // =========================================================================
+test4:
+    // Set NAPOT mode
+    LI(t5, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t5
+    LI(t5, SPMP_A_NAPOT)
+    csrw CSR_SIREG2, t5
+
+    // Clear the G-1 bit
+    LI(t5, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t5
+    csrc CSR_SIREG, a7
+
+    // Read back and check
+    csrr t6, CSR_SIREG
+    and t6, t6, a7
+
+    // Store result - should be 0 (bit cleared)
+    RVTEST_SIGUPD(x13, t6)
+
+    // =========================================================================
+    // Test 5: Bit is writable in NAPOT mode - set it
+    // =========================================================================
+test5:
+    // Set the G-1 bit
+    LI(t5, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t5
+    csrs CSR_SIREG, a7
+
+    // Read back and check
+    csrr t6, CSR_SIREG
+    and t6, t6, a7
+
+    // Store result - should be non-zero (bit set)
+    RVTEST_SIGUPD(x13, t6)
+
+    // =========================================================================
+    // Test 6: Bit reads as 0 in OFF mode
+    // =========================================================================
+test6:
+    // Switch to OFF mode
+    LI(t5, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t5
+    csrw CSR_SIREG2, zero
+
+    // Read spmpaddr and check G-1 bit
+    csrr t6, CSR_SIREG
+    and t6, t6, a7
+
+    // Store result - should be 0 in OFF mode
+    RVTEST_SIGUPD(x13, t6)
+
+    // =========================================================================
+    // Test 7: Switch back to NAPOT, bit should be readable again
+    // =========================================================================
+test7:
+    // Switch back to NAPOT mode
+    LI(t5, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t5
+    LI(t5, SPMP_A_NAPOT)
+    csrw CSR_SIREG2, t5
+
+    // Read back and check
+    csrr t6, CSR_SIREG
+    and t6, t6, a7
+
+    // Store result - should still have the bit set
+    RVTEST_SIGUPD(x13, t6)
+
+    // =========================================================================
+    // Test 8: Writing the bit while in OFF mode (read-as-zero)
+    // =========================================================================
+test8:
+    // First clear the bit in NAPOT mode
+    LI(t5, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t5
+    LI(t5, SPMP_A_NAPOT)
+    csrw CSR_SIREG2, t5
+    csrc CSR_SIREG, a7
+
+    // Switch to OFF mode
+    csrw CSR_SIREG2, zero
+
+    // Set the bit while in OFF mode
+    csrs CSR_SIREG, a7
+
+    // Switch back to NAPOT mode
+    LI(t5, SPMP_A_NAPOT)
+    csrw CSR_SIREG2, t5
+
+    // Read and check - bit should be set
+    csrr t6, CSR_SIREG
+    and t6, t6, a7
+
+    // Store result
+    RVTEST_SIGUPD(x13, t6)
+
+    // =========================================================================
+    // Test 9: csrs/csrc from zero register should have no side effects
+    // =========================================================================
+test9:
+    // Switch to OFF mode with bit still set
+    LI(t5, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t5
+    csrw CSR_SIREG2, zero
+
+    // csrs and csrc from zero register should not modify the value
+    csrc CSR_SIREG, zero
+    csrs CSR_SIREG, zero
+
+    // Switch back to NAPOT mode
+    LI(t5, SPMP_A_NAPOT)
+    csrw CSR_SIREG2, t5
+
+    // Check bit is still set
+    csrr t6, CSR_SIREG
+    and t6, t6, a7
+
+    // Store result - should still be set
+    RVTEST_SIGUPD(x13, t6)
+
+    // =========================================================================
+    // Test 10: Setting other bits in OFF mode clears the read-as-zero bit
+    // =========================================================================
+test10:
+    // Switch to OFF mode
+    LI(t5, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t5
+    csrw CSR_SIREG2, zero
+
+    // Set other bits (all except G-1 bit)
+    not t0, a7
+    csrs CSR_SIREG, t0
+
+    // Switch back to NAPOT mode
+    LI(t5, SPMP_A_NAPOT)
+    csrw CSR_SIREG2, t5
+
+    // Check G-1 bit - should be cleared
+    csrr t6, CSR_SIREG
+    and t6, t6, a7
+
+    // Store result - should be 0
+    RVTEST_SIGUPD(x13, t6)
+
+test_complete:
+    // =========================================================================
+    // Test complete - store final marker
+    // =========================================================================
+    LI(a4, 0xbeefcafe)
+    RVTEST_SIGUPD(x13, a4)
+
+    j exit
+
+exit:
+#endif
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+.align 4
+
+rvtest_data:
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+    .fill 256*(XLEN/32),4,0xdeadbeef
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+
+gpr_save:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END

--- a/riscv-test-suite/rv64i_s/Sspmp/src/spmp_cfg.S
+++ b/riscv-test-suite/rv64i_s/Sspmp/src/spmp_cfg.S
@@ -1,0 +1,312 @@
+// --------------------------------------------------------------------------------
+// Title       : SPMP Configuration Register Test via Indirect Access
+// Authors     : Ported from riscv-tests SPMP test suite
+//
+// Description : This test verifies the functionality of SPMP configuration
+//               registers (spmpcfg*) via indirect access mechanism (Sscsrind).
+//
+//               According to SPMP specification:
+//               - Each SPMP entry has an SXLEN-bit configuration register
+//               - spmpcfg[i] layout (SXLEN bits):
+//                 Bit 0: R (read)
+//                 Bit 1: W (write)
+//                 Bit 2: X (execute)
+//                 Bits [4:3]: A (address matching: 00=OFF, 01=TOR, 10=NA4, 11=NAPOT)
+//                 Bits [6:5]: Reserved (WPRI)
+//                 Bit 7: L (lock)
+//                 Bit 8: U (user mode)
+//                 Bit 9: S (shared)
+//                 Bits [SXLEN-1:10]: Reserved (WPRI)
+//
+//               Access via indirect mechanism:
+//               - siselect = 0x100 + i selects SPMP entry i
+//               - sireg2 accesses spmpcfg[i]
+//
+// Notes       : - Requires Sscsrind extension for indirect CSR access
+//               - Requires Sspmp extension implementation
+//
+// Coverpoints : SPMP configuration register access and modes
+//
+// Test Cases  : - Basic read/write of spmpcfg via indirect access
+//               - TOR/NAPOT/NA4/OFF mode configurations
+//               - U (user mode) and S (shared) bit testing
+//               - Multiple SPMP entry configurations
+//               - CSR set/clear bit operations
+//
+// Dependencies: model_test.h, arch_test.h
+// --------------------------------------------------------------------------------
+
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV64I_Zicsr_Sscsrind_Sspmp")
+
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+RVTEST_CASE(0,"//check ISA:=regex(.*64.*); check ISA:=regex(.*I.*S.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; verify (Sspmp['implemented']); verify (Sscsrind['implemented']); def TEST_CASE_1=True",spmp_cfg)
+
+#ifdef TEST_CASE_1
+RVTEST_SIGBASE(x13, signature_x13_1)
+    .attribute unaligned_access, 0
+    .attribute stack_align, 16
+    .align 3
+    .option norvc
+
+main:
+    RVTEST_GOTO_MMODE
+
+#ifdef rvtest_strap_routine
+    csrw satp, zero                // Disable address translation.
+#endif
+
+    // =========================================================================
+    // Test 1: Basic read/write of spmpcfg[0] via indirect access
+    // =========================================================================
+test1:
+    // Select SPMP entry 0
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+
+    // Clear spmpcfg[0]
+    csrw CSR_SIREG2, zero
+    csrr t0, CSR_SIREG2
+
+    // Store result - should read 0 after writing 0
+    RVTEST_SIGUPD(x13, t0)
+
+    // =========================================================================
+    // Test 2: Write TOR mode with R permission to spmpcfg[0]
+    // =========================================================================
+test2:
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+
+    // TOR mode (A=01) + R permission = 0x09
+    LI(t0, (SPMP_A_TOR | SPMP_R))
+    csrw CSR_SIREG2, t0
+    csrr t1, CSR_SIREG2
+    andi t1, t1, 0x1F  // Mask to check R, W, X, A fields
+
+    // Store result - expect 0x09
+    RVTEST_SIGUPD(x13, t1)
+
+    // =========================================================================
+    // Test 3: Write NAPOT mode with R+W permissions
+    // =========================================================================
+test3:
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+
+    // NAPOT mode (A=11) + R + W = 0x1B
+    LI(t0, (SPMP_A_NAPOT | SPMP_R | SPMP_W))
+    csrw CSR_SIREG2, t0
+    csrr t1, CSR_SIREG2
+    andi t1, t1, 0x1F
+
+    // Store result - expect 0x1B
+    RVTEST_SIGUPD(x13, t1)
+
+    // =========================================================================
+    // Test 4: Write NA4 mode with R+W+X permissions
+    // =========================================================================
+test4:
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+
+    // NA4 mode (A=10) + R + W + X = 0x17
+    LI(t0, (SPMP_A_NA4 | SPMP_R | SPMP_W | SPMP_X))
+    csrw CSR_SIREG2, t0
+    csrr t1, CSR_SIREG2
+    andi t1, t1, 0x1F
+
+    // Store result - expect 0x17
+    RVTEST_SIGUPD(x13, t1)
+
+    // =========================================================================
+    // Test 5: Test U (user mode) bit
+    // =========================================================================
+test5:
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+
+    // NAPOT + R + U = 0x119
+    LI(t0, (SPMP_A_NAPOT | SPMP_R | SPMP_U))
+    csrw CSR_SIREG2, t0
+    csrr t1, CSR_SIREG2
+    andi t1, t1, 0x1FF  // Check key bits including U
+
+    // Store result - expect 0x119
+    RVTEST_SIGUPD(x13, t1)
+
+    // =========================================================================
+    // Test 6: Test S (shared) bit
+    // =========================================================================
+test6:
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+
+    // NAPOT + R + S + U (shared region) = 0x319
+    LI(t0, (SPMP_A_NAPOT | SPMP_R | SPMP_S | SPMP_U))
+    csrw CSR_SIREG2, t0
+    csrr t1, CSR_SIREG2
+    andi t1, t1, 0x3FF  // Check all key bits including S
+
+    // Store result - expect 0x319
+    RVTEST_SIGUPD(x13, t1)
+
+    // =========================================================================
+    // Test 7: Test multiple SPMP entries (entry 0 and entry 1)
+    // =========================================================================
+test7:
+    // Configure entry 0
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+    LI(t0, (SPMP_A_TOR | SPMP_R))
+    csrw CSR_SIREG2, t0
+
+    // Configure entry 1
+    LI(t0, (SPMP_SELECT_BASE + 1))
+    csrw CSR_SISELECT, t0
+    LI(t0, (SPMP_A_NAPOT | SPMP_R | SPMP_W | SPMP_X))
+    csrw CSR_SIREG2, t0
+
+    // Verify entry 0
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+    csrr t1, CSR_SIREG2
+    andi t1, t1, 0x1F
+
+    // Store entry 0 result - expect (SPMP_A_TOR | SPMP_R) = 0x09
+    RVTEST_SIGUPD(x13, t1)
+
+    // Verify entry 1
+    LI(t0, (SPMP_SELECT_BASE + 1))
+    csrw CSR_SISELECT, t0
+    csrr t1, CSR_SIREG2
+    andi t1, t1, 0x1F
+
+    // Store entry 1 result - expect (SPMP_A_NAPOT | SPMP_R | SPMP_W | SPMP_X) = 0x1F
+    RVTEST_SIGUPD(x13, t1)
+
+    // =========================================================================
+    // Test 8: Clear configuration
+    // =========================================================================
+test8:
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+    csrw CSR_SIREG2, zero
+    csrr t1, CSR_SIREG2
+
+    // Store result - expect 0
+    RVTEST_SIGUPD(x13, t1)
+
+    // =========================================================================
+    // Test 9: Test CSR set bits on spmpcfg[0]
+    // =========================================================================
+test9:
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+    csrw CSR_SIREG2, zero
+
+    // Set R bit using csrs
+    LI(t0, SPMP_R)
+    csrs CSR_SIREG2, t0
+    csrr t1, CSR_SIREG2
+    andi t1, t1, SPMP_R
+
+    // Store result - expect SPMP_R = 0x01
+    RVTEST_SIGUPD(x13, t1)
+
+    // =========================================================================
+    // Test 10: Test CSR clear bits on spmpcfg[0]
+    // =========================================================================
+test10:
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+
+    // Write all permission bits
+    LI(t0, (SPMP_A_NAPOT | SPMP_R | SPMP_W | SPMP_X))
+    csrw CSR_SIREG2, t0
+
+    // Clear R bit using csrc
+    LI(t1, SPMP_R)
+    csrc CSR_SIREG2, t1
+    csrr t2, CSR_SIREG2
+    andi t2, t2, SPMP_R
+
+    // Store result - expect 0 (R bit cleared)
+    RVTEST_SIGUPD(x13, t2)
+
+    // =========================================================================
+    // Test 11: Verify OFF mode (A=00) disables entry
+    // =========================================================================
+test11:
+    LI(t0, SPMP_SELECT_BASE)
+    csrw CSR_SISELECT, t0
+
+    // Set OFF mode with some permissions (should be null region)
+    LI(t0, (SPMP_A_OFF | SPMP_R | SPMP_W))
+    csrw CSR_SIREG2, t0
+    csrr t1, CSR_SIREG2
+    // A field should be 0 (OFF)
+    andi t1, t1, SPMP_A
+
+    // Store result - expect 0 (A field = OFF)
+    RVTEST_SIGUPD(x13, t1)
+
+    // =========================================================================
+    // Test complete - store final marker
+    // =========================================================================
+    LI(a4, 0xbeefcafe)
+    RVTEST_SIGUPD(x13, a4)
+
+    j exit
+
+exit:
+#endif
+RVTEST_CODE_END
+RVMODEL_HALT
+
+RVTEST_DATA_BEGIN
+.align 4
+
+rvtest_data:
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+.word 0xbabecafe
+RVTEST_DATA_END
+
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+signature_x13_1:
+    .fill 64*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+    .fill 256*(XLEN/32),4,0xdeadbeef
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+
+gpr_save:
+    .fill 32*(XLEN/32),4,0xdeadbeef
+
+#endif
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END


### PR DESCRIPTION
This PR introduces basic tests for the RISC-V S-level Physical Memory Protection (SPMP) extension.

Here is a pre-built PDF of SPMP:
https://github.com/riscv/riscv-spmp/blob/main/rv-spmp-spec.pdf

Here is a pre-built PDF of riscv-privileged manual with SPMP:
https://github.com/riscv/riscv-spmp/releases/download/v0.8.18/riscv-privileged-with-spmp.pdf

Here is the pointer to the SPMP specification:
https://github.com/riscv/riscv-isa-manual/pull/2573

Here is the Spike implementation supporting the tests:
https://github.com/riscv-software-src/riscv-isa-sim/pull/2244

Here are the test logs:
https://drive.google.com/drive/folders/1MT65PQ7_RgEeZ8O90XkNR9AzX2AzLgIe?usp=drive_link