### PR TITLE
Report no summary line as a failure in run_tests

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -89,7 +89,7 @@ def run_test(command: str, log_dir: Path, elf_path: Path, verbose: bool) -> bool
     no_summary = len(summaries) == 0
 
     # Overall failure for test
-    failed = exit_failed or summary_failed or summary_sigrun
+    failed = exit_failed or summary_failed or summary_sigrun or no_summary
 
     # Print failure message for test
     if summary_sigrun:
@@ -119,6 +119,12 @@ def run_test(command: str, log_dir: Path, elf_path: Path, verbose: bool) -> bool
         print(
             f"  {red('FAIL')}  {bold(elf_path.name)} — RVCP-SUMMARY: TEST PASSED but exit code {result.returncode} indicates failure"
             f"\n         Likely bug in RVMODEL_HALT_PASS macro."
+            f"\n         Log: {dim(str(log_file))}"
+        )
+    elif no_summary and not exit_failed:
+        print(
+            f"  {red('FAIL')}  {bold(elf_path.name)} — exit code 0 but no RVCP-SUMMARY line found"
+            f"\n         Test may have been killed externally or hung without producing output."
             f"\n         Log: {dim(str(log_file))}"
         )
 


### PR DESCRIPTION
Killing the Imperas iss from another shell when it hung was being reported as a success before.
