### PR TITLE
Move canary_mismatch string to failure_code.h

### DIFF
--- a/generators/testgen/scripts/vector_testgen_common.py
+++ b/generators/testgen/scripts/vector_testgen_common.py
@@ -75,8 +75,7 @@ def add_testcase_string(cp: str, instr_name: str) -> None:
   )
 
 def generate_testcase_string_section() -> str:
-  lines = ['canary_mismatch: .string "Testcase signature canary mismatch!"']
-  lines.extend(testcase_strings)
+  lines = list(testcase_strings)
   return "\n".join(lines)
 
 ##################################

--- a/generators/testgen/src/testgen/asm/sections.py
+++ b/generators/testgen/src/testgen/asm/sections.py
@@ -46,7 +46,6 @@ def generate_test_string_section(data_strings: list[str]) -> str:
     Returns:
         Assembly code for the .data section
     """
-    lines: list[str] = ['canary_mismatch: .string "Testcase signature canary mismatch!"']
-    lines.extend(data_strings)
+    lines: list[str] = list(data_strings)
 
     return "\n".join(lines)

--- a/tests-dev/priv/Sv/mstatus_tvm_test.S
+++ b/tests-dev/priv/Sv/mstatus_tvm_test.S
@@ -85,7 +85,6 @@ RVTEST_CODE_END
 
 RVTEST_DATA_BEGIN
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1: .string "\"test: 1; cp: check mstatus.tvm\""
 test_2: .string "\"test: 2; cp: check satp\""
 

--- a/tests/env/failure_code.h
+++ b/tests/env/failure_code.h
@@ -737,4 +737,6 @@
         .string "RVCP: END OF DEBUG INFORMATION\n\n"
     fflagsstr:
         .string "fflags\n"
+    canary_mismatch:
+        .string "Testcase signature canary mismatch!"
 .endm

--- a/tests/priv/Sv/mprv_vm_bare_mode.S
+++ b/tests/priv/Sv/mprv_vm_bare_mode.S
@@ -119,7 +119,6 @@ rvtest_data_1:
 
 //---------------------------------------------------------------------------------------------------------------------------------
 
-canary_mismatch:   .string "Testcase signature canary mismatch!"
 test1_mstatus_str: .string "\"Mismatch in mstatus value in Test Case 1!\""
 test1_store_str:   .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:    .string "\"Mismatch during lw in Test Case 1!\""

--- a/tests/priv/Sv/sv32_VA_all_ones_Smode.S
+++ b/tests/priv/Sv/sv32_VA_all_ones_Smode.S
@@ -164,7 +164,6 @@ rvtest_data_1_l0_x:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_exec_str:  .string "\"Mismatch during jalr in Test Case 2!\""

--- a/tests/priv/Sv/sv32_VA_all_zeros_Smode.S
+++ b/tests/priv/Sv/sv32_VA_all_zeros_Smode.S
@@ -159,7 +159,6 @@ rvtest_data_1_l0_x:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_exec_str:  .string "\"Mismatch during jalr in Test Case 2!\""

--- a/tests/priv/Sv/sv32_global_pte_Smode.S
+++ b/tests/priv/Sv/sv32_global_pte_Smode.S
@@ -180,7 +180,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_access1_store_str: .string "\"Mismatch during sw in Test Case 1, Access 1!\""
 test1_access1_load_str:  .string "\"Mismatch during lw in Test Case 1, Access 1!\""
 test1_access1_exec_str:  .string "\"Mismatch during jalr in Test Case 1, Access 1!\""

--- a/tests/priv/Sv/sv32_global_pte_Umode.S
+++ b/tests/priv/Sv/sv32_global_pte_Umode.S
@@ -180,7 +180,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_access1_store_str: .string "\"Mismatch during sw in Test Case 1, Access 1!\""
 test1_access1_load_str:  .string "\"Mismatch during lw in Test Case 1, Access 1!\""
 test1_access1_exec_str:  .string "\"Mismatch during jalr in Test Case 1, Access 1!\""

--- a/tests/priv/Sv/sv32_invalid_pte_Smode.S
+++ b/tests/priv/Sv/sv32_invalid_pte_Smode.S
@@ -174,7 +174,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_invalid_pte_Umode.S
+++ b/tests/priv/Sv/sv32_invalid_pte_Umode.S
@@ -174,7 +174,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_misaligned_page_Smode.S
+++ b/tests/priv/Sv/sv32_misaligned_page_Smode.S
@@ -144,7 +144,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_misaligned_page_Umode.S
+++ b/tests/priv/Sv/sv32_misaligned_page_Umode.S
@@ -144,7 +144,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_mstatus_mprv_Smode.S
+++ b/tests/priv/Sv/sv32_mstatus_mprv_Smode.S
@@ -184,7 +184,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_mstatus_mprv_Umode.S
+++ b/tests/priv/Sv/sv32_mstatus_mprv_Umode.S
@@ -182,7 +182,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_mstatus_mxr_Smode.S
+++ b/tests/priv/Sv/sv32_mstatus_mxr_Smode.S
@@ -203,7 +203,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_mstatus_mxr_Umode.S
+++ b/tests/priv/Sv/sv32_mstatus_mxr_Umode.S
@@ -203,7 +203,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_mstatus_sbe_and_sum_set_Smode.S
+++ b/tests/priv/Sv/sv32_mstatus_sbe_and_sum_set_Smode.S
@@ -179,7 +179,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_store_str: .string "\"Mismatch during sw in Test Case 2!\""

--- a/tests/priv/Sv/sv32_mstatus_sbe_set_Smode.S
+++ b/tests/priv/Sv/sv32_mstatus_sbe_set_Smode.S
@@ -183,7 +183,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_nleaf_pte_level0_Smode.S
+++ b/tests/priv/Sv/sv32_nleaf_pte_level0_Smode.S
@@ -155,7 +155,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_nleaf_pte_level0_Umode.S
+++ b/tests/priv/Sv/sv32_nleaf_pte_level0_Umode.S
@@ -155,7 +155,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_pte_reserved_rwx_Smode.S
+++ b/tests/priv/Sv/sv32_pte_reserved_rwx_Smode.S
@@ -196,7 +196,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_pte_reserved_rwx_Umode.S
+++ b/tests/priv/Sv/sv32_pte_reserved_rwx_Umode.S
@@ -196,7 +196,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_pte_rsw_Smode.S
+++ b/tests/priv/Sv/sv32_pte_rsw_Smode.S
@@ -233,7 +233,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:      .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_pte_rsw_Umode.S
+++ b/tests/priv/Sv/sv32_pte_rsw_Umode.S
@@ -233,7 +233,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:      .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_satp_access_test.S
+++ b/tests/priv/Sv/sv32_satp_access_test.S
@@ -207,7 +207,6 @@ RVTEST_CODE_END
 RVTEST_DATA_BEGIN
 
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 test1_csrw_str:   .string "\"Mismatch on csrw in Test Case 1!\""
 test1_csrs_str:   .string "\"Mismatch on csrs in Test Case 1!\""
 test1_csrc_str:   .string "\"Mismatch on csrc in Test Case 1!\""

--- a/tests/priv/Sv/sv32_spage_Smode.S
+++ b/tests/priv/Sv/sv32_spage_Smode.S
@@ -272,7 +272,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_spage_access_Umode.S
+++ b/tests/priv/Sv/sv32_spage_access_Umode.S
@@ -282,7 +282,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_spage_mstatus_sum_set_Smode.S
+++ b/tests/priv/Sv/sv32_spage_mstatus_sum_set_Smode.S
@@ -214,7 +214,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_upage_Umode.S
+++ b/tests/priv/Sv/sv32_upage_Umode.S
@@ -272,7 +272,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_upage_mprv_set_sum_set_Smode.S
+++ b/tests/priv/Sv/sv32_upage_mprv_set_sum_set_Smode.S
@@ -186,7 +186,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_upage_mprv_set_sum_unset_Smode.S
+++ b/tests/priv/Sv/sv32_upage_mprv_set_sum_unset_Smode.S
@@ -189,7 +189,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_upage_mstatus_sum_set_Smode.S
+++ b/tests/priv/Sv/sv32_upage_mstatus_sum_set_Smode.S
@@ -287,7 +287,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv32_upage_mstatus_sum_unset_Smode.S
+++ b/tests/priv/Sv/sv32_upage_mstatus_sum_unset_Smode.S
@@ -283,7 +283,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_VA_all_ones_Smode.S
+++ b/tests/priv/Sv/sv39_VA_all_ones_Smode.S
@@ -170,7 +170,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_exec_str:  .string "\"Mismatch during jalr in Test Case 2!\""

--- a/tests/priv/Sv/sv39_VA_all_zeros_Smode.S
+++ b/tests/priv/Sv/sv39_VA_all_zeros_Smode.S
@@ -165,7 +165,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_exec_str:  .string "\"Mismatch during jalr in Test Case 2!\""

--- a/tests/priv/Sv/sv39_canonical_Smode.S
+++ b/tests/priv/Sv/sv39_canonical_Smode.S
@@ -179,7 +179,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_canonical_Umode.S
+++ b/tests/priv/Sv/sv39_canonical_Umode.S
@@ -179,7 +179,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_global_pte_Smode.S
+++ b/tests/priv/Sv/sv39_global_pte_Smode.S
@@ -207,7 +207,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_access1_store_str: .string "\"Mismatch during sw in Test Case 1, Access 1!\""
 test1_access1_load_str:  .string "\"Mismatch during lw in Test Case 1, Access 1!\""
 test1_access1_exec_str:  .string "\"Mismatch during jalr in Test Case 1, Access 1!\""

--- a/tests/priv/Sv/sv39_global_pte_Umode.S
+++ b/tests/priv/Sv/sv39_global_pte_Umode.S
@@ -207,7 +207,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_access1_store_str: .string "\"Mismatch during sw in Test Case 1, Access 1!\""
 test1_access1_load_str:  .string "\"Mismatch during lw in Test Case 1, Access 1!\""
 test1_access1_exec_str:  .string "\"Mismatch during jalr in Test Case 1, Access 1!\""

--- a/tests/priv/Sv/sv39_invalid_pte_Smode.S
+++ b/tests/priv/Sv/sv39_invalid_pte_Smode.S
@@ -175,7 +175,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_invalid_pte_Umode.S
+++ b/tests/priv/Sv/sv39_invalid_pte_Umode.S
@@ -175,7 +175,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_misaligned_page_Smode.S
+++ b/tests/priv/Sv/sv39_misaligned_page_Smode.S
@@ -153,7 +153,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_misaligned_page_Umode.S
+++ b/tests/priv/Sv/sv39_misaligned_page_Umode.S
@@ -153,7 +153,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_mstatus_mprv_Smode.S
+++ b/tests/priv/Sv/sv39_mstatus_mprv_Smode.S
@@ -192,7 +192,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_mstatus_mprv_Umode.S
+++ b/tests/priv/Sv/sv39_mstatus_mprv_Umode.S
@@ -190,7 +190,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_mstatus_mxr_Smode.S
+++ b/tests/priv/Sv/sv39_mstatus_mxr_Smode.S
@@ -228,7 +228,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_mstatus_mxr_Umode.S
+++ b/tests/priv/Sv/sv39_mstatus_mxr_Umode.S
@@ -228,7 +228,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_mstatus_sbe_and_sum_set_Smode.S
+++ b/tests/priv/Sv/sv39_mstatus_sbe_and_sum_set_Smode.S
@@ -200,7 +200,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_store_str: .string "\"Mismatch during sw in Test Case 2!\""

--- a/tests/priv/Sv/sv39_mstatus_sbe_set_Smode.S
+++ b/tests/priv/Sv/sv39_mstatus_sbe_set_Smode.S
@@ -204,7 +204,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_nleaf_pte_level0_Smode.S
+++ b/tests/priv/Sv/sv39_nleaf_pte_level0_Smode.S
@@ -139,7 +139,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_nleaf_pte_level0_Umode.S
+++ b/tests/priv/Sv/sv39_nleaf_pte_level0_Umode.S
@@ -139,7 +139,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_pte_reserved_field_Smode.S
+++ b/tests/priv/Sv/sv39_pte_reserved_field_Smode.S
@@ -218,7 +218,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_pte_reserved_rwx_Smode.S
+++ b/tests/priv/Sv/sv39_pte_reserved_rwx_Smode.S
@@ -216,7 +216,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_pte_reserved_rwx_Umode.S
+++ b/tests/priv/Sv/sv39_pte_reserved_rwx_Umode.S
@@ -216,7 +216,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_pte_rsw_Smode.S
+++ b/tests/priv/Sv/sv39_pte_rsw_Smode.S
@@ -274,7 +274,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch:     .string "Testcase signature canary mismatch!"
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:      .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_pte_rsw_Umode.S
+++ b/tests/priv/Sv/sv39_pte_rsw_Umode.S
@@ -274,7 +274,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch:     .string "Testcase signature canary mismatch!"
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:      .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_satp_access_test.S
+++ b/tests/priv/Sv/sv39_satp_access_test.S
@@ -195,7 +195,6 @@ RVTEST_CODE_END
 RVTEST_DATA_BEGIN
 
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 test1_csrw_str:   .string "\"Mismatch on csrw in Test Case 1!\""
 test1_csrs_str:   .string "\"Mismatch on csrs in Test Case 1!\""
 test1_csrc_str:   .string "\"Mismatch on csrc in Test Case 1!\""

--- a/tests/priv/Sv/sv39_spage_access_Umode.S
+++ b/tests/priv/Sv/sv39_spage_access_Umode.S
@@ -179,7 +179,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_spage_mstatus_sum_set_Smode.S
+++ b/tests/priv/Sv/sv39_spage_mstatus_sum_set_Smode.S
@@ -252,7 +252,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_svnapot_not_supported_Smode.S
+++ b/tests/priv/Sv/sv39_svnapot_not_supported_Smode.S
@@ -142,7 +142,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_svpbmt_disabled_Smode.S
+++ b/tests/priv/Sv/sv39_svpbmt_disabled_Smode.S
@@ -171,7 +171,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_upage_mprv_set_sum_set_Smode.S
+++ b/tests/priv/Sv/sv39_upage_mprv_set_sum_set_Smode.S
@@ -194,7 +194,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_upage_mprv_set_sum_unset_Smode.S
+++ b/tests/priv/Sv/sv39_upage_mprv_set_sum_unset_Smode.S
@@ -197,7 +197,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_upage_mstatus_sum_set_Smode.S
+++ b/tests/priv/Sv/sv39_upage_mstatus_sum_set_Smode.S
@@ -339,7 +339,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv39_upage_mstatus_sum_unset_Smode.S
+++ b/tests/priv/Sv/sv39_upage_mstatus_sum_unset_Smode.S
@@ -335,7 +335,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_VA_all_ones_Smode.S
+++ b/tests/priv/Sv/sv48_VA_all_ones_Smode.S
@@ -173,7 +173,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_exec_str:  .string "\"Mismatch during jalr in Test Case 2!\""

--- a/tests/priv/Sv/sv48_VA_all_zeros_Smode.S
+++ b/tests/priv/Sv/sv48_VA_all_zeros_Smode.S
@@ -168,7 +168,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_exec_str:  .string "\"Mismatch during jalr in Test Case 2!\""

--- a/tests/priv/Sv/sv48_canonical_Smode.S
+++ b/tests/priv/Sv/sv48_canonical_Smode.S
@@ -196,7 +196,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_canonical_Umode.S
+++ b/tests/priv/Sv/sv48_canonical_Umode.S
@@ -196,7 +196,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_global_pte_Smode.S
+++ b/tests/priv/Sv/sv48_global_pte_Smode.S
@@ -235,7 +235,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_access1_store_str: .string "\"Mismatch during sw in Test Case 1, Access 1!\""
 test1_access1_load_str:  .string "\"Mismatch during lw in Test Case 1, Access 1!\""
 test1_access1_exec_str:  .string "\"Mismatch during jalr in Test Case 1, Access 1!\""

--- a/tests/priv/Sv/sv48_global_pte_Umode.S
+++ b/tests/priv/Sv/sv48_global_pte_Umode.S
@@ -235,7 +235,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_access1_store_str: .string "\"Mismatch during sw in Test Case 1, Access 1!\""
 test1_access1_load_str:  .string "\"Mismatch during lw in Test Case 1, Access 1!\""
 test1_access1_exec_str:  .string "\"Mismatch during jalr in Test Case 1, Access 1!\""

--- a/tests/priv/Sv/sv48_invalid_pte_Smode.S
+++ b/tests/priv/Sv/sv48_invalid_pte_Smode.S
@@ -196,7 +196,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_invalid_pte_Umode.S
+++ b/tests/priv/Sv/sv48_invalid_pte_Umode.S
@@ -196,7 +196,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_misaligned_page_Smode.S
+++ b/tests/priv/Sv/sv48_misaligned_page_Smode.S
@@ -171,7 +171,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_misaligned_page_Umode.S
+++ b/tests/priv/Sv/sv48_misaligned_page_Umode.S
@@ -171,7 +171,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_mstatus_mprv_Smode.S
+++ b/tests/priv/Sv/sv48_mstatus_mprv_Smode.S
@@ -210,7 +210,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_mstatus_mprv_Umode.S
+++ b/tests/priv/Sv/sv48_mstatus_mprv_Umode.S
@@ -208,7 +208,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_mstatus_mxr_Smode.S
+++ b/tests/priv/Sv/sv48_mstatus_mxr_Smode.S
@@ -269,7 +269,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_mstatus_mxr_Umode.S
+++ b/tests/priv/Sv/sv48_mstatus_mxr_Umode.S
@@ -269,7 +269,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_mstatus_sbe_and_sum_set_Smode.S
+++ b/tests/priv/Sv/sv48_mstatus_sbe_and_sum_set_Smode.S
@@ -223,7 +223,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_store_str: .string "\"Mismatch during sw in Test Case 2!\""

--- a/tests/priv/Sv/sv48_mstatus_sbe_set_Smode.S
+++ b/tests/priv/Sv/sv48_mstatus_sbe_set_Smode.S
@@ -227,7 +227,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_nleaf_pte_level0_Smode.S
+++ b/tests/priv/Sv/sv48_nleaf_pte_level0_Smode.S
@@ -148,7 +148,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_nleaf_pte_level0_Umode.S
+++ b/tests/priv/Sv/sv48_nleaf_pte_level0_Umode.S
@@ -147,7 +147,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_pte_reserved_field_Smode.S
+++ b/tests/priv/Sv/sv48_pte_reserved_field_Smode.S
@@ -218,7 +218,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_pte_reserved_rwx_Smode.S
+++ b/tests/priv/Sv/sv48_pte_reserved_rwx_Smode.S
@@ -252,7 +252,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_pte_reserved_rwx_Umode.S
+++ b/tests/priv/Sv/sv48_pte_reserved_rwx_Umode.S
@@ -252,7 +252,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_pte_rsw_Smode.S
+++ b/tests/priv/Sv/sv48_pte_rsw_Smode.S
@@ -328,7 +328,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:      .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_pte_rsw_Umode.S
+++ b/tests/priv/Sv/sv48_pte_rsw_Umode.S
@@ -328,7 +328,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:      .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_satp_access_test.S
+++ b/tests/priv/Sv/sv48_satp_access_test.S
@@ -107,7 +107,6 @@ RVTEST_CODE_END
 RVTEST_DATA_BEGIN
 
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 test1_sv48_str:   .string "\"Mismatch on setting satp.MODE=Sv48 in Test Case 1!\""
 test2_zeros_str:  .string "\"Mismatch on setting satp.PPN=Zeros in Test Case 2!\""
 test2_ones_str:   .string "\"Mismatch on setting satp.PPN=Ones in Test Case 2!\""

--- a/tests/priv/Sv/sv48_spage_access_Umode.S
+++ b/tests/priv/Sv/sv48_spage_access_Umode.S
@@ -196,7 +196,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_spage_mstatus_sum_set_Smode.S
+++ b/tests/priv/Sv/sv48_spage_mstatus_sum_set_Smode.S
@@ -311,7 +311,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_svnapot_not_supported_Smode.S
+++ b/tests/priv/Sv/sv48_svnapot_not_supported_Smode.S
@@ -150,7 +150,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_svpbmt_disabled_Smode.S
+++ b/tests/priv/Sv/sv48_svpbmt_disabled_Smode.S
@@ -172,7 +172,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_upage_mprv_set_sum_set_Smode.S
+++ b/tests/priv/Sv/sv48_upage_mprv_set_sum_set_Smode.S
@@ -213,7 +213,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_upage_mprv_set_sum_unset_Smode.S
+++ b/tests/priv/Sv/sv48_upage_mprv_set_sum_unset_Smode.S
@@ -216,7 +216,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_upage_mstatus_sum_set_Smode.S
+++ b/tests/priv/Sv/sv48_upage_mstatus_sum_set_Smode.S
@@ -419,7 +419,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv48_upage_mstatus_sum_unset_Smode.S
+++ b/tests/priv/Sv/sv48_upage_mstatus_sum_unset_Smode.S
@@ -415,7 +415,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_VA_all_ones_Smode.S
+++ b/tests/priv/Sv/sv57_VA_all_ones_Smode.S
@@ -177,7 +177,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_exec_str:  .string "\"Mismatch during jalr in Test Case 2!\""

--- a/tests/priv/Sv/sv57_VA_all_zeros_Smode.S
+++ b/tests/priv/Sv/sv57_VA_all_zeros_Smode.S
@@ -172,7 +172,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_exec_str:  .string "\"Mismatch during jalr in Test Case 2!\""

--- a/tests/priv/Sv/sv57_canonical_Smode.S
+++ b/tests/priv/Sv/sv57_canonical_Smode.S
@@ -217,7 +217,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_canonical_Umode.S
+++ b/tests/priv/Sv/sv57_canonical_Umode.S
@@ -217,7 +217,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_global_pte_Smode.S
+++ b/tests/priv/Sv/sv57_global_pte_Smode.S
@@ -265,7 +265,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_access1_store_str: .string "\"Mismatch during sw in Test Case 1, Access 1!\""
 test1_access1_load_str:  .string "\"Mismatch during lw in Test Case 1, Access 1!\""
 test1_access1_exec_str:  .string "\"Mismatch during jalr in Test Case 1, Access 1!\""

--- a/tests/priv/Sv/sv57_global_pte_Umode.S
+++ b/tests/priv/Sv/sv57_global_pte_Umode.S
@@ -265,7 +265,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_access1_store_str: .string "\"Mismatch during sw in Test Case 1, Access 1!\""
 test1_access1_load_str:  .string "\"Mismatch during lw in Test Case 1, Access 1!\""
 test1_access1_exec_str:  .string "\"Mismatch during jalr in Test Case 1, Access 1!\""

--- a/tests/priv/Sv/sv57_invalid_pte_Smode.S
+++ b/tests/priv/Sv/sv57_invalid_pte_Smode.S
@@ -217,7 +217,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_invalid_pte_Umode.S
+++ b/tests/priv/Sv/sv57_invalid_pte_Umode.S
@@ -217,7 +217,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_misaligned_page_Smode.S
+++ b/tests/priv/Sv/sv57_misaligned_page_Smode.S
@@ -191,7 +191,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_misaligned_page_Umode.S
+++ b/tests/priv/Sv/sv57_misaligned_page_Umode.S
@@ -191,7 +191,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_mstatus_mprv_Smode.S
+++ b/tests/priv/Sv/sv57_mstatus_mprv_Smode.S
@@ -231,7 +231,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_mstatus_mprv_Umode.S
+++ b/tests/priv/Sv/sv57_mstatus_mprv_Umode.S
@@ -229,7 +229,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_mstatus_mxr_Smode.S
+++ b/tests/priv/Sv/sv57_mstatus_mxr_Smode.S
@@ -312,7 +312,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_mstatus_mxr_Umode.S
+++ b/tests/priv/Sv/sv57_mstatus_mxr_Umode.S
@@ -312,7 +312,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_mstatus_sbe_and_sum_set_Smode.S
+++ b/tests/priv/Sv/sv57_mstatus_sbe_and_sum_set_Smode.S
@@ -249,7 +249,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test2_store_str: .string "\"Mismatch during sw in Test Case 2!\""

--- a/tests/priv/Sv/sv57_mstatus_sbe_set_Smode.S
+++ b/tests/priv/Sv/sv57_mstatus_sbe_set_Smode.S
@@ -253,7 +253,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_nleaf_pte_level0_Smode.S
+++ b/tests/priv/Sv/sv57_nleaf_pte_level0_Smode.S
@@ -151,7 +151,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_nleaf_pte_level0_Umode.S
+++ b/tests/priv/Sv/sv57_nleaf_pte_level0_Umode.S
@@ -151,7 +151,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_pte_reserved_field_Smode.S
+++ b/tests/priv/Sv/sv57_pte_reserved_field_Smode.S
@@ -220,7 +220,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_pte_reserved_rwx_Smode.S
+++ b/tests/priv/Sv/sv57_pte_reserved_rwx_Smode.S
@@ -291,7 +291,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_pte_reserved_rwx_Umode.S
+++ b/tests/priv/Sv/sv57_pte_reserved_rwx_Umode.S
@@ -291,7 +291,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_pte_rsw_Smode.S
+++ b/tests/priv/Sv/sv57_pte_rsw_Smode.S
@@ -386,7 +386,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:      .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_pte_rsw_Umode.S
+++ b/tests/priv/Sv/sv57_pte_rsw_Umode.S
@@ -386,7 +386,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:      .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_satp_access_test.S
+++ b/tests/priv/Sv/sv57_satp_access_test.S
@@ -107,7 +107,6 @@ RVTEST_CODE_END
 RVTEST_DATA_BEGIN
 
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 test1_sv57_str:   .string "\"Mismatch on setting satp.MODE=Sv57 in Test Case 1!\""
 test2_zeros_str:  .string "\"Mismatch on setting satp.PPN=Zeros in Test Case 2!\""
 test2_ones_str:   .string "\"Mismatch on setting satp.PPN=Ones in Test Case 2!\""

--- a/tests/priv/Sv/sv57_spage_access_Umode.S
+++ b/tests/priv/Sv/sv57_spage_access_Umode.S
@@ -217,7 +217,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_spage_mstatus_sum_set_Smode.S
+++ b/tests/priv/Sv/sv57_spage_mstatus_sum_set_Smode.S
@@ -365,7 +365,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_svnapot_not_supported_Smode.S
+++ b/tests/priv/Sv/sv57_svnapot_not_supported_Smode.S
@@ -154,7 +154,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_svpbmt_disabled_Smode.S
+++ b/tests/priv/Sv/sv57_svpbmt_disabled_Smode.S
@@ -174,7 +174,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_upage_mprv_set_sum_set_Smode.S
+++ b/tests/priv/Sv/sv57_upage_mprv_set_sum_set_Smode.S
@@ -234,7 +234,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_upage_mprv_set_sum_unset_Smode.S
+++ b/tests/priv/Sv/sv57_upage_mprv_set_sum_unset_Smode.S
@@ -237,7 +237,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_upage_mstatus_sum_set_Smode.S
+++ b/tests/priv/Sv/sv57_upage_mstatus_sum_set_Smode.S
@@ -506,7 +506,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/sv57_upage_mstatus_sum_unset_Smode.S
+++ b/tests/priv/Sv/sv57_upage_mstatus_sum_unset_Smode.S
@@ -501,7 +501,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Sv/vm_mstatus_tvm_test.S
+++ b/tests/priv/Sv/vm_mstatus_tvm_test.S
@@ -93,7 +93,6 @@ RVTEST_DATA_BEGIN
 
 //---------------------------------------------------------------------------------------------------------------------------------
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 tvm_str:   .string "\"Mismatch in mstatus value while setting TVM bit!\""
 test1_str: .string "\"Mismatch in Test Case 1!\""
 test3_str: .string "\"Mismatch in Test Case 3!\""

--- a/tests/priv/SvPMP/sv32_pmp_on_pa_Smode.S
+++ b/tests/priv/SvPMP/sv32_pmp_on_pa_Smode.S
@@ -266,7 +266,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 pmpcfg0_rx_str:   .string "\"Mismatch in pmpcfg0 while setting RX permission!\""
 pmpcfg0_rw_str:   .string "\"Mismatch in pmpcfg0 while setting RW permission!\""
 pmpcfg0_x_str:    .string "\"Mismatch in pmpcfg0 while setting X permission!\""

--- a/tests/priv/SvPMP/sv32_pmp_on_pa_Umode.S
+++ b/tests/priv/SvPMP/sv32_pmp_on_pa_Umode.S
@@ -266,7 +266,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 pmpcfg0_rx_str:   .string "\"Mismatch in pmpcfg0 while setting RX permission!\""
 pmpcfg0_rw_str:   .string "\"Mismatch in pmpcfg0 while setting RW permission!\""
 pmpcfg0_x_str:    .string "\"Mismatch in pmpcfg0 while setting X permission!\""

--- a/tests/priv/SvPMP/sv32_pmp_on_pte_Smode.S
+++ b/tests/priv/SvPMP/sv32_pmp_on_pte_Smode.S
@@ -217,7 +217,6 @@ rvtest_slvl0_pg_tbl:
     .skip(4096)
 .align (RVMODEL_PMP_GRAIN+2)
 
-canary_mismatch:     .string "Testcase signature canary mismatch!"
 write_pmpcfg0_str:   .string "\"Mismatch in pmpcfg0!\""
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""

--- a/tests/priv/SvPMP/sv32_pmp_on_pte_Umode.S
+++ b/tests/priv/SvPMP/sv32_pmp_on_pte_Umode.S
@@ -217,7 +217,6 @@ rvtest_slvl0_pg_tbl:
     .skip(4096)
 .align (RVMODEL_PMP_GRAIN+2)
 
-canary_mismatch:     .string "Testcase signature canary mismatch!"
 write_pmpcfg0_str:   .string "\"Mismatch in pmpcfg0!\""
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""

--- a/tests/priv/SvPMP/sv39_pmp_on_pa_Smode.S
+++ b/tests/priv/SvPMP/sv39_pmp_on_pa_Smode.S
@@ -301,7 +301,6 @@ rvtest_slvl0_pg_tbl:
 rvtest_slvl1_pg_tbl:
     .skip(4096)
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 pmpcfg0_rx_str:   .string "\"Mismatch in pmpcfg0 while setting RX permission!\""
 pmpcfg0_rw_str:   .string "\"Mismatch in pmpcfg0 while setting RW permission!\""
 pmpcfg0_x_str:    .string "\"Mismatch in pmpcfg0 while setting X permission!\""

--- a/tests/priv/SvPMP/sv39_pmp_on_pa_Umode.S
+++ b/tests/priv/SvPMP/sv39_pmp_on_pa_Umode.S
@@ -301,7 +301,6 @@ rvtest_slvl0_pg_tbl:
 rvtest_slvl1_pg_tbl:
     .skip(4096)
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 pmpcfg0_rx_str:   .string "\"Mismatch in pmpcfg0 while setting RX permission!\""
 pmpcfg0_rw_str:   .string "\"Mismatch in pmpcfg0 while setting RW permission!\""
 pmpcfg0_x_str:    .string "\"Mismatch in pmpcfg0 while setting X permission!\""

--- a/tests/priv/SvPMP/sv39_pmp_on_pte_Smode.S
+++ b/tests/priv/SvPMP/sv39_pmp_on_pte_Smode.S
@@ -248,7 +248,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 .align (RVMODEL_PMP_GRAIN+2)
 
-canary_mismatch:     .string "Testcase signature canary mismatch!"
 write_pmpcfg0_str:   .string "\"Mismatch in pmpcfg0!\""
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""

--- a/tests/priv/SvPMP/sv39_pmp_on_pte_Umode.S
+++ b/tests/priv/SvPMP/sv39_pmp_on_pte_Umode.S
@@ -248,7 +248,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 .align (RVMODEL_PMP_GRAIN+2)
 
-canary_mismatch:     .string "Testcase signature canary mismatch!"
 write_pmpcfg0_str:   .string "\"Mismatch in pmpcfg0!\""
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""

--- a/tests/priv/SvPMP/sv48_pmp_on_pa_Smode.S
+++ b/tests/priv/SvPMP/sv48_pmp_on_pa_Smode.S
@@ -342,7 +342,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 pmpcfg0_rx_str:   .string "\"Mismatch in pmpcfg0 while setting RX permission!\""
 pmpcfg0_rw_str:   .string "\"Mismatch in pmpcfg0 while setting RW permission!\""
 pmpcfg0_x_str:    .string "\"Mismatch in pmpcfg0 while setting X permission!\""

--- a/tests/priv/SvPMP/sv48_pmp_on_pa_Umode.S
+++ b/tests/priv/SvPMP/sv48_pmp_on_pa_Umode.S
@@ -342,7 +342,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 pmpcfg0_rx_str:   .string "\"Mismatch in pmpcfg0 while setting RX permission!\""
 pmpcfg0_rw_str:   .string "\"Mismatch in pmpcfg0 while setting RW permission!\""
 pmpcfg0_x_str:    .string "\"Mismatch in pmpcfg0 while setting X permission!\""

--- a/tests/priv/SvPMP/sv48_pmp_on_pte_Smode.S
+++ b/tests/priv/SvPMP/sv48_pmp_on_pte_Smode.S
@@ -282,7 +282,6 @@ rvtest_slvl2_pg_tbl:
     .skip(4096)
 .align (RVMODEL_PMP_GRAIN+2)
 
-canary_mismatch:     .string "Testcase signature canary mismatch!"
 write_pmpcfg0_str:   .string "\"Mismatch in pmpcfg0!\""
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""

--- a/tests/priv/SvPMP/sv48_pmp_on_pte_Umode.S
+++ b/tests/priv/SvPMP/sv48_pmp_on_pte_Umode.S
@@ -282,7 +282,6 @@ rvtest_slvl2_pg_tbl:
     .skip(4096)
 .align (RVMODEL_PMP_GRAIN+2)
 
-canary_mismatch:     .string "Testcase signature canary mismatch!"
 write_pmpcfg0_str:   .string "\"Mismatch in pmpcfg0!\""
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""

--- a/tests/priv/SvPMP/sv57_pmp_on_pa_Smode.S
+++ b/tests/priv/SvPMP/sv57_pmp_on_pa_Smode.S
@@ -386,7 +386,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 pmpcfg0_rx_str:   .string "\"Mismatch in pmpcfg0 while setting RX permission!\""
 pmpcfg0_rw_str:   .string "\"Mismatch in pmpcfg0 while setting RW permission!\""
 pmpcfg0_x_str:    .string "\"Mismatch in pmpcfg0 while setting X permission!\""

--- a/tests/priv/SvPMP/sv57_pmp_on_pa_Umode.S
+++ b/tests/priv/SvPMP/sv57_pmp_on_pa_Umode.S
@@ -386,7 +386,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch:  .string "Testcase signature canary mismatch!"
 pmpcfg0_rx_str:   .string "\"Mismatch in pmpcfg0 while setting RX permission!\""
 pmpcfg0_rw_str:   .string "\"Mismatch in pmpcfg0 while setting RW permission!\""
 pmpcfg0_x_str:    .string "\"Mismatch in pmpcfg0 while setting X permission!\""

--- a/tests/priv/SvPMP/sv57_pmp_on_pte_Smode.S
+++ b/tests/priv/SvPMP/sv57_pmp_on_pte_Smode.S
@@ -318,7 +318,6 @@ rvtest_slvl3_pg_tbl:
     .skip(4096)
 .align (RVMODEL_PMP_GRAIN+2)
 
-canary_mismatch:     .string "Testcase signature canary mismatch!"
 write_pmpcfg0_str:   .string "\"Mismatch in pmpcfg0!\""
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""

--- a/tests/priv/SvPMP/sv57_pmp_on_pte_Umode.S
+++ b/tests/priv/SvPMP/sv57_pmp_on_pte_Umode.S
@@ -318,7 +318,6 @@ rvtest_slvl3_pg_tbl:
     .skip(4096)
 .align (RVMODEL_PMP_GRAIN+2)
 
-canary_mismatch:     .string "Testcase signature canary mismatch!"
 write_pmpcfg0_str:   .string "\"Mismatch in pmpcfg0!\""
 test1_store_str:     .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:      .string "\"Mismatch during lw in Test Case 1!\""

--- a/tests/priv/Svade/sv32_Svade_Smode.S
+++ b/tests/priv/Svade/sv32_Svade_Smode.S
@@ -251,7 +251,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Svade/sv32_Svade_Umode.S
+++ b/tests/priv/Svade/sv32_Svade_Umode.S
@@ -251,7 +251,6 @@ rvtest_data_1:
 rvtest_slvl0_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Svade/sv39_Svade_Smode.S
+++ b/tests/priv/Svade/sv39_Svade_Smode.S
@@ -297,7 +297,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Svade/sv39_Svade_Umode.S
+++ b/tests/priv/Svade/sv39_Svade_Umode.S
@@ -297,7 +297,6 @@ rvtest_slvl1_pg_tbl:
     .skip(4096)
 
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Svade/sv48_Svade_Smode.S
+++ b/tests/priv/Svade/sv48_Svade_Smode.S
@@ -362,7 +362,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Svade/sv48_Svade_Umode.S
+++ b/tests/priv/Svade/sv48_Svade_Umode.S
@@ -362,7 +362,6 @@ rvtest_slvl1_pg_tbl:
 rvtest_slvl2_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Svade/sv57_Svade_Smode.S
+++ b/tests/priv/Svade/sv57_Svade_Smode.S
@@ -434,7 +434,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/Svade/sv57_Svade_Umode.S
+++ b/tests/priv/Svade/sv57_Svade_Umode.S
@@ -434,7 +434,6 @@ rvtest_slvl2_pg_tbl:
 rvtest_slvl3_pg_tbl:
     .skip(4096)
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test1_store_str: .string "\"Mismatch during sw in Test Case 1!\""
 test1_load_str:  .string "\"Mismatch during lw in Test Case 1!\""
 test1_exec_str:  .string "\"Mismatch during jalr in Test Case 1!\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_all_entries_check.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_all_entries_check.S
@@ -680,7 +680,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_pmpm64_sw\""
 test_2_str: .string "\"test: 2; cp: cp_pmpm64_lw\""
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_all.S
@@ -357,7 +357,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1; cp: cp_cfg_A_all_test_1\""
 test_2_str:  .string "\"test: 2; cp: cp_cfg_A_all_test_2\""
 test_3_str:  .string "\"test: 3; cp: cp_cfg_A_all_test_3\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_off_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_off_all.S
@@ -350,7 +350,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_A_off_all_jalr\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_A_off_all_sw\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_A_off_all_lw\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_bot.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_bot.S
@@ -213,7 +213,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_A_tor_bot_store_access_at_pmpaddr0-4\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_A_tor_bot_store_access_at_pmpaddr0+4\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_A_tor_bot_store_access_at_pmpaddr1-4\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_zero.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_A_tor_zero.S
@@ -180,7 +180,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_A_tor_zero_store_access_at_pmpaddr0\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_A_tor_zero_store_access_at_pmpaddr0-4\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_A_tor_zero_load_access_at_pmpaddr0\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_access_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_access_all.S
@@ -335,7 +335,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_cfg_L_access_all_lw and cp_none_lw\""
 test_2_str: .string "\"test: 2; cp: cp_cfg_L_access_all_sw and cp_none_sw\""
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_napot.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_napot.S
@@ -177,7 +177,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1; cp: cp_cfg_L_modify_test_1\""
 test_2_str:  .string "\"test: 2; cp: cp_cfg_L_modify_test_2\""
 test_3_str:  .string "\"test: 3; cp: cp_cfg_L_modify_test_3\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_off.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_off.S
@@ -177,7 +177,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1; cp: cp_cfg_L_modify_1\""
 test_2_str:  .string "\"test: 2; cp: cp_cfg_L_modify_2\""
 test_3_str:  .string "\"test: 3; cp: cp_cfg_L_modify_3\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_tor.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_L_modify_tor.S
@@ -176,7 +176,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1; cp: cp_cfg_L_modify\""
 test_2_str:  .string "\"test: 2; cp: cp_cfg_L_modify\""
 test_3_str:  .string "\"test: 3; cp: cp_cfg_L_modify\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-01.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-01.S
@@ -280,7 +280,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-02.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-02.S
@@ -281,7 +281,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-03.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-03.S
@@ -278,7 +278,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-04.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_XWR_all-04.S
@@ -279,7 +279,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_na4_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_na4_all.S
@@ -289,7 +289,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_na4_all_lw_address\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_na4_all_address-4\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_na4_all_address+4\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_napot_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_napot_all.S
@@ -334,7 +334,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_napot_all_lw_address\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_napot_all_address-4\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_napot_all_address+4\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_all.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_all.S
@@ -269,7 +269,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_tor_all_lw\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-01.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-01.S
@@ -192,7 +192,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_tor_check1_store_access_at_pmpaddr-4\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_tor_check1_store_access_at_pmpaddr\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_tor_check1_store_access_at_pmpaddr+4\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-02.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-02.S
@@ -196,7 +196,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_tor_check1_store_access_at_pmpaddr-4\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_tor_check1_store_access_at_pmpaddr\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_tor_check1_store_access_at_pmpaddr+4\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-03.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_cfg_tor_check-03.S
@@ -197,7 +197,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_tor_check3_store_access_at_pmpaddr-4\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_tor_check3_store_access_at_pmpaddr\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_tor_check3_store_access_at_pmpaddr+4\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_csr_walk.S
@@ -634,7 +634,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_1\""
 test_2_str:  .string "\"test: 2; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_2\""
 test_3_str:  .string "\"test: 3; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_3\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_grain.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_grain.S
@@ -369,7 +369,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: cp_pmp_grain\""
 test_2_str:  .string "\"test: 2;  cp: cp_pmp_grain\""
 test_3_str:  .string "\"test: 3;  cp: cp_pmp_grain\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_grain_check.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_grain_check.S
@@ -112,7 +112,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_pmp_grain_check_1\""
 test_2_str: .string "\"test: 1; cp: cp_pmp_grain_check_2\""
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_off.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_misaligned_off.S
@@ -197,7 +197,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: pmpm_misaligned_na4_sw_address-1\""
 test_2_str:  .string "\"test: 2;  cp: pmpm_misaligned_na4_sh_address-1\""
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_na4_legal_lwxr.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_na4_legal_lwxr.S
@@ -247,7 +247,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_aligned_sw_address\""
 test_2_str: .string "\"test: 2; cp: pmpm_aligned_lw_address\""
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_napot_legal_lwxr.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_napot_legal_lwxr.S
@@ -367,7 +367,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: pmpm_aligned_sb_address\""
 test_2_str:  .string "\"test: 2;  cp: pmpm_aligned_sh_address\""
 test_3_str:  .string "\"test: 3;  cp: pmpm_aligned_sw_address\""

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority.S
@@ -198,7 +198,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_priority_sw\""
 test_2_str: .string "\"test: 2; cp: pmpm_priority_lw\""
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority_off.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_priority_off.S
@@ -154,7 +154,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_priority_off_sw\""
 test_2_str: .string "\"test: 2; cp: pmpm_priority_off_lw\""
 

--- a/tests/priv/pmp/pmp32/PMPSm/pmpsm_tor_legal_lwxr.S
+++ b/tests/priv/pmp/pmp32/PMPSm/pmpsm_tor_legal_lwxr.S
@@ -338,7 +338,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: pmpm_aligned_sw_address\""
 test_2_str:  .string "\"test: 2;  cp: pmpm_aligned_sw_address-4\""
 test_3_str:  .string "\"test: 3;  cp: pmpm_aligned_sw_address+4\""

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_na4.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_na4.S
@@ -139,7 +139,6 @@ RVTEST_DATA_BEGIN
 
 .align 4
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_napot.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_napot.S
@@ -171,7 +171,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_off.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_off.S
@@ -145,7 +145,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_tor.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_aligned_tor.S
@@ -156,7 +156,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_na4.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_na4.S
@@ -136,7 +136,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_napot.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_napot.S
@@ -147,7 +147,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_tor.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_cret_tor.S
@@ -145,7 +145,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_legal_lwrx.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_legal_lwrx.S
@@ -253,7 +253,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_legal_lxwr_sw\""
 test_2_str: .string "\"test: 1; cp: pmpzca_legal_lxwr_lw\""
 test_3_str: .string "\"test: 1; cp: pmpzca_legal_lxwr_c.swsp\""

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_na4.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_na4.S
@@ -149,7 +149,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_napot.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_napot.S
@@ -177,7 +177,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_off.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_off.S
@@ -151,7 +151,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_tor.S
+++ b/tests/priv/pmp/pmp32/PMPZca/pmpzca_misaligned_tor.S
@@ -162,7 +162,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_misaligned_tor_start\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp32/PMPmisaligned/pmpsm_misaligned_na4.S
+++ b/tests/priv/pmp/pmp32/PMPmisaligned/pmpsm_misaligned_na4.S
@@ -195,7 +195,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: pmpm_misaligned_na4_sw_address-1\""
 test_2_str:  .string "\"test: 2;  cp: pmpm_misaligned_na4_sh_address-1\""
 test_3_str:  .string "\"test: 3;  cp: pmpm_misaligned_na4_sw_address+4-1\""

--- a/tests/priv/pmp/pmp32/PMPmisaligned/pmpsm_misaligned_napot.S
+++ b/tests/priv/pmp/pmp32/PMPmisaligned/pmpsm_misaligned_napot.S
@@ -210,7 +210,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: pmpm_misaligned_na4_sw_address-1\""
 test_2_str:  .string "\"test: 2;  cp: pmpm_misaligned_na4_sh_address-1\""
 

--- a/tests/priv/pmp/pmp32/PMPmisaligned/pmpsm_misaligned_tor.S
+++ b/tests/priv/pmp/pmp32/PMPmisaligned/pmpsm_misaligned_tor.S
@@ -198,7 +198,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: pmpm_misaligned_na4_sw_address-1\""
 test_2_str:  .string "\"test: 2;  cp: pmpm_misaligned_na4_sh_address-1\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_access_double_region.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_access_double_region.S
@@ -139,7 +139,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_tor_doubleregionfail_sd\""
 test_2_str: .string "\"test: 2; cp: cp_tor_doubleregionfail_ld\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_all_entries_check.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_all_entries_check.S
@@ -562,7 +562,6 @@ RVTEST_CODE_END
 RVTEST_DATA_BEGIN
 .align 4
 
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_pmpm64_lw\""
 test_2_str: .string "\"test: 2; cp: cp_pmpm64_sw\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_all.S
@@ -173,7 +173,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1; cp: cp_cfg_A_all_test_1\""
 test_2_str:  .string "\"test: 2; cp: cp_cfg_A_all_test_2\""
 test_3_str:  .string "\"test: 3; cp: cp_cfg_A_all_test_3\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_off_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_off_all.S
@@ -369,7 +369,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_cfg_A_off_all_lw\""
 test_2_str: .string "\"test: 2; cp: cp_cfg_A_off_all_sw\""
 test_3_str: .string "\"test: 3; cp: cp_cfg_A_off_all_x\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_bot.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_bot.S
@@ -212,7 +212,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_A_tor_bot_store_access_at_pmpaddr0-4\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_A_tor_bot_store_access_at_pmpaddr0+4\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_A_tor_bot_store_access_at_pmpaddr1-4\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_zero.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_A_tor_zero.S
@@ -180,7 +180,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_A_tor_zero_store_access_at_pmpaddr0\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_A_tor_zero_store_access_at_pmpaddr0-4\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_A_tor_zero_load_access_at_pmpaddr0\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_access_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_access_all.S
@@ -335,7 +335,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_cfg_L_access_all_lw and cp_none_lw\""
 test_2_str: .string "\"test: 2; cp: cp_cfg_L_access_all_sw and cp_none_sw\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_napot.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_napot.S
@@ -176,7 +176,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1; cp: cp_cfg_L_modify_test_1\""
 test_2_str:  .string "\"test: 2; cp: cp_cfg_L_modify_test_2\""
 test_3_str:  .string "\"test: 3; cp: cp_cfg_L_modify_test_3\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_off.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_off.S
@@ -178,7 +178,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1; cp: cp_cfg_L_modify_1\""
 test_2_str:  .string "\"test: 2; cp: cp_cfg_L_modify_2\""
 test_3_str:  .string "\"test: 3; cp: cp_cfg_L_modify_3\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_tor.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_L_modify_tor.S
@@ -176,7 +176,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1; cp: cp_cfg_L_modify\""
 test_2_str:  .string "\"test: 2; cp: cp_cfg_L_modify\""
 test_3_str:  .string "\"test: 3; cp: cp_cfg_L_modify\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-01.S
@@ -260,7 +260,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-02.S
@@ -252,7 +252,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-03.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-03.S
@@ -270,7 +270,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-04.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-04.S
@@ -244,7 +244,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-05.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-05.S
@@ -261,7 +261,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-06.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-06.S
@@ -253,7 +253,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-07.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-07.S
@@ -270,7 +270,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-08.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_XWR_all-08.S
@@ -244,7 +244,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_XWR_all_sb\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_XWR_all_sh\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_XWR_all_sw\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_na4_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_na4_all.S
@@ -286,7 +286,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_na4_all_lw_address\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_na4_all_address-4\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_na4_all_address+4\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_napot_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_napot_all.S
@@ -331,7 +331,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_napot_all_lw_address\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_napot_all_address-4\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_napot_all_address+4\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_all.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_all.S
@@ -268,7 +268,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_tor_all_lw\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-01.S
@@ -192,7 +192,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_tor_check1_store_access_at_pmpaddr-4\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_tor_check1_store_access_at_pmpaddr\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_tor_check1_store_access_at_pmpaddr+4\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-02.S
@@ -193,7 +193,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_tor_check2_store_access_at_pmpaddr-4\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_tor_check2_store_access_at_pmpaddr\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_tor_check2_store_access_at_pmpaddr+4\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-03.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_cfg_tor_check-03.S
@@ -194,7 +194,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_cfg_tor_check3_store_access_at_pmpaddr-4\""
 test_2_str: .string "\"test: 2; cp: pmpm_cfg_tor_check3_store_access_at_pmpaddr\""
 test_3_str: .string "\"test: 3; cp: pmpm_cfg_tor_check3_store_access_at_pmpaddr+4\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_csr_walk.S
@@ -1280,7 +1280,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_1\""
 test_2_str:  .string "\"test: 2; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_2\""
 test_3_str:  .string "\"test: 3; cp: cp_pmpcfg_walk_and_cp_pmpaddr_walk_test_3\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_grain.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_grain.S
@@ -371,7 +371,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: cp_pmp_grain\""
 test_2_str:  .string "\"test: 2;  cp: cp_pmp_grain\""
 test_3_str:  .string "\"test: 3;  cp: cp_pmp_grain\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_grain_check.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_grain_check.S
@@ -114,7 +114,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_pmp_grain_check_1\""
 test_2_str: .string "\"test: 1; cp: cp_pmp_grain_check_2\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_off.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_misaligned_off.S
@@ -225,7 +225,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: pmpm_misaligned_napot_sh_address-1\""
 test_2_str:  .string "\"test: 2;  cp: pmpm_misaligned_napot_lh_address-1\""
 test_3_str:  .string "\"test: 3;  cp: pmpm_misaligned_napot_lhu_address-1\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_boundary-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_boundary-01.S
@@ -125,7 +125,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_na4_boundary_ld\""
 test_2_str: .string "\"test: 2; cp: cp_na4_boundary_sd\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_boundary-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_boundary-02.S
@@ -126,7 +126,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_na4_boundary_ld\""
 test_2_str: .string "\"test: 2; cp: cp_na4_boundary_sd\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_legal_lwxr.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_na4_legal_lwxr.S
@@ -252,7 +252,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_cfg_A_na4_sw_address\""
 test_2_str: .string "\"test: 2; cp: cp_cfg_A_na4_lw_address\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-01.S
@@ -322,7 +322,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: cp_cfg_A_napot_sb_address\""
 test_2_str:  .string "\"test: 2;  cp: cp_cfg_A_napot_sh_address\""
 test_3_str:  .string "\"test: 3;  cp: cp_cfg_A_napot_sw_address\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_napot_legal_lxwr-02.S
@@ -322,7 +322,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: cp_cfg_A_napot_sb_address\""
 test_2_str:  .string "\"test: 2;  cp: cp_cfg_A_napot_sh_address\""
 test_3_str:  .string "\"test: 3;  cp: cp_cfg_A_napot_sw_address\""

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority.S
@@ -193,7 +193,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_priority_sw\""
 test_2_str: .string "\"test: 2; cp: pmpm_priority_lw\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority_off.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_priority_off.S
@@ -154,7 +154,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_priority_off_sw\""
 test_2_str: .string "\"test: 2; cp: pmpm_priority_off_lw\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_boundary-01.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_boundary-01.S
@@ -135,7 +135,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_tor_boundary_sd\""
 test_2_str: .string "\"test: 2; cp: cp_tor_boundary_ld\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_boundary-02.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_boundary-02.S
@@ -136,7 +136,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: cp_tor_boundary_sd\""
 test_2_str: .string "\"test: 2; cp: cp_tor_boundary_ld\""
 

--- a/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_legal_lxwr.S
+++ b/tests/priv/pmp/pmp64/PMPSm/pmpsm_tor_legal_lxwr.S
@@ -345,7 +345,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: cp_cfg_A_tor_sw_address\""
 test_2_str:  .string "\"test: 2;  cp: cp_cfg_A_tor_sw_address-4\""
 test_3_str:  .string "\"test: 3;  cp: cp_cfg_A_tor_sw_address+4\""

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_na4.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_na4.S
@@ -140,7 +140,6 @@ RVTEST_DATA_BEGIN
 
 .align 4
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_napot.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_napot.S
@@ -171,7 +171,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_napot_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_off.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_off.S
@@ -145,7 +145,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_off_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_tor.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_aligned_tor.S
@@ -156,7 +156,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_tor_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_na4.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_na4.S
@@ -135,7 +135,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_napot.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_napot.S
@@ -146,7 +146,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_tor.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_cret_tor.S
@@ -146,7 +146,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_cret_napot_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_legal_lwrx.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_legal_lwrx.S
@@ -284,7 +284,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_legal_lxwr_sw\""
 test_2_str: .string "\"test: 2; cp: pmpzca_legal_lxwr_lw\""
 test_3_str: .string "\"test: 3; cp: pmpzca_legal_lxwr_c.jalr\""

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_na4.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_na4.S
@@ -148,7 +148,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_aligned_na4_region_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_napot.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_napot.S
@@ -175,7 +175,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_misaligned_napot_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_off.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_off.S
@@ -150,7 +150,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_misaligned_off_execute\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_tor.S
+++ b/tests/priv/pmp/pmp64/PMPZca/pmpzca_misaligned_tor.S
@@ -162,7 +162,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpzca_misaligned_tor_start\""
 
 RVTEST_DATA_END

--- a/tests/priv/pmp/pmp64/PMPmisaligned/pmpsm_misaligned_na4.S
+++ b/tests/priv/pmp/pmp64/PMPmisaligned/pmpsm_misaligned_na4.S
@@ -213,7 +213,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: pmpm_misaligned_na4_sd_address-1\""
 test_2_str:  .string "\"test: 2;  cp: pmpm_misaligned_na4_ld_address-1\""
 test_3_str:  .string "\"test: 3;  cp: pmpm_misaligned_na4_sw_address-1\""

--- a/tests/priv/pmp/pmp64/PMPmisaligned/pmpsm_misaligned_na4_wrap.S
+++ b/tests/priv/pmp/pmp64/PMPmisaligned/pmpsm_misaligned_na4_wrap.S
@@ -139,7 +139,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_mislaigned_na4_wrap_sd\""
 test_2_str: .string "\"test: 1; cp: pmpm_mislaigned_na4_wrap_ld\""
 

--- a/tests/priv/pmp/pmp64/PMPmisaligned/pmpsm_misaligned_napot.S
+++ b/tests/priv/pmp/pmp64/PMPmisaligned/pmpsm_misaligned_napot.S
@@ -241,7 +241,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: pmpm_misaligned_napot_sh_address-1\""
 test_2_str:  .string "\"test: 2;  cp: pmpm_misaligned_napot_lh_address-1\""
 test_3_str:  .string "\"test: 3;  cp: pmpm_misaligned_napot_lhu_address-1\""

--- a/tests/priv/pmp/pmp64/PMPmisaligned/pmpsm_misaligned_tor.S
+++ b/tests/priv/pmp/pmp64/PMPmisaligned/pmpsm_misaligned_tor.S
@@ -228,7 +228,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str:  .string "\"test: 1;  cp: pmpm_misaligned_napot_sh_address-1\""
 test_2_str:  .string "\"test: 2;  cp: pmpm_misaligned_napot_lh_address-1\""
 test_3_str:  .string "\"test: 3;  cp: pmpm_misaligned_napot_lhu_address-1\""

--- a/tests/priv/pmp/pmp64/PMPmisaligned/pmpsm_misaligned_tor_wrap.S
+++ b/tests/priv/pmp/pmp64/PMPmisaligned/pmpsm_misaligned_tor_wrap.S
@@ -142,7 +142,6 @@ RVTEST_DATA_BEGIN
 .align 4
 
 // Test case strings for reporting
-canary_mismatch: .string "Testcase signature canary mismatch!"
 test_1_str: .string "\"test: 1; cp: pmpm_mislaigned_na4_wrap_sd\""
 test_2_str: .string "\"test: 1; cp: pmpm_mislaigned_na4_wrap_ld\""
 


### PR DESCRIPTION
Previously it was included at the end of every test.