### PR TITLE
Add run commands for CVW

### DIFF
--- a/config/cores/cvw/cvw-rv32gc/run_cmd.txt
+++ b/config/cores/cvw/cvw-rv32gc/run_cmd.txt
@@ -1,0 +1,1 @@
+wsim rv32gc --elf

--- a/config/cores/cvw/cvw-rv32imc/run_cmd.txt
+++ b/config/cores/cvw/cvw-rv32imc/run_cmd.txt
@@ -1,0 +1,1 @@
+wsim rv32imc --elf

--- a/config/cores/cvw/cvw-rv64gc/run_cmd.txt
+++ b/config/cores/cvw/cvw-rv64gc/run_cmd.txt
@@ -1,0 +1,1 @@
+wsim rv64gc --elf


### PR DESCRIPTION
Enables `make cvw`, `make cvw-rv64gc`, etc. Requires CVW to be installed with `wsim` on your path.