### PR TITLE
Revert "Update cv32e20 to use Zca instead of C extension"

### DIFF
--- a/config/cores/cve2/cv32e20/cv32e20.yaml
+++ b/config/cores/cve2/cv32e20/cv32e20.yaml
@@ -13,6 +13,7 @@ description: CV32E20 (CVE2 small) - RV32IMC configuration DUT
 implemented_extensions:
   - { name: I, version: "= 2.1" }
   - { name: M, version: "= 2.0" }
+  - { name: C, version: "= 2.0" }
   - { name: Zca, version: "= 1.0.0" }
   - { name: Zicsr, version: "= 2.0" }
   - { name: Zifencei, version: "= 2.0" }


### PR DESCRIPTION
Reverts riscv/riscv-arch-test#1074

In a previous PR, the C extension was replaced with Zca to reflect the core's lack of floating-point support. I unfortunately didn't think this through - this core's specification was finalized before the Zca naming convention. Therefore, rtl defines its capabilities through the standard misa CSR using the legacy 'C' bit (Bit 2). I should wait till phase 1, when we will see if this changes are needed.