### PR TITLE
Add verbose option to build process and run_tests script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,20 @@ WORKDIR     ?= work
 #  - ExceptionsZaamo: Configuration needed between access and misaligned faults
 #  - InterruptsSm,PMPSm,PMPZca,PMPmisaligned: Additional testing needed on a wider range of configs. Some missing config options to match ref model.
 EXTENSIONS  ?=
-EXCLUDE_EXTENSIONS ?= Sm,S,InterruptsSm,ExceptionsZalrsc,ExceptionsZaamo,PMPSm,PMPZca,PMPmisaligned,Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo
+EXCLUDE_EXTENSIONS ?= Sm,S,InterruptsSm,ExceptionsZalrsc,ExceptionsZaamo,PMPSm,PMPZca,PMPmisaligned,Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo
 
-# DEBUG and FAST are runtime options for controlling build output. They are mutually exclusive. Set to True to enable either option.
+# DEBUG, FAST, and VERBOSE are runtime options for controlling build output. DEBUG and FAST are mutually exclusive.
 # DEBUG enables debug output (signature objdump and trace files). This will slow down ELF generation significantly.
 # FAST disables objdump generation for faster builds. This speeds up ELF generation significantly, but makes debugging mismatches harder.
+# VERBOSE implies DEBUG, serializes all commands (JOBS=1), and prints each command as it is issued.
 DEBUG       ?=
 FAST        ?=
+VERBOSE     ?=
+
+# VERBOSE implies DEBUG
+ifneq ($(VERBOSE),)
+  DEBUG := True
+endif
 
 # COVERAGE_SIMULATOR is only used when collecting coverage (make coverage)
 COVERAGE_SIMULATOR ?= questa # Coverage simulator backend: questa or vcs
@@ -91,6 +98,7 @@ elfs: tests
 		$(if $(EXCLUDE_EXTENSIONS),--exclude $(EXCLUDE_EXTENSIONS)) \
 		$(if $(DEBUG),--debug) \
 		$(if $(FAST),--fast) \
+		$(if $(VERBOSE),--verbose) \
 		$(if $(COVERAGE),--coverage) \
 		$(if $(COVERAGE),--coverage-simulator $(COVERAGE_SIMULATOR))
 
@@ -148,13 +156,13 @@ coverage: elfs
 ########### Regression ###########
 # Clean, run coverage, then run all configs that have a run_cmd.txt, continuing through failures.
 .PHONY: regression
-regression: clean tests
+regression: clean
 	@exit_code=0; \
 	$(MAKE) coverage || exit_code=1; \
 	CONFIG_FILES="$(patsubst %/run_cmd.txt,%/test_config.yaml,$(RUN_CMD_FILES))" \
 	$(MAKE) elfs || exit_code=1; \
 	$(foreach f,$(RUN_CMD_FILES),\
-	  ./run_tests.py $(if $(DEBUG),--debug) "$$(cat $(f))" $(WORKDIR)/$(notdir $(patsubst %/run_cmd.txt,%,$(f)))/elfs || exit_code=1; ) \
+	  ./run_tests.py $(if $(DEBUG),--debug) $(if $(VERBOSE),--verbose) "$$(cat $(f))" $(WORKDIR)/$(notdir $(patsubst %/run_cmd.txt,%,$(f)))/elfs || exit_code=1; ) \
 	exit $$exit_code
 
 
@@ -191,7 +199,7 @@ $(1): tests
 	$$(MAKE) elfs
 	@exit_code=0; \
 	$(foreach f,$(_TARGETS_$(1)),\
-	  ./run_tests.py $(if $(DEBUG),--debug) "$$$$(cat $(f))" $$(WORKDIR)/$(notdir $(patsubst %/run_cmd.txt,%,$(f)))/elfs || exit_code=1; ) \
+	  ./run_tests.py $(if $(DEBUG),--debug) $(if $(VERBOSE),--verbose) "$$$$(cat $(f))" $$(WORKDIR)/$(notdir $(patsubst %/run_cmd.txt,%,$(f)))/elfs || exit_code=1; ) \
 	exit $$$$exit_code
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,10 @@ DEBUG       ?=
 FAST        ?=
 VERBOSE     ?=
 
-# VERBOSE implies DEBUG
+# VERBOSE implies DEBUG and serializes the build
 ifneq ($(VERBOSE),)
   DEBUG := True
+	JOBS  := 1
 endif
 
 # COVERAGE_SIMULATOR is only used when collecting coverage (make coverage)

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ The following variables can be set on the command line to customize the build (e
 | `EXCLUDE_EXTENSIONS` | _(see below)_                                   | Comma-separated list of extensions to exclude from test generation. Applied as a negative filter after `EXTENSIONS`.                               |
 | `DEBUG`              | _(empty)_                                       | Set to `True` to enable debug output (signature objdump and trace files). Significantly slows down ELF generation. Mutually exclusive with `FAST`. |
 | `FAST`               | _(empty)_                                       | Set to `True` to skip objdump generation for faster builds. Makes debugging mismatches harder. Mutually exclusive with `DEBUG`.                    |
+| `VERBOSE`            | _(empty)_                                       | Set to `True` to enable verbose output (prints all commands). Also implies debug mode and serializes all commands (JOBS=1).                        |
 | `JOBS`               | Auto-detected from `make -j` flag, or CPU count | Number of parallel build jobs for test compilation. Set to `1` for debugging test hangs.                                                           |
 
 By default, both `CONFIG_FILES` and `WORKDIR` are relative to the `riscv-arch-test` directory. Use an absolute path if you need to specify a directory that is out-of-tree.

--- a/framework/src/act/act.py
+++ b/framework/src/act/act.py
@@ -59,6 +59,9 @@ def run_act(
     coverage: Annotated[bool, typer.Option(help="Enable coverage generation")] = False,
     debug: Annotated[bool, typer.Option(help="Enable debug output (signature objdump and trace files)")] = False,
     fast: Annotated[bool, typer.Option(help="Disable objdump generation for faster builds")] = False,
+    verbose: Annotated[
+        bool, typer.Option(help="Implies --debug, serializes builds (jobs=1), and prints each command as it runs")
+    ] = False,
     keep_going: Annotated[bool, typer.Option("--keep-going", "-k", help="Continue building after failures")] = False,
     dry_run: Annotated[
         bool, typer.Option("--dry-run", "-n", help="Show what would be built without executing")
@@ -68,6 +71,10 @@ def run_act(
         typer.Option(help="Coverage simulator backend", case_sensitive=False),
     ] = CoverageSimulator.QUESTA,
 ) -> None:
+    if verbose:
+        debug = True
+        jobs = 1
+
     if debug and fast:
         raise typer.BadParameter("--debug and --fast cannot be used together")
 
@@ -121,7 +128,7 @@ def run_act(
     )
 
     # Run all tasks to compile ELFs
-    result = build(tasks, jobs=jobs, keep_going=keep_going, dry_run=dry_run)
+    result = build(tasks, jobs=jobs, keep_going=keep_going, dry_run=dry_run, verbose=verbose)
 
     # Print summary
     parts = []

--- a/framework/src/act/build.py
+++ b/framework/src/act/build.py
@@ -125,8 +125,10 @@ def is_stale(task: BuildTask) -> bool:
     return any(inp.exists() and inp.stat().st_mtime > oldest_output_mtime for inp in all_inputs)
 
 
-def execute_task(task: BuildTask) -> BuildError | None:
+def execute_task(task: BuildTask, *, verbose: bool = False) -> BuildError | None:
     """Execute a single build task. Returns None on success, BuildError on failure."""
+    if verbose:
+        print(f"  {_task_str(task)}")
     action = task.action
 
     if isinstance(action, SubprocessAction):
@@ -191,6 +193,7 @@ def build(
     jobs: int,
     keep_going: bool = False,
     dry_run: bool = False,
+    verbose: bool = False,
 ) -> BuildResult:
     """Execute a DAG of build tasks using TopologicalSorter + ThreadPoolExecutor.
 
@@ -199,6 +202,7 @@ def build(
         jobs: Number of parallel workers.
         keep_going: If True, continue building independent tasks after a failure.
         dry_run: If True, print what would be built without executing.
+        verbose: If True, print each command as it is issued.
 
     Returns:
         BuildResult with counts and any errors.
@@ -299,7 +303,7 @@ def build(
                     continue
 
                 # Submit task to thread pool
-                future = executor.submit(execute_task, task)
+                future = executor.submit(execute_task, task, verbose=verbose)
                 in_flight[key] = future
                 future_to_key[future] = key
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -159,11 +159,21 @@ def main() -> int:
     )
     parser.add_argument("elf_dir", type=Path, help="Path to ELF directory (e.g., work/spike-rv64/elfs)")
     parser.add_argument("-j", "--jobs", type=int, default=os.cpu_count(), help="Number of parallel jobs")
-    parser.add_argument("-v", "--verbose", action="store_true", help="Print the full command for every test")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print the full command for every ELF, implies --debug, serializes to 1 job",
+    )
     parser.add_argument(
         "-d", "--debug", action="store_true", help="Enable debug mode: expand {debug:...} placeholders in the command"
     )
     args = parser.parse_args()
+
+    # Verbose implies debug and serialized execution
+    if args.verbose:
+        args.debug = True
+        args.jobs = 1
 
     # Expand {debug:...} placeholders based on --debug flag
     command = _expand_debug_placeholders(args.command, debug=args.debug)
@@ -180,7 +190,7 @@ def main() -> int:
     # Print banner for this config
     banner = f"══════ {config_name} ══════"
     print(f"\n{bold_cyan(banner)}")
-    print(f"  {bold('Running ELFs from')}:    {elf_dir}")
+    print(f"  {bold('Running ELFs from')}: {elf_dir}")
     print(f"  {bold('Using command')}: {command} <elf_path>")
     print(f"  {bold('Summary available at')}: {summary_log}")
 


### PR DESCRIPTION
Adds a new `VERBOSE` flag in the Makefile to print all commands. Also implies debug mode and serializes all commands (JOBS=1).

Closes #1201