### PR TITLE
Fix InterruptsU mstatus.MIE bit (0x80 -> 0x8)

### DIFF
--- a/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
@@ -52,9 +52,9 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
 
             lines.extend(
                 [
-                    f"LI(x{r_scratch}, 0x80)",
+                    f"LI(x{r_scratch}, 0x8)",   # mstatus.MIE bit mask (bit 3)
                     f"{'CSRS' if mstatus_mie else 'CSRC'}(mstatus, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x80)",
+                    f"LI(x{r_scratch}, 0x80)",  # mie.MTIE bit mask (bit 7)
                     f"CSRW(mie, x{r_scratch})",
                     "RVTEST_GOTO_LOWER_MODE Umode",
                     test_data.add_testcase(binname, coverpoint, covergroup),
@@ -118,7 +118,7 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
 
             lines.extend(
                 [
-                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
+                    f"LI(x{r_scratch}, 0x8)",   # mstatus.MIE bit mask (bit 3)
                     f"{'CSRS' if mstatus_mie else 'CSRC'}(mstatus, x{r_scratch})",
                     f"LI(x{r_scratch}, 0x08)",  # Enable MSIE
                     f"CSRW(mie, x{r_scratch})",
@@ -184,7 +184,7 @@ def _generate_user_mei_tests(test_data: TestData) -> list[str]:
 
             lines.extend(
                 [
-                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
+                    f"LI(x{r_scratch}, 0x8)",   # mstatus.MIE bit mask (bit 3)
                     f"{'CSRS' if mstatus_mie else 'CSRC'}(mstatus, x{r_scratch})",
                     f"LI(x{r_scratch}, 0x800)",  # Enable MEIE
                     f"CSRW(mie, x{r_scratch})",
@@ -235,7 +235,7 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
             # Set MIE if needed
             lines.extend(
                 [
-                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
+                    f"LI(x{r_scratch}, 0x8)",   # mstatus.MIE bit mask (bit 3)
                     f"{'CSRS' if mie_val else 'CSRC'}(mstatus, x{r_scratch})",
                 ]
             )
@@ -300,7 +300,7 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
                     "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
                     f"LI(x{r_scratch}, 0x80)",
                     f"CSRC(mie, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
+                    f"LI(x{r_scratch}, 0x8)",   # mstatus.MIE bit mask (bit 3)
                     f"{'CSRS' if mie_val else 'CSRC'}(mstatus, x{r_scratch})",
                 ]
             )


### PR DESCRIPTION
Fixes #1308

Same bug as fixed for `InterruptsSm` in #1303.

`mstatus.MIE` is **bit 3** (mask `0x8`), not bit 7 (mask `0x80`, which is `mstatus.MPIE`).

Five locations in `InterruptsU.py` were using `0x80` when setting/clearing `mstatus` to
control the MIE bit, which silently toggled MPIE instead — making the
`mstatus.MIE={0/1}` cross-product tests incorrect.

## Locations Fixed

| Function | Line | Destination CSR | Was | Fixed to |
|---|---|---|---|---|
| `_generate_user_mti_tests` | 55 | `mstatus` | `0x80` | `0x8` |
| `_generate_user_msi_tests` | 121 | `mstatus` | `0x80` | `0x8` |
| `_generate_user_mei_tests` | 187 | `mstatus` | `0x80` | `0x8` |
| `_generate_user_wfi_tests` | 238 | `mstatus` | `0x80` | `0x8` |
| `_generate_user_wfi_timeout_tests` | 303 | `mstatus` | `0x80` | `0x8` |

The `0x80` values writing to the `mie` CSR (e.g. enabling `mie.MTIE`) are **not changed**
— `0x80` is correct for bit 7 of `mie`.

Misleading comments (`mstatus.MPIE bit mask (bit 7)`) corrected to `mstatus.MIE bit mask (bit 3)`.
