### PR TITLE
Load failure code embedded pointers in parts on rv64

### DIFF
--- a/tests/env/failure_code.h
+++ b/tests/env/failure_code.h
@@ -278,7 +278,15 @@
         # The jal returns to DEFAULT_LINK_REG, which points to the data after jal  (i.e., the first pointer itself)
 
         # Save failing address (loaded from embedded instruction pointer after jal)
-        LREG x6, 0(DEFAULT_LINK_REG)      # load the instruction address from memory
+        # Only guaranteed to be 4-byte aligned, so need to load in 4-byte chunks on rv64
+    #if __riscv_xlen == 64
+        lwu x6, 0(DEFAULT_LINK_REG)      # load lower 32 bits of instruction address
+        lw  x7, 4(DEFAULT_LINK_REG)      # load upper 32 bits
+        slli x7, x7, 32
+        or x6, x6, x7                    # combine into 64-bit value
+    #else
+        lw x6, 0(DEFAULT_LINK_REG)       # RV32: 4-byte aligned, safe
+    #endif
         SREG x6, 264(DEFAULT_TEMP_REG)
 
         # Fetch the failing instruction using INSTR_PTR address
@@ -294,7 +302,15 @@
         sw x7, 256(DEFAULT_TEMP_REG)      # record failing instruction (16 or 32 bits)
 
         # Get pointer to failure string (loaded from second embedded pointer after jal)
-        LREG x6, REGWIDTH(DEFAULT_LINK_REG) # load the string pointer from memory
+        # Only guaranteed to be 4-byte aligned, so need to load in 4-byte chunks on rv64
+    #if __riscv_xlen == 64
+        lwu x6, 8(DEFAULT_LINK_REG)       # load lower 32 bits of string pointer
+        lw  x7, 12(DEFAULT_LINK_REG)      # load upper 32 bits
+        slli x7, x7, 32
+        or x6, x6, x7                     # combine into 64-bit value
+    #else
+        lw x6, REGWIDTH(DEFAULT_LINK_REG) # RV32: 4-byte aligned, safe
+    #endif
         SREG x6, 288(DEFAULT_TEMP_REG)    # save the string pointer
 
     failedtest_report:

--- a/tests/env/failure_code.h
+++ b/tests/env/failure_code.h
@@ -304,8 +304,8 @@
         # Get pointer to failure string (loaded from second embedded pointer after jal)
         # Only guaranteed to be 4-byte aligned, so need to load in 4-byte chunks on rv64
     #if __riscv_xlen == 64
-        lwu x6, 8(DEFAULT_LINK_REG)       # load lower 32 bits of string pointer
-        lw  x7, 12(DEFAULT_LINK_REG)      # load upper 32 bits
+        lwu x6, REGWIDTH(DEFAULT_LINK_REG)       # load lower 32 bits of string pointer
+        lw  x7, REGWIDTH+4(DEFAULT_LINK_REG)      # load upper 32 bits
         slli x7, x7, 32
         or x6, x6, x7                     # combine into 64-bit value
     #else


### PR DESCRIPTION
The embedded pointers are only guaranteed to be aligned to 4-bytes, so load them in 4-byte chunks to avoid misaligned accesses.

Fixes #1088