### PR TITLE
Fix entrypoint address alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ A linker script is needed to place the code and data regions in the appropriate 
 - The `ENTRY` point must be `rvtest_entry_point`.
   - DUT-specific boot code can be run using the `RVMODEL_BOOT` macro, which `rvtest_entry_point` will run before anything else.
 - There must be a `.text.init` output section that contains the `.text.init` input section (i.e. `.text.init : { *(.text.init) }`).
-- There must be another `.text` output section that contains at least the `.text.rvtest` input section (i.e. `.text : { *(.text) *(.text.*) }`).
+- There must be another `.text` output section that contains at least the `.text.rvtest` input section (i.e. `.text : { *(.text) *(.text.*) }`). This must follow the `.text.init` section.
 - There must be a `.bss` output section (i.e. `.bss : { *(.bss) }`). This should follow the `.text` section.
 - There must be a `.data` output section (i.e. `.data : { *(.data) }`). This should follow the `.bss` section.
 

--- a/README.md
+++ b/README.md
@@ -240,10 +240,11 @@ Complete examples are available for an example DUT ([config/cores/cvw/cvw-rv64gc
 A linker script is needed to place the code and data regions in the appropriate place for the DUT's memory map. This can be customized as needed, but it must adhere to the following requirements:
 
 - The `ENTRY` point must be `rvtest_entry_point`.
-  - DUT-specific boot code can be run using the `RVMODEL_BOOT` macro, which `rvtest_entry_point` will run before anything else. It should not be directly called by the `ENTRY` point.
-- There must be a `.text` section.
-- There must be a `.bss` section. This should follow the `.text` section.
-- There must be a `.data` section. This should follow the `.bss` section.
+  - DUT-specific boot code can be run using the `RVMODEL_BOOT` macro, which `rvtest_entry_point` will run before anything else.
+- There must be a `.text` output section.
+  - The `.text` output section must place the `.text.init` input section before the rest of the `.text` input sections, i.e. `.text : { *(.text.init) *(.text) }`.
+- There must be a `.bss` output section. This should follow the `.text` section.
+- There must be a `.data` output section. This should follow the `.bss` section.
 
 For an example linker script that should work for most basic implementations (modify the base address as needed for your memory map), see [config/cores/cvw/cvw-rv64gc/link.ld](./config/cores/cvw/cvw-rv64gc/link.ld).
 

--- a/README.md
+++ b/README.md
@@ -241,10 +241,10 @@ A linker script is needed to place the code and data regions in the appropriate 
 
 - The `ENTRY` point must be `rvtest_entry_point`.
   - DUT-specific boot code can be run using the `RVMODEL_BOOT` macro, which `rvtest_entry_point` will run before anything else.
-- There must be a `.text` output section.
-  - The `.text` output section must place the `.text.init` input section before the rest of the `.text` input sections, i.e. `.text : { *(.text.init) *(.text) }`.
-- There must be a `.bss` output section. This should follow the `.text` section.
-- There must be a `.data` output section. This should follow the `.bss` section.
+- There must be a `.text.init` output section that contains the `.text.init` input section (i.e. `.text.init : { *(.text.init) }`).
+- There must be another `.text` output section that contains at least the `.text.rvtest` input section (i.e. `.text : { *(.text) *(.text.*) }`).
+- There must be a `.bss` output section (i.e. `.bss : { *(.bss) }`). This should follow the `.text` section.
+- There must be a `.data` output section (i.e. `.data : { *(.data) }`). This should follow the `.bss` section.
 
 For an example linker script that should work for most basic implementations (modify the base address as needed for your memory map), see [config/cores/cvw/cvw-rv64gc/link.ld](./config/cores/cvw/cvw-rv64gc/link.ld).
 

--- a/config/cores/cve2/cv32e20/link.ld
+++ b/config/cores/cve2/cv32e20/link.ld
@@ -4,7 +4,8 @@ ENTRY(rvtest_entry_point)
 SECTIONS
 {
   . = 0x00004000;
-  .text : { *(.text.init) *(.text) }
+  .text.init : { *(.text.init) }
+  .text : { *(.text) *(.text.*) }
   . = ALIGN(0x4000);
   .bss : { *(.bss) }
   . = ALIGN(0x1000);

--- a/config/cores/cvw/cvw-rv64gc/link.ld
+++ b/config/cores/cvw/cvw-rv64gc/link.ld
@@ -4,7 +4,8 @@ ENTRY(rvtest_entry_point)
 SECTIONS
 {
   . = 0x80000000;
-  .text : { *(.text.init) *(.text) }
+  .text.init : { *(.text.init) }
+  .text : { *(.text) *(.text.*) }
   . = ALIGN(0x4000);
   .bss : { *(.bss) }
   . = ALIGN(0x1000);

--- a/config/qemu/qemu-rv64-max/link.ld
+++ b/config/qemu/qemu-rv64-max/link.ld
@@ -4,7 +4,8 @@ ENTRY(rvtest_entry_point)
 SECTIONS
 {
   . = 0x80000000;
-  .text : { *(.text.init) *(.text) }
+  .text.init : { *(.text.init) }
+  .text : { *(.text) *(.text.*) }
   . = ALIGN(0x4000);
   .bss : { *(.bss) }
   . = ALIGN(0x1000);

--- a/config/sail/sail-rv64-max/link.ld
+++ b/config/sail/sail-rv64-max/link.ld
@@ -4,7 +4,8 @@ ENTRY(rvtest_entry_point)
 SECTIONS
 {
   . = 0x80000000;
-  .text : { *(.text.init) *(.text) }
+  .text.init : { *(.text.init) }
+  .text : { *(.text) *(.text.*) }
   . = ALIGN(0x4000);
   .bss : { *(.bss) }
   . = ALIGN(0x1000);

--- a/config/spike/spike-rv64-max/link.ld
+++ b/config/spike/spike-rv64-max/link.ld
@@ -4,7 +4,8 @@ ENTRY(rvtest_entry_point)
 SECTIONS
 {
   . = 0x80000000;
-  .text : { *(.text.init) *(.text) }
+  .text.init : { *(.text.init) }
+  .text : { *(.text) *(.text.*) }
   . = ALIGN(0x4000);
   .bss : { *(.bss) }
   . = ALIGN(0x1000);

--- a/tests/env/test_setup.h
+++ b/tests/env/test_setup.h
@@ -35,7 +35,13 @@
   // Include model specific boot code
   j rvmodel_boot
 
-  // Create new section to ensure alignment of code does not influence entry point
+  // Create new section so that .align directives in the test code don't affect the
+  // entry point address. The assembler increases a section's overall alignment to
+  // the largest .align in that section, so any large .align used in a test would
+  // increase .text.init's alignment, shifting rvtest_entry_point to an unexpected
+  // address. Placing test code in its own section avoids that because the .text.rvtest
+  // section will have its own alignment. This requires .text.init and .text.rvtest
+  // to be in separate output sections in the linker script.
   .section .text.rvtest
 
   // Test initialization

--- a/tests/env/test_setup.h
+++ b/tests/env/test_setup.h
@@ -31,10 +31,12 @@
   .option rvc
   .align UNROLLSZ
   .option norvc
-  .section .text.init
 
   // Include model specific boot code
   j rvmodel_boot
+
+  // Create new section to ensure alignment of code does not influence entry point
+  .section .text.rvtest
 
   // Test initialization
   .global rvtest_init


### PR DESCRIPTION
Create separate sections for the entrypoint and the rest of the test so the alignment of the test does not influence where the entrypoint is placed.