### PR TITLE
Cleanup CANARY in signature

### DIFF
--- a/tests/env/signature.h
+++ b/tests/env/signature.h
@@ -43,27 +43,6 @@
     .option pop
 #endif
 
-// RVTEST_SIGUPD_NOPS is the same length as RVTEST_SIGUPD but is filled with nops
-#if __riscv_xlen == 64
-  #define RVTEST_SIGUPD_NOPS \
-    nop ;\
-    nop ;\
-    nop ;\
-    nop ;\
-    nop ;\
-    nop ;\
-    nop ;\
-    nop
-#else
-  #define RVTEST_SIGUPD_NOPS \
-    nop ;\
-    nop ;\
-    nop ;\
-    nop ;\
-    nop ;\
-    nop
-#endif
-
 // TRAP_SIGUPD(tempreg, sigreg, offset, instptr, strptr)
 // Used to compare/write signatures while handling traps.
 // In Self Check mode, compare reference and DUT signatures and jump to

--- a/tests/env/test_setup.h
+++ b/tests/env/test_setup.h
@@ -76,8 +76,18 @@
       // DEFAULT_SIG_REG = x2, DEFAULT_TEMP_REG = x4, DEFAULT_LINK_REG = x5
       RVTEST_SIGUPD(x2, x5, x4, T1, canary_check, canary_mismatch) # sig_begin_canary
     #else
-      // nops to match selfchecking test length
-      RVTEST_SIGUPD_NOPS
+      // Increment sig pointer to skip the CANARY
+      addi DEFAULT_SIG_REG, DEFAULT_SIG_REG, SIG_STRIDE
+      // nops to ensure the number of instructions executed matches the self-checking test length
+      nop
+      nop
+      nop
+      nop
+      nop
+      #if __riscv_xlen == 64
+        nop
+        nop
+      #endif
     #endif
     // Initialize test data pointer
     LA(DEFAULT_DATA_REG, rvtest_data_begin)
@@ -271,12 +281,12 @@
           // Preload signature region with correct values for self-checking
           #include SIGNATURE_FILE
     #else
-      // Create canary at beginning of signature region to detect overwrites
-      sig_begin_canary:
-        CANARY
-
+      // Canary is the first entry in the signature region; the dynamic canary
+      // check at test start overwrites it with the same value to verify the signature
+      // works correctly.
       signature_base:
-        // Initialize signature region to known value for initial pass
+        CANARY
+        // Initialize remaining signature region to known value for initial pass
         .fill SIGUPD_COUNT*(SIG_STRIDE>>2),4,0xdeadbeef
 
       // Signature region for trap handlers

--- a/tests/env/test_setup.h
+++ b/tests/env/test_setup.h
@@ -74,11 +74,12 @@
     #ifdef RVTEST_SELFCHECK
       // Can't use DEFAULT_*_REG macros here because of macro expansion order
       // DEFAULT_SIG_REG = x2, DEFAULT_TEMP_REG = x4, DEFAULT_LINK_REG = x5
-      RVTEST_SIGUPD(x2, x5, x4, T1, canary_check, canary_mismatch) # sig_begin_canary
+      RVTEST_SIGUPD(x2, x5, x4, T1, canary_check, canary_mismatch) # signature_base canary
     #else
       // Increment sig pointer to skip the CANARY
       addi DEFAULT_SIG_REG, DEFAULT_SIG_REG, SIG_STRIDE
-      // nops to ensure the number of instructions executed matches the self-checking test length
+      // NOPs to keep the emitted code size/bytes aligned with the RVTEST_SIGUPD sequence
+      // used in self-check mode (including its embedded pointer words/dwords).
       nop
       nop
       nop
@@ -282,8 +283,8 @@
           #include SIGNATURE_FILE
     #else
       // Canary is the first entry in the signature region; the dynamic canary
-      // check at test start overwrites it with the same value to verify the signature
-      // works correctly.
+      // check at test start reads and verifies this value to ensure the signature
+      // mechanism is functioning correctly.
       signature_base:
         CANARY
         // Initialize remaining signature region to known value for initial pass


### PR DESCRIPTION
The CANARY confusingly appeared twice at the beginning of the signature region because of how Sail was dumping the signature. This cleans up the sig_begin logic to ensure the CANARY is only present once.

Fixes #1081