### PR TITLE
Improve fflags checking

### DIFF
--- a/generators/testgen/src/testgen/asm/helpers.py
+++ b/generators/testgen/src/testgen/asm/helpers.py
@@ -78,7 +78,9 @@ def load_float_reg(
     return f"{INDENT}RVTEST_TESTDATA_LOAD_FLOAT_{fp_load_type.upper()}(x{test_data.int_regs.data_reg}, f{reg}) # load {name}: f{reg} = {to_hex(val & ((1 << fp_load_bits) - 1), fp_load_bits)}"
 
 
-def write_sigupd(check_reg: int, test_data: TestData, sig_type: Literal["int", "float"] = "int") -> str:
+def write_sigupd(
+    check_reg: int | None, test_data: TestData, sig_type: Literal["int", "fflags", "float"] = "int"
+) -> str:
     """
     Generate assembly for SIGUPD and increment sigupd_count.
     """
@@ -87,14 +89,26 @@ def write_sigupd(check_reg: int, test_data: TestData, sig_type: Literal["int", "
     link_reg = test_data.int_regs.link_reg
     temp_reg = test_data.int_regs.temp_reg
     fp_temp_reg = test_data.float_regs.temp_reg
+    label = test_data.current_testcase_label
     if sig_type == "int":
+        if check_reg is None:
+            raise ValueError("check_reg must be provided for int sig_type")
         test_data.test_chunk.sigupd_count += 1
         return (
             f"{INDENT}# Check if x{check_reg} contains the expected result. x{sig_reg} is the signature ptr, "
             f"x{link_reg} is the link ptr, x{temp_reg} is a temp reg.\n"
-            f"{INDENT}RVTEST_SIGUPD(x{sig_reg}, x{link_reg}, x{temp_reg}, x{check_reg}, {test_data.current_testcase_label}, {test_data.current_testcase_label}_str)"
+            f"{INDENT}RVTEST_SIGUPD(x{sig_reg}, x{link_reg}, x{temp_reg}, x{check_reg}, {label}, {label}_str)"
+        )
+    elif sig_type == "fflags":
+        test_data.test_chunk.sigupd_count += 1
+        return (
+            f"{INDENT}# Check fflags. x{sig_reg} is the signature ptr, "
+            f"x{link_reg} is the link ptr, x{temp_reg} is a temp reg.\n"
+            f"{INDENT}RVTEST_SIGUPD_FFLAGS(x{sig_reg}, x{link_reg}, x{temp_reg}, {label}, {label}_str)"
         )
     elif sig_type == "float":
+        if check_reg is None:
+            raise ValueError("check_reg must be provided for float sig_type")
         if test_data.flen > test_data.xlen:
             test_data.test_chunk.sigupd_count += 3
         else:
@@ -103,7 +117,7 @@ def write_sigupd(check_reg: int, test_data: TestData, sig_type: Literal["int", "
             f"{INDENT}# Check if f{check_reg} contains the expected result. Also checks fflags. "
             f"x{sig_reg} is the signature ptr, x{link_reg} is the link ptr, x{temp_reg} "
             f"is a temp reg, f{fp_temp_reg} is a floating point temp reg.\n"
-            f"{INDENT}RVTEST_SIGUPD_F(x{sig_reg}, x{link_reg}, x{temp_reg}, f{fp_temp_reg}, f{check_reg}, {test_data.current_testcase_label}, {test_data.current_testcase_label}_str)"
+            f"{INDENT}RVTEST_SIGUPD_F(x{sig_reg}, x{link_reg}, x{temp_reg}, f{fp_temp_reg}, f{check_reg}, {label}, {label}_str)"
         )
     else:
         raise ValueError(f"Unknown sig_type: {sig_type}")

--- a/generators/testgen/src/testgen/formatters/types/cfl_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cfl_type.py
@@ -47,6 +47,7 @@ def format_cfl_type(
     test_data.test_chunk.data_values.append(params.temp_val)
 
     setup = [
+        "fsflagsi 0b00000 # clear all fflags",
         f"addi x{params.rs1}, x{test_data.int_regs.data_reg}, {-params.immval} # adjust base address for load",
     ]
     test = [

--- a/generators/testgen/src/testgen/formatters/types/cfls_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cfls_type.py
@@ -45,7 +45,7 @@ def format_cfls_type(
     assert test_data.test_chunk is not None
     test_data.test_chunk.data_values.append(params.temp_val)
 
-    setup: list[str] = []
+    setup: list[str] = ["fsflagsi 0b00000 # clear all fflags"]
     # sp (x2) is used as the base pointer for CFLS instructions
     # Ensure sp is allocated
     asm = test_data.int_regs.consume_registers([2])

--- a/generators/testgen/src/testgen/formatters/types/cfs_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cfs_type.py
@@ -49,6 +49,7 @@ def format_cfs_type(
     # Move sig_reg to rs1
     setup = [
         load_float_reg("fs2", params.fs2, params.fs2val, test_data),
+        "fsflagsi 0b00000 # clear all fflags",
     ]
     if params.rs1 != test_data.int_regs.sig_reg:
         setup.append(
@@ -78,4 +79,5 @@ def format_cfs_type(
     ]
     assert test_data.test_chunk is not None
     test_data.test_chunk.sigupd_count += 1
+    check.append(write_sigupd(None, test_data, "fflags"))
     return (setup, test, check)

--- a/generators/testgen/src/testgen/formatters/types/cfss_type.py
+++ b/generators/testgen/src/testgen/formatters/types/cfss_type.py
@@ -46,7 +46,7 @@ def format_cfss_type(
     # Wrap into valid range
     params.immval = params.immval % (max_val + alignment)
 
-    setup: list[str] = []
+    setup: list[str] = ["fsflagsi 0b00000 # clear all fflags"]
     asm = test_data.int_regs.consume_registers([2])  # sp (x2) is used as the base pointer for CSS instructions
     if asm:
         setup.append(asm)

--- a/generators/testgen/src/testgen/formatters/types/f2x_type.py
+++ b/generators/testgen/src/testgen/formatters/types/f2x_type.py
@@ -34,5 +34,8 @@ def format_f2x_type(
     test = [
         f"{instr_name} x{params.rd}, f{params.fs1}{frm} # perform operation",
     ]
-    check = [write_sigupd(params.rd, test_data)]
+    check = [
+        write_sigupd(params.rd, test_data, "int"),
+        write_sigupd(None, test_data, "fflags"),
+    ]
     return (setup, test, check)

--- a/generators/testgen/src/testgen/formatters/types/fc_type.py
+++ b/generators/testgen/src/testgen/formatters/types/fc_type.py
@@ -29,5 +29,8 @@ def format_fc_type(
     test = [
         f"{instr_name} x{params.rd}, f{params.fs1}, f{params.fs2} # perform operation",
     ]
-    check = [write_sigupd(params.rd, test_data)]
+    check = [
+        write_sigupd(params.rd, test_data, "int"),
+        write_sigupd(None, test_data, "fflags"),
+    ]
     return (setup, test, check)

--- a/generators/testgen/src/testgen/formatters/types/fix_type.py
+++ b/generators/testgen/src/testgen/formatters/types/fix_type.py
@@ -27,5 +27,8 @@ def format_fix_type(
     test = [
         f"{instr_name} x{params.rd}, f{params.fs1} # perform operation",
     ]
-    check = [write_sigupd(params.rd, test_data)]
+    check = [
+        write_sigupd(params.rd, test_data, "int"),
+        write_sigupd(None, test_data, "fflags"),
+    ]
     return (setup, test, check)

--- a/generators/testgen/src/testgen/formatters/types/fl_type.py
+++ b/generators/testgen/src/testgen/formatters/types/fl_type.py
@@ -35,7 +35,7 @@ def format_fl_type(
         test_data.int_regs.return_register(params.rs1)
         params.rs1 = test_data.int_regs.get_register(exclude_regs=[0])
 
-    setup: list[str] = []
+    setup: list[str] = ["fsflagsi 0b00000 # clear all fflags"]
 
     # Handle special case where offset is -2048 (can't represent +2048 in 12 bits)
     if params.immval == -2048:

--- a/generators/testgen/src/testgen/formatters/types/fs_type.py
+++ b/generators/testgen/src/testgen/formatters/types/fs_type.py
@@ -36,6 +36,7 @@ def format_fs_type(
     # load test value
     setup = [
         load_float_reg("fs2", params.fs2, params.fs2val, test_data, params.fp_load_type),
+        "fsflagsi 0b00000 # clear all fflags",
     ]
 
     # Move sig_reg to rs1
@@ -76,4 +77,5 @@ def format_fs_type(
     ]
     assert test_data.test_chunk is not None
     test_data.test_chunk.sigupd_count += 1
+    check.append(write_sigupd(None, test_data, "fflags"))
     return (setup, test, check)

--- a/tests/env/signature.h
+++ b/tests/env/signature.h
@@ -69,15 +69,52 @@
     2:                                                          ;
 #endif
 
+// RVTEST_SIGUPD_FFLAGS(sigptr, linkreg, tempreg, instptr, strptr)
+// Reads fcsr and compares/stores it to the signature at 0(sigptr).
+// In SELFCHECK mode, compares the value in fcsr with the value in memory
+// at 0(sigptr) and jumps to a failure handler if different.
+// In non-SELFCHECK mode, stores fcsr to memory at 0(sigptr).
+// In both cases, increments sigptr by SIG_STRIDE.
+//  _SIG_PTR - Base register for signature region
+//  _LINK_REG - Link register to use for failure jump
+//  _TEMP_REG - Temporary register to use for loading signature
+//  _INST_PTR - label on instruction being tested (for PC reporting)
+//  _STR_PTR - label to string describing the test
+#ifdef RVTEST_SELFCHECK
+  #define RVTEST_SIGUPD_FFLAGS(_SIG_PTR, _LINK_REG, _TEMP_REG, _INST_PTR, _STR_PTR)  \
+    .option push                                           ;\
+    .option norvc                                          ;\
+    csrr _LINK_REG, fcsr                                   ;\
+    LREG _TEMP_REG, 0(_SIG_PTR)                            ;\
+    beq _TEMP_REG, _LINK_REG, 1f                           ;\
+    jal _LINK_REG, failedtest_fflags_##_LINK_REG##_##_TEMP_REG ;\
+    RVTEST_WORD_PTR _INST_PTR                              ;\
+    RVTEST_WORD_PTR _STR_PTR                               ;\
+    1:                                                     ;\
+    addi _SIG_PTR, _SIG_PTR, SIG_STRIDE                    ;\
+    .option pop
+#else
+  #define RVTEST_SIGUPD_FFLAGS(_SIG_PTR, _LINK_REG, _TEMP_REG, _INST_PTR, _STR_PTR)  \
+    .option push                                           ;\
+    .option norvc                                          ;\
+    csrr _LINK_REG, fcsr                                   ;\
+    SREG _LINK_REG, 0(_SIG_PTR)                            ;\
+    beq x0, x0, 1f                                         ;\
+    jal _LINK_REG, failedtest_fflags_##_LINK_REG##_##_TEMP_REG ;\
+    RVTEST_WORD_PTR _INST_PTR                              ;\
+    RVTEST_WORD_PTR _STR_PTR                               ;\
+    1:                                                     ;\
+    addi _SIG_PTR, _SIG_PTR, SIG_STRIDE                    ;\
+    .option pop
+#endif
+
 // RVTEST_SIGUPD_F(sigptr, linkreg, tempreg, ftempreg, sigreg, instptr, strptr)
-// compares the value in sigreg with the value in memory at 0(sigptr) and the
-// value in FCSR with the value in memory at SIG_STRIDE(sigptr). If either are
-// different, it jumps to a failure handler whose label is formed from linkreg
-// and tempreg. On success, it increments sigptr by 2*SIG_STRIDE. In non-SELFCHECK
-// mode, it simply stores sigreg to memory at 0(sigptr), FCSR at SIG_STRIDE(sigptr),
-// and increments sigptr by 2*SIG_STRIDE. instptr and strptr are included as
-// .word/.dword directives so the instruction address and a pointer to the
-// string can be retrieved from the failure handler.
+// Checks both a floating point result register and fflags against the signature.
+// Compares the float value in sigreg with the value in memory at 0(sigptr),
+// then uses RVTEST_SIGUPD_FFLAGS to check fflags. When FLEN > XLEN, the float
+// value requires 2 signature entries (low and high words), plus 1 for fflags
+// (total 3*SIG_STRIDE). When FLEN == XLEN, uses 1 entry for the float value
+// plus 1 for fflags (total 2*SIG_STRIDE).
 //  _SIG_PTR - Base register for signature region
 //  _LINK_REG - Link register to use for failure jump
 //  _TEMP_REG - Temporary register to use for loading signature
@@ -114,15 +151,9 @@
       RVTEST_WORD_PTR _INST_PTR                              ;\
       RVTEST_WORD_PTR _STR_PTR                               ;\
       2:                                                     ;\
-      csrr _LINK_REG, fcsr                                   ;\
-      LREG _TEMP_REG, 2*SIG_STRIDE(_SIG_PTR)                 ;\
-      beq _TEMP_REG, _LINK_REG, 3f                           ;\
-      jal _LINK_REG, failedtest_fflags_##_LINK_REG##_##_TEMP_REG ;\
-      RVTEST_WORD_PTR _INST_PTR                              ;\
-      RVTEST_WORD_PTR _STR_PTR                               ;\
-      3:                                                     ;\
-      addi _SIG_PTR, _SIG_PTR, 3*SIG_STRIDE                  ;\
-      .option pop
+      addi _SIG_PTR, _SIG_PTR, 2*SIG_STRIDE                  ;\
+      .option pop                                            ;\
+      RVTEST_SIGUPD_FFLAGS(_SIG_PTR, _LINK_REG, _TEMP_REG, _INST_PTR, _STR_PTR)
   #else
     #define RVTEST_SIGUPD_F(_SIG_PTR, _LINK_REG, _TEMP_REG, _F_TEMP_REG, _FR, _INST_PTR, _STR_PTR)  \
       .option push                                           ;\
@@ -145,15 +176,9 @@
       RVTEST_WORD_PTR _INST_PTR                              ;\
       RVTEST_WORD_PTR _STR_PTR                               ;\
       2:                                                     ;\
-      csrr _LINK_REG, fcsr                                   ;\
-      SREG _LINK_REG, 2*SIG_STRIDE(_SIG_PTR)                 ;\
-      beq x0, x0, 3f                                         ;\
-      jal _LINK_REG, failedtest_fflags_##_LINK_REG##_##_TEMP_REG ;\
-      RVTEST_WORD_PTR _INST_PTR                              ;\
-      RVTEST_WORD_PTR _STR_PTR                               ;\
-      3:                                                     ;\
-      addi _SIG_PTR, _SIG_PTR, 3*SIG_STRIDE                  ;\
-      .option pop
+      addi _SIG_PTR, _SIG_PTR, 2*SIG_STRIDE                  ;\
+      .option pop                                            ;\
+      RVTEST_SIGUPD_FFLAGS(_SIG_PTR, _LINK_REG, _TEMP_REG, _INST_PTR, _STR_PTR)
   #endif
 #else
   #ifdef RVTEST_SELFCHECK
@@ -169,15 +194,9 @@
       RVTEST_WORD_PTR _INST_PTR                              ;\
       RVTEST_WORD_PTR _STR_PTR                               ;\
       1:                                                     ;\
-      csrr _LINK_REG, fcsr                                   ;\
-      LREG _TEMP_REG, SIG_STRIDE(_SIG_PTR)                   ;\
-      beq _TEMP_REG, _LINK_REG, 3f                           ;\
-      jal _LINK_REG, failedtest_fflags_##_LINK_REG##_##_TEMP_REG ;\
-      RVTEST_WORD_PTR _INST_PTR                              ;\
-      RVTEST_WORD_PTR _STR_PTR                               ;\
-      3:                                                     ;\
-      addi _SIG_PTR, _SIG_PTR, 2*SIG_STRIDE                  ;\
-      .option pop
+      addi _SIG_PTR, _SIG_PTR, SIG_STRIDE                    ;\
+      .option pop                                            ;\
+      RVTEST_SIGUPD_FFLAGS(_SIG_PTR, _LINK_REG, _TEMP_REG, _INST_PTR, _STR_PTR)
   #else
     #define RVTEST_SIGUPD_F(_SIG_PTR, _LINK_REG, _TEMP_REG, _F_TEMP_REG, _FR, _INST_PTR, _STR_PTR)  \
       .option push                                           ;\
@@ -191,15 +210,9 @@
       RVTEST_WORD_PTR _INST_PTR                              ;\
       RVTEST_WORD_PTR _STR_PTR                               ;\
       1:                                                     ;\
-      csrr _LINK_REG, fcsr                                   ;\
-      SREG _LINK_REG, SIG_STRIDE(_SIG_PTR)                   ;\
-      beq x0, x0, 3f                                         ;\
-      jal _LINK_REG, failedtest_fflags_##_LINK_REG##_##_TEMP_REG ;\
-      RVTEST_WORD_PTR _INST_PTR                              ;\
-      RVTEST_WORD_PTR _STR_PTR                               ;\
-      3:                                                     ;\
-      addi _SIG_PTR, _SIG_PTR, 2*SIG_STRIDE                  ;\
-      .option pop
+      addi _SIG_PTR, _SIG_PTR, SIG_STRIDE                    ;\
+      .option pop                                            ;\
+      RVTEST_SIGUPD_FFLAGS(_SIG_PTR, _LINK_REG, _TEMP_REG, _INST_PTR, _STR_PTR)
   #endif
 #endif
 

--- a/tests/env/signature.h
+++ b/tests/env/signature.h
@@ -70,10 +70,10 @@
 #endif
 
 // RVTEST_SIGUPD_FFLAGS(sigptr, linkreg, tempreg, instptr, strptr)
-// Reads fcsr and compares/stores it to the signature at 0(sigptr).
-// In SELFCHECK mode, compares the value in fcsr with the value in memory
+// Reads fflags and compares/stores it to the signature at 0(sigptr).
+// In SELFCHECK mode, compares the value in fflags with the value in memory
 // at 0(sigptr) and jumps to a failure handler if different.
-// In non-SELFCHECK mode, stores fcsr to memory at 0(sigptr).
+// In non-SELFCHECK mode, stores fflags to memory at 0(sigptr).
 // In both cases, increments sigptr by SIG_STRIDE.
 //  _SIG_PTR - Base register for signature region
 //  _LINK_REG - Link register to use for failure jump
@@ -84,7 +84,7 @@
   #define RVTEST_SIGUPD_FFLAGS(_SIG_PTR, _LINK_REG, _TEMP_REG, _INST_PTR, _STR_PTR)  \
     .option push                                           ;\
     .option norvc                                          ;\
-    csrr _LINK_REG, fcsr                                   ;\
+    csrr _LINK_REG, fflags                                 ;\
     LREG _TEMP_REG, 0(_SIG_PTR)                            ;\
     beq _TEMP_REG, _LINK_REG, 1f                           ;\
     jal _LINK_REG, failedtest_fflags_##_LINK_REG##_##_TEMP_REG ;\
@@ -97,7 +97,7 @@
   #define RVTEST_SIGUPD_FFLAGS(_SIG_PTR, _LINK_REG, _TEMP_REG, _INST_PTR, _STR_PTR)  \
     .option push                                           ;\
     .option norvc                                          ;\
-    csrr _LINK_REG, fcsr                                   ;\
+    csrr _LINK_REG, fflags                                 ;\
     SREG _LINK_REG, 0(_SIG_PTR)                            ;\
     beq x0, x0, 1f                                         ;\
     jal _LINK_REG, failedtest_fflags_##_LINK_REG##_##_TEMP_REG ;\


### PR DESCRIPTION
Floating point instructions that wrote to integer registers were not checking `fflags`.