### PR TITLE
fix: derive FLEN from DUT extensions, not test march

### DIFF
--- a/framework/src/act/act.py
+++ b/framework/src/act/act.py
@@ -21,7 +21,7 @@ from act.build_plan import generate_build_plan
 from act.config import CoverageSimulator, load_config
 from act.coverreport import print_coverage_summary
 from act.parse_test_constraints import generate_test_dict
-from act.parse_udb_config import generate_udb_files, get_config_params, get_implemented_extensions
+from act.parse_udb_config import compute_flen, generate_udb_files, get_config_params, get_implemented_extensions
 from act.select_tests import select_tests
 
 # CLI interface setup
@@ -120,6 +120,7 @@ def run_act(
             generate_build_plan(
                 config,
                 mxlen,
+                compute_flen(implemented_extensions, mxlen),
                 selected_tests,
                 test_dir,
                 coverpoint_dir,

--- a/framework/src/act/build_plan.py
+++ b/framework/src/act/build_plan.py
@@ -57,6 +57,7 @@ def gen_compile_tasks(
     test_metadata: TestMetadata,
     base_dir: Path,
     xlen: int,
+    dut_flen: int,
     config: Config,
     compiler_cmd: list[str],
     debug: bool = False,
@@ -93,9 +94,12 @@ def gen_compile_tasks(
 
     # Metadata — substitute ${XLEN} placeholder used by priv tests
     march = test_metadata.march.replace("${XLEN}", str(xlen))
-    flen = test_metadata.flen
     test_path = test_metadata.test_path
     mabi = f"{'i' if xlen == 32 else ''}lp{xlen}{'e' if test_metadata.e_ext else ''}"
+
+    # Cap FLEN to what the test march actually supports — prevents emitting D/Q instructions
+    # in tests whose march string only covers F, even when the DUT supports wider FP.
+    flen = min(dut_flen, test_metadata.flen)
 
     # 1. sig.elf – compile with -DSIGNATURE
     sig_elf_cmd = [
@@ -387,6 +391,7 @@ def gen_coverage_tasks(
 def generate_build_plan(
     config: Config,
     xlen: int,
+    dut_flen: int,
     selected_tests: dict[str, TestMetadata],
     tests_dir: Path,
     coverpoint_dir: Path,
@@ -416,6 +421,7 @@ def generate_build_plan(
                 test_metadata,
                 config_wkdir,
                 xlen,
+                dut_flen,
                 config,
                 compiler_cmd,
                 debug,

--- a/framework/src/act/parse_test_constraints.py
+++ b/framework/src/act/parse_test_constraints.py
@@ -34,20 +34,20 @@ class TestMetadata(BaseModel):
         return value if isinstance(value, int) else None
 
     @property
-    def flen(self) -> str:
+    def flen(self) -> int:
         """Get floating-point register length from the march string.
 
-        FLEN is determined by the widest FP extension in the march: Q=128, D=64, F=32.
+        FLEN is the widest FP extension in the march: Q=128, D=64, F=32.
         Single-letter extensions (including G=IMAFD) appear before the first underscore.
         """
         base = self.march.split("_")[0].lower()
         if "q" in base:
-            return "128"
+            return 128
         if "d" in base or "g" in base:
-            return "64"
+            return 64
         if "f" in base:
-            return "32"
-        return "32"
+            return 32
+        return 32
 
     @property
     def e_ext(self) -> bool:

--- a/framework/src/act/parse_udb_config.py
+++ b/framework/src/act/parse_udb_config.py
@@ -83,6 +83,21 @@ def get_implemented_extensions(extension_list_file: Path) -> set[str]:
     return set(extension_list_file.read_text().splitlines())
 
 
+def compute_flen(implemented_extensions: set[str], xlen: int) -> int:
+    """Compute FLEN from DUT's implemented extensions.
+
+    FLEN is determined by the widest FP extension: Q=128, D=64, F=32.
+    Q (FLEN=128) is not supported on RV32, so it is skipped when xlen==32.
+    """
+    if "Q" in implemented_extensions and xlen != 32:
+        return 128
+    if "D" in implemented_extensions:
+        return 64
+    if "F" in implemented_extensions:
+        return 32
+    return 32
+
+
 def generate_udb_files(udb_config_file: Path, output_dir: Path) -> None:
     if (
         not (output_dir / "extensions.txt").exists()


### PR DESCRIPTION
FLEN was computed solely from the test's march string, which can diverge from the DUT in both directions:

- Test march wider than DUT (e.g. ZicsrF march includes D for optional coverpoints, but DUT only has F): `fsd` emitted on an F-only DUT, Sail hangs.
- DUT wider than test march (e.g. D-capable DUT compiling an F-only test with `rv32imaf` march): `fsd` emitted in a march context that doesn't include D, assembler error.

Fix: compute FLEN as `min(dut_flen, test_march_flen)`.

- `compute_flen(implemented_extensions, xlen)` derives FLEN from the DUT's extensions (Q skipped on RV32 since toolchains don't support FLEN=128 with XLEN=32).
- `gen_compile_tasks` caps it to the test's march FLEN, preventing wider FP instructions than the test arch allows.

Fixes: #1223