### PR TITLE
Rev 1.0 of RVI20 CRD. Applied relevant changes to MC100 CRD too.

### DIFF
--- a/docs/crd/src/mc100_crd.adoc
+++ b/docs/crd/src/mc100_crd.adoc
@@ -119,12 +119,16 @@ include::in_scope_param_intro.adoc[]
 |===
 | Parameter | Allowed Value(s) | Impact on Certificate Scope
 
+| <<param:HPM_COUNTER_SZ,HPM_COUNTER_SZ>>
+| Any
+| Only counters with a size of 0 are IN-SCOPE since the behavior of HPM counters is implementation-specific.
+
 | <<param:LRSC_RESERVATION_STRATEGY,LRSC_RESERVATION_STRATEGY>>
 | Any
 | The load-reserved/store-conditional instructions are only IN-SCOPE if this parameter is not "Other"
 
 | <<param:MISALIGNED_LDST_HW_SUPPORT,MISALIGNED_LDST_HW_SUPPORT>>
-| True, False
+| Any
 | Misaligned load/store instructions are only IN-SCOPE if this parameter is true
 and if any restrictions on misaligned load/store instructions expressed by other parameters are met.
 
@@ -149,7 +153,7 @@ include::out_of_scope_param_intro.adoc[]
 |===
 | Parameter
 
-| <<param:HPM_COUNTER_SZ,HPM_COUNTER_SZ>>
+| TBD
 
 |===
 

--- a/docs/crd/src/param_defs/HPM_COUNTER_SZ.adoc
+++ b/docs/crd/src/param_defs/HPM_COUNTER_SZ.adoc
@@ -7,4 +7,4 @@ Normative Rule(s):
 | Array[3:31] of Integer 0 to 64
 | Zicntr
 | Bit width of each implemented unprivileged hardware performance counter.
-A value of 0 indicates the corresponding counter is not implemented.
+A value of 0 indicates the corresponding counter is not implemented and will not trap if read.

--- a/docs/crd/src/param_defs/TIME_CSR_HW_SUPPORT.adoc
+++ b/docs/crd/src/param_defs/TIME_CSR_HW_SUPPORT.adoc
@@ -3,7 +3,7 @@ a|
 
 Normative Rule(s):
 
-* https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#execution_environment_implementation_flexibility[execution_environment_implementation_flexibility]
+* https://riscv.github.io/riscv-isa-manual/snapshot/norm-rules/norm-rules.html#EE_IMPL_FLEX[EE_IMPL_FLEX]
 | Boolean
 | Zicntr
 | Implementation supports reading of all unprivileged time-related CSRs without triggering an exception. For RV31I the `time` and `timeh` CSRs are the unprivileged time-related CSRs. For RV64I the `time` CSR is the only unprivileged time-related CSR.

--- a/docs/crd/src/rvi20_crd.adoc
+++ b/docs/crd/src/rvi20_crd.adoc
@@ -1,4 +1,4 @@
-= RVI20 Certification Requirements Document (rev 0.8)
+= RVI20 Certification Requirements Document (rev 1.0)
 :description: RVI20 CRD (Certificate Requirements Document)
 include::../../common/adoc_common.adoc[]
 
@@ -17,6 +17,11 @@ History of documentation changes that eventually lead to releases.
 [cols="1,1,5"]
 |===
 | Date | Revision | Changes
+
+| Mar 10, 2026
+| 1.0 - Voted on and approved by the CSC Requirements WG on this date
+a| * Set allowed values for MISALIGNED_LDST_HW_SUPPORT to be "Any" to be consistent with other parameters.
+   * Moved HPM_COUNTER_SZ to IN-SCOPE parameters and add "and will not trap if read." to its parameter definition.
 
 | Mar 10, 2026
 | 0.8
@@ -152,12 +157,16 @@ include::in_scope_param_intro.adoc[]
 |===
 | Parameter | Allowed Value(s) | Impact on Certificate Scope
 
+| <<param:HPM_COUNTER_SZ,HPM_COUNTER_SZ>>
+| Any
+| Only counters with a size of 0 are IN-SCOPE since the behavior of HPM counters is implementation-specific.
+
 | <<param:LRSC_RESERVATION_STRATEGY,LRSC_RESERVATION_STRATEGY>>
 | Any
 | The load-reserved/store-conditional instructions are only IN-SCOPE if this parameter is not "Other"
 
 | <<param:MISALIGNED_LDST_HW_SUPPORT,MISALIGNED_LDST_HW_SUPPORT>>
-| True, False
+| Any
 | Misaligned load/store instructions are only IN-SCOPE if this parameter is true
 and if any restrictions on misaligned load/store instructions expressed by other parameters are met.
 
@@ -174,7 +183,7 @@ include::out_of_scope_param_intro.adoc[]
 |===
 | Parameter
 
-| <<param:HPM_COUNTER_SZ,HPM_COUNTER_SZ>>
+| None
 
 |===
 


### PR DESCRIPTION
- Set allowed values for MISALIGNED_LDST_HW_SUPPORT to be "Any" to be consistent with other parameters.
- Moved HPM_COUNTER_SZ to IN-SCOPE parameters and add "and will not trap if read." to its parameter definition.
- Bumped up rev from 0.8 to 1.0