### PR TITLE
Add GitHub Actions workflow for autofixing tests and coverpoints

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,28 @@
+# jcarlin@hmc.edu
+# SPDX-License-Identifier: Apache-2.0
+
+name: autofix.ci
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    name: Update generated tests and coverpoints
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+
+      - name: Regenerate tests and coverpoints
+        run: make clean-tests tests
+
+      - name: Apply fixes
+        uses: autofix-ci/action@7a166d7532b277f34e16238930461bf77f9d7ed8


### PR DESCRIPTION
PRs that change the test or coverpoint generators will automatically have the PR updated to contain the changes to the generated files. It is easy to forget to commit the generated files, so this workflow helps ensure they are always up to date.