### PR TITLE
feat: implement Zcmop unprivileged test suite

### DIFF
--- a/config/imperas/imperas-rv64-max/imperas.ic
+++ b/config/imperas/imperas-rv64-max/imperas.ic
@@ -67,7 +67,5 @@
 --override cpu*/PMP_undefined=T # access to unimplemented PMP registers cause illegal instruction exception
 
 # More extensions
---override cpu*/Zimop=T
---override cpu*/Zcmop=T
 #--override cpu*/Smdbltrp=T
 #--override cpu*/Ssdbltrp=T

--- a/config/imperas/imperas-rv64-max/imperas.ic
+++ b/config/imperas/imperas-rv64-max/imperas.ic
@@ -67,5 +67,7 @@
 --override cpu*/PMP_undefined=T # access to unimplemented PMP registers cause illegal instruction exception
 
 # More extensions
+--override cpu*/Zimop=T
+--override cpu*/Zcmop=T
 #--override cpu*/Smdbltrp=T
 #--override cpu*/Ssdbltrp=T

--- a/coverpoints/norm/Zcmop.yaml
+++ b/coverpoints/norm/Zcmop.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024 RISC-V International
+
+Zcmop_instruction_format:
+  description: >
+    Verify that all c.mop.n instructions correctly execute
+    as May-Be-Operations. They must not write to any register,
+    and must not raise an illegal-instruction exception.
+  coverpoints:
+    - cp_asm_count

--- a/coverpoints/norm/Zcmop.yaml
+++ b/coverpoints/norm/Zcmop.yaml
@@ -1,10 +1,7 @@
-# SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2024 RISC-V International
-
-Zcmop_instruction_format:
-  description: >
-    Verify that all c.mop.n instructions correctly execute
-    as May-Be-Operations. They must not write to any register,
-    and must not raise an illegal-instruction exception.
-  coverpoints:
-    - cp_asm_count
+# Mapping of normative rules to coverpoints for a test suite
+normative_rule_definitions:
+  - name: c_mop_op
+    # c.mop.n instructions are May-Be-Operations. Unless redefined by another
+    # extension, they do not write to any register and must not raise an
+    # illegal-instruction exception.
+    coverpoint: ["Zcmop_c_mop_cg/cp_asm_count"]

--- a/docs/ctp/src/unprivmisc23.adoc
+++ b/docs/ctp/src/unprivmisc23.adoc
@@ -40,5 +40,5 @@ Should write 0 to rd unless implemented.
 [[t-Zcmop-coverpoints]]
 .Zcmop Coverpoints
 //,===
-//include::{testplansdir}/Zcmop.adoc[]
+include::{testplansdir}/Zcmop.adoc[]
 //,===

--- a/framework/src/act/fcov/disassemble.svh
+++ b/framework/src/act/fcov/disassemble.svh
@@ -148,6 +148,15 @@ function string disassemble (logic [31:0] instrRaw);
     MOP_RR_5: $sformat(decoded, "mop.rr.5 %s, %s, %s", rd, rs1, rs2);
     MOP_RR_6: $sformat(decoded, "mop.rr.6 %s, %s, %s", rd, rs1, rs2);
     MOP_RR_7: $sformat(decoded, "mop.rr.7 %s, %s, %s", rd, rs1, rs2);
+    // Zcmop Extension
+    C_MOP_1:  $sformat(decoded, "c.mop.1");
+    C_MOP_3:  $sformat(decoded, "c.mop.3");
+    C_MOP_5:  $sformat(decoded, "c.mop.5");
+    C_MOP_7:  $sformat(decoded, "c.mop.7");
+    C_MOP_9:  $sformat(decoded, "c.mop.9");
+    C_MOP_11: $sformat(decoded, "c.mop.11");
+    C_MOP_13: $sformat(decoded, "c.mop.13");
+    C_MOP_15: $sformat(decoded, "c.mop.15");
     // Base Instructions
     ADD:     $sformat(decoded, "add %s, %s, %s", rd, rs1, rs2);
     SUB:     $sformat(decoded, "sub %s, %s, %s", rd, rs1, rs2);

--- a/testplans/Zcmop.csv
+++ b/testplans/Zcmop.csv
@@ -1,0 +1,9 @@
+Instruction,Type,RV32,RV64,cp_asm_count
+c.mop.1,CI,x,x,x
+c.mop.3,CI,x,x,x
+c.mop.5,CI,x,x,x
+c.mop.7,CI,x,x,x
+c.mop.9,CI,x,x,x
+c.mop.11,CI,x,x,x
+c.mop.13,CI,x,x,x
+c.mop.15,CI,x,x,x

--- a/testplans/Zcmop.csv
+++ b/testplans/Zcmop.csv
@@ -1,9 +1,9 @@
 Instruction,Type,RV32,RV64,cp_asm_count
-c.mop.1,CI,x,x,x
-c.mop.3,CI,x,x,x
-c.mop.5,CI,x,x,x
-c.mop.7,CI,x,x,x
-c.mop.9,CI,x,x,x
-c.mop.11,CI,x,x,x
-c.mop.13,CI,x,x,x
-c.mop.15,CI,x,x,x
+c.mop.1,CN,x,x,x
+c.mop.3,CN,x,x,x
+c.mop.5,CN,x,x,x
+c.mop.7,CN,x,x,x
+c.mop.9,CN,x,x,x
+c.mop.11,CN,x,x,x
+c.mop.13,CN,x,x,x
+c.mop.15,CN,x,x,x


### PR DESCRIPTION
implements the complete unprivileged test suite for the `Zcmop` (Compressed May-Be-Operations) extension, following the `act4` unprivileged test generation strategy.
As defined in the RISC-V Unprivileged Specification, the `c.mop.n` instructions are nullary and do not write to any register. Therefore, this suite strictly validates execution without fabricating operand or register-value coverpoints. 

##Implementation Details:
* **Testplan (`Zcmop.csv`):** Added all 8 compressed instructions (`c.mop.1` through `c.mop.15`) as `CI` type, tracking only `cp_asm_count`.
* **Coverpoints (`Zcmop.yaml`):** Implemented normative coverpoint specifically targeting `cp_asm_count` to verify execution without raising illegal-instruction exceptions.
* **Disassembler (`disassemble.svh`):** Injected the 8 decoding strings for the framework.
* **Documentation (`unprivmisc23.adoc`):** Uncommented the Zcmop testplan inclusion to generate the CTP tables.

*(While verifying the Imperas configs, I noticed that the `rv64-max` config was missing the flags for both `Zimop` and `Zcmop`. I have gone ahead and added both `--override cpu*/Zimop=T` and `--override cpu*/Zcmop=T` to `imperas-rv64-max/imperas.ic` in this PR to ensure the 64-bit simulator catches both MOP extensions.
