### PR TITLE
Fix/cv32e20 boot addr jal

### DIFF
--- a/config/cores/cve2/cv32e20/link.ld
+++ b/config/cores/cve2/cv32e20/link.ld
@@ -3,7 +3,7 @@ ENTRY(rvtest_entry_point)
 
 SECTIONS
 {
-  . = 0x00002000;
+  . = 0x00004000;
   .text : { *(.text.init) *(.text) }
   . = ALIGN(0x4000);
   .bss : { *(.bss) }


### PR DESCRIPTION
I-jal generated test from ACT4 uses .align 14, requiring .text at a 16KB-aligned address. Therefore 0x2000 value in linker is wrong and needs to be moved to 0x4000.

Sail doesn't use a hardcoded reset vector - it loads the ELF and starts executing from the rvtest_entry_point symbol directly, wherever the linker placed it. So Sail was always running from 0x4000 (following the ELF), while the DUT was reset-fetching from 0x2000, a completely different address. That is why Sail produced a correct signature while the DUT hung.
