### PR TITLE
fix Sail hang on ExceptionsSm instr_access_fault

### DIFF
--- a/config/cores/cv32e40p/cv32e40p_v1.0.0_rv32imc/sail.json
+++ b/config/cores/cv32e40p/cv32e40p_v1.0.0_rv32imc/sail.json
@@ -65,11 +65,11 @@
       {
         "base": {
           "len": 64,
-          "value": "0x0"
+          "value": "0x00000080"
         },
         "size": {
           "len": 64,
-          "value": "0x80000000"
+          "value": "0x7FFFFF80"
         },
         "attributes": {
           "cacheable": true,

--- a/config/cores/cv32e40p/cv32e40p_v1.8.3_rv32imc/sail.json
+++ b/config/cores/cv32e40p/cv32e40p_v1.8.3_rv32imc/sail.json
@@ -65,11 +65,11 @@
       {
         "base": {
           "len": 64,
-          "value": "0x0"
+          "value": "0x00000080"
         },
         "size": {
           "len": 64,
-          "value": "0x80000000"
+          "value": "0x7FFFFF80"
         },
         "attributes": {
           "cacheable": true,

--- a/config/cores/cv32e40p/cv32e40p_v1.8.3_rv32imcf/sail.json
+++ b/config/cores/cv32e40p/cv32e40p_v1.8.3_rv32imcf/sail.json
@@ -65,11 +65,11 @@
       {
         "base": {
           "len": 64,
-          "value": "0x0"
+          "value": "0x00000080"
         },
         "size": {
           "len": 64,
-          "value": "0x80000000"
+          "value": "0x7FFFFF80"
         },
         "attributes": {
           "cacheable": true,

--- a/config/cores/cve2/cv32e20/sail.json
+++ b/config/cores/cve2/cv32e20/sail.json
@@ -91,11 +91,11 @@
       {
         "base": {
           "len": 64,
-          "value": "0x0"
+          "value": "0x4000"
         },
         "size": {
           "len": 64,
-          "value": "0x80000000"
+          "value": "0x7FFFC000"
         },
         "attributes": {
           "cacheable": true,


### PR DESCRIPTION
The instr_access_fault coverpoint jumps to address 0x0 to trigger an instruction access fault. With the memory region starting at 0x0, Sail fetched 0x0000 (c.illegal) instead of faulting, causing an infinite illegal-instruction trap loop.

Fix: start the memory region at 0x4000 to match link.ld, leaving 0x0-0x3FFF unmapped so Sail correctly raises an instruction access fault.