### PR TITLE
InterrutpsSstc Python Generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ override EXCLUDE_EXTENSIONS := $(subst $(space),$(empty),$(EXCLUDE_EXTENSIONS))
 # DEBUG enables debug output (signature objdump, trace files, and trap report). This will slow down ELF generation significantly.
 # FAST disables objdump generation for faster builds. This speeds up ELF generation significantly, but makes debugging mismatches harder.
 # VERBOSE implies DEBUG, serializes all commands (JOBS=1), and prints each command as it is issued.
-DEBUG       ?= True
+DEBUG       ?=
 FAST        ?=
 VERBOSE     ?=
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ WORKDIR     ?= work
 #  - ExceptionsZaamo: Configuration needed between access and misaligned faults
 #  - InterruptsSm,PMPSm,PMPZca,PMPmisaligned: Additional testing needed on a wider range of configs. Some missing config options to match ref model.
 EXTENSIONS  ?=
-EXCLUDE_EXTENSIONS ?= Sm,S,InterruptsSm,ExceptionsZalrsc,ExceptionsZaamo,PMPSm,PMPZca,PMPmisaligned,Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo
+EXCLUDE_EXTENSIONS ?= Sm,S,InterruptsSm,InterruptsS,ExceptionsZalrsc,ExceptionsZaamo,PMPSm,PMPZca,PMPmisaligned,Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo
 
 # Strip spaces from comma-separated lists so shell word-splitting doesn't break CLI arguments
 empty :=
@@ -35,7 +35,7 @@ override EXCLUDE_EXTENSIONS := $(subst $(space),$(empty),$(EXCLUDE_EXTENSIONS))
 # DEBUG enables debug output (signature objdump, trace files, and trap report). This will slow down ELF generation significantly.
 # FAST disables objdump generation for faster builds. This speeds up ELF generation significantly, but makes debugging mismatches harder.
 # VERBOSE implies DEBUG, serializes all commands (JOBS=1), and prints each command as it is issued.
-DEBUG       ?=
+DEBUG       ?= True
 FAST        ?=
 VERBOSE     ?=
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ WORKDIR     ?= work
 #  - ExceptionsZaamo: Configuration needed between access and misaligned faults
 #  - InterruptsSm,InterruptsS,InterruptsU,PMPSm,PMPZca,PMPmisaligned: Additional testing needed on a wider range of configs. Some missing config options to match ref model.
 EXTENSIONS  ?=
-EXCLUDE_EXTENSIONS ?= Sm,S,InterruptsSm,InterruptsS,InterruptsU,ExceptionsZalrsc,ExceptionsZaamo,PMPSm,PMPZca,PMPmisaligned,Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo
+EXCLUDE_EXTENSIONS ?= Sm,S,InterruptsSm,InterruptsS,InterruptsSstc,InterruptsU,ExceptionsZalrsc,ExceptionsZaamo,PMPSm,PMPZca,PMPmisaligned,Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo
 
 # Strip spaces from comma-separated lists so shell word-splitting doesn't break CLI arguments
 empty :=

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ WORKDIR     ?= work
 #  - Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo: sail-riscv missing support for Svade/Svadu causes mismatches. Resolved in upcoming sail-riscv release.
 #  - ExceptionsZalrsc: See sail-riscv issue 1574. Resolved in upcoming sail-riscv release.
 #  - ExceptionsZaamo: Configuration needed between access and misaligned faults
-#  - InterruptsSm,PMPSm,PMPZca,PMPmisaligned: Additional testing needed on a wider range of configs. Some missing config options to match ref model.
+#  - InterruptsSm,InterruptsS,InterruptsU,PMPSm,PMPZca,PMPmisaligned: Additional testing needed on a wider range of configs. Some missing config options to match ref model.
 EXTENSIONS  ?=
-EXCLUDE_EXTENSIONS ?= Sm,S,InterruptsSm,InterruptsS,ExceptionsZalrsc,ExceptionsZaamo,PMPSm,PMPZca,PMPmisaligned,Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo
+EXCLUDE_EXTENSIONS ?= Sm,S,InterruptsSm,InterruptsS,InterruptsU,ExceptionsZalrsc,ExceptionsZaamo,PMPSm,PMPZca,PMPmisaligned,Sv,Svade,Svadu,SvaduPMP,SvPMP,SvZicbo,SvPMPZicbo
 
 # Strip spaces from comma-separated lists so shell word-splitting doesn't break CLI arguments
 empty :=

--- a/config/qemu/qemu-RVI20U64/sail.json
+++ b/config/qemu/qemu-RVI20U64/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/qemu/qemu-rv32-max/sail.json
+++ b/config/qemu/qemu-rv32-max/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/qemu/qemu-rv64-max/sail.json
+++ b/config/qemu/qemu-rv64-max/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-RVA20S64/sail.json
+++ b/config/sail/sail-RVA20S64/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-RVA22S64-optional/sail.json
+++ b/config/sail/sail-RVA22S64-optional/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-RVA22S64/sail.json
+++ b/config/sail/sail-RVA22S64/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-RVA23S64-optional/sail.json
+++ b/config/sail/sail-RVA23S64-optional/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-RVA23S64/sail.json
+++ b/config/sail/sail-RVA23S64/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-RVB23S64-optional/sail.json
+++ b/config/sail/sail-RVB23S64-optional/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-RVB23S64/sail.json
+++ b/config/sail/sail-RVB23S64/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-RVI20U32/sail.json
+++ b/config/sail/sail-RVI20U32/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-RVI20U64/sail.json
+++ b/config/sail/sail-RVI20U64/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-rv32-max/sail.json
+++ b/config/sail/sail-rv32-max/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/sail/sail-rv64-max/rvmodel_macros.h
+++ b/config/sail/sail-rv64-max/rvmodel_macros.h
@@ -132,23 +132,18 @@
 
 
 // TODO: check to see if SAIL support this, and we may want to implement this in WALLY
-#define CLINT_SSIP_ADDRESS (CLINT_BASE_ADDRESS + 0xC000)
-// #define RVMODEL_SET_SSW_INT(_R1, _R2)        \
-//   li _R1, 1;                 \
-//   li _R2, CLINT_SSIP_ADDRESS;              \
-//   sw _R1, 0(_R2);
-
-
-// #define RVMODEL_CLR_SSW_INT(_R1, _R2)        \
-//   li _R2, CLINT_SSIP_ADDRESS;              \
-//   sw zero, 0(_R2);
-
+// #define CLINT_SSIP_ADDRESS (CLINT_BASE_ADDRESS + 0xC000)
+#define CLINT_SSIP_ADDRESS (0x80000000)
 #define RVMODEL_SET_SSW_INT(_R1, _R2)        \
-  li _R1, 2;                 \
-  csrs mip, _R1;             /* Set mip.SSIP (M-mode) */
+  li _R1, 1;                 \
+  li _R2, CLINT_SSIP_ADDRESS;              \
+  sw _R1, 0(_R2);
+
 
 #define RVMODEL_CLR_SSW_INT(_R1, _R2)        \
-  li _R1, 2;                 \
-  csrc sip, _R1;             /* Clear sip.SSIP (S-mode handler: only used when mideleg.SSIP=1) */
+  li _R2, CLINT_SSIP_ADDRESS;              \
+  sw zero, 0(_R2);
+
+
 
 #endif // _RVMODEL_MACROS_H

--- a/config/sail/sail-rv64-max/rvmodel_macros.h
+++ b/config/sail/sail-rv64-max/rvmodel_macros.h
@@ -133,14 +133,22 @@
 
 // TODO: check to see if SAIL support this, and we may want to implement this in WALLY
 #define CLINT_SSIP_ADDRESS (CLINT_BASE_ADDRESS + 0xC000)
-#define RVMODEL_SET_SSW_INT(_R1, _R2)        \
-  li _R1, 1;                 \
-  li _R2, CLINT_SSIP_ADDRESS;              \
-  sw _R1, 0(_R2);
+// #define RVMODEL_SET_SSW_INT(_R1, _R2)        \
+//   li _R1, 1;                 \
+//   li _R2, CLINT_SSIP_ADDRESS;              \
+//   sw _R1, 0(_R2);
 
+
+// #define RVMODEL_CLR_SSW_INT(_R1, _R2)        \
+//   li _R2, CLINT_SSIP_ADDRESS;              \
+//   sw zero, 0(_R2);
+
+#define RVMODEL_SET_SSW_INT(_R1, _R2)        \
+  li _R1, 2;                 \
+  csrs mip, _R1;             /* Set mip.SSIP (M-mode) */
 
 #define RVMODEL_CLR_SSW_INT(_R1, _R2)        \
-  li _R2, CLINT_SSIP_ADDRESS;              \
-  sw zero, 0(_R2);
+  li _R1, 2;                 \
+  csrc sip, _R1;             /* Clear sip.SSIP (S-mode handler: only used when mideleg.SSIP=1) */
 
 #endif // _RVMODEL_MACROS_H

--- a/config/sail/sail-rv64-max/sail.json
+++ b/config/sail/sail-rv64-max/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/spike/spike-RVI20U32/sail.json
+++ b/config/spike/spike-RVI20U32/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/spike/spike-RVI20U64/sail.json
+++ b/config/spike/spike-RVI20U64/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/spike/spike-rv32-max/sail.json
+++ b/config/spike/spike-rv32-max/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/config/spike/spike-rv64-max/sail.json
+++ b/config/spike/spike-rv64-max/sail.json
@@ -179,7 +179,7 @@
     },
     "clock_frequency": 1000000000,
     "instructions_per_tick": 2,
-    "wfi_is_nop": true
+    "wfi_is_nop": false
   },
   "extensions": {
     "M": {

--- a/coverpoints/priv/InterruptsS_coverage.svh
+++ b/coverpoints/priv/InterruptsS_coverage.svh
@@ -18,22 +18,22 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
 
     // building blocks for the main coverpoints
 
-    mstatus_mie: coverpoint ins.current.csr[12'h300][3]  {
+    mstatus_mie: coverpoint ins.prev.csr[12'h300][3]  {
         // autofill 0/1
     }
-    mstatus_mie_zero: coverpoint ins.current.csr[12'h300][3] {
+    mstatus_mie_zero: coverpoint ins.prev.csr[12'h300][3] {
         bins zero = {0};
     }
-    mstatus_mie_one: coverpoint ins.current.csr[12'h300][3] {
+    mstatus_mie_one: coverpoint ins.prev.csr[12'h300][3] {
         bins one = {1};
     }
-    mstatus_mie_rise: coverpoint ins.current.csr[12'h300][3] {
+    mstatus_mie_rise: coverpoint ins.prev.csr[12'h300][3] {
         bins rise = (0 => 1);
     }
-    mstatus_sie: coverpoint ins.current.csr[12'h300][1] {
+    mstatus_sie: coverpoint ins.prev.csr[12'h300][1] {
         // autofill 0/1
     }
-    mstatus_sie_one: coverpoint ins.current.csr[12'h300][1] {
+    mstatus_sie_one: coverpoint ins.prev.csr[12'h300][1] {
         bins one = {1};
     }
     prev_mstatus_sie_zero: coverpoint ins.prev.csr[12'h300][1] {
@@ -275,52 +275,62 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     }
 
     // main coverpoints
-    cp_trigger_mti:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_mtip_one;
-    cp_trigger_msi:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_msip_one;
-    cp_trigger_mei:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_meip_one;
+    cp_trigger_sti1:             cross mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_stip_one;
+    cp_trigger_sti2:             cross priv_mode_s, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_stip_one;
+    cp_trigger_sti3:             cross priv_mode_s, mstatus_mie_zero, mie_ones, mideleg_ones_zeros, mip_stip_one;
+    cp_trigger_sti4:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mideleg_ones_zeros, mip_stip_one;
+    cp_trigger_sti5:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mip_stip_one;
+    cp_trigger_sti6:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros;
+
+    cp_trigger_sti7:             cross priv_mode_s, mstatus_mie_zero, mie_ones, mideleg_ones_zeros;
+
+
+    // cp_trigger_mti:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_mtip_one;
+    // cp_trigger_msi:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_msip_one;
+    // cp_trigger_mei:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_meip_one;
     cp_trigger_sti:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_stip_one;
-    cp_trigger_ssi_mip:         cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_ssip_one;
-    cp_trigger_ssi_sip:         cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, csrrs, write_sip_ssip;
-    cp_trigger_sei:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_seip_one, s_ext_intr_high;
-    cp_trigger_sei_seip:        cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_seip_one, s_ext_intr_low;
-    cp_trigger_changingtos_sti: cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_stip_one, csrrs, write_sstatus_sie;
-    cp_trigger_changingtos_ssi: cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_ssip_one, csrrs, write_sstatus_sie;
-    cp_trigger_changingtos_sei: cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_seip_one, csrrs, write_sstatus_sie;
-    cp_interrupts_s:            cross priv_mode_s, mstatus_mie_zero, mideleg_ones_zeros, mtvec_direct, mip_walking, mie_walking;
-    cp_vectored_s:              cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_ones, mideleg_ones, stvec_mode, mip_walking;
-    cp_priority_mip_s:          cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mip_combinations, mie_ones,   mideleg_ones_zeros;
-    cp_priority_mie_s:          cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_combinations, mip_ones,   mideleg_ones_zeros;
-    cp_priority_both_s:         cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_combinations, mip_mie_eq, mideleg_ones_zeros;
-    cp_priority_mideleg_m:      cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations, mip_ones_s, mie_ones;
-    cp_priority_mideleg_s:      cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations, mip_ones_s, mideleg_mie_eq;
-    cp_wfi_s:                   cross priv_mode_s, wfi, mstatus_mie, mstatus_sie, mideleg_ones_zeros, mstatus_tw, mie_mtie_one, mip_mtip_one; // could cause funky coverage since WFI often doesn't retire. Revisit later
-    cp_wfi_timeout_s:           cross priv_mode_s, wfi, mstatus_mie, mstatus_sie, mideleg_ones_zeros, mstatus_tw_one, mie_mtie, timeout;
+    // cp_trigger_ssi_mip:         cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_ssip_one;
+    // cp_trigger_ssi_sip:         cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, csrrs, write_sip_ssip;
+    // cp_trigger_sei:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_seip_one, s_ext_intr_high;
+    // cp_trigger_sei_seip:        cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_seip_one, s_ext_intr_low;
+    // cp_trigger_changingtos_sti: cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_stip_one, csrrs, write_sstatus_sie;
+    // cp_trigger_changingtos_ssi: cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_ssip_one, csrrs, write_sstatus_sie;
+    // cp_trigger_changingtos_sei: cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_seip_one, csrrs, write_sstatus_sie;
+    // cp_interrupts_s:            cross priv_mode_s, mstatus_mie_zero, mideleg_ones_zeros, mtvec_direct, mip_walking, mie_walking;
+    // cp_vectored_s:              cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_ones, mideleg_ones, stvec_mode, mip_walking;
+    // cp_priority_mip_s:          cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mip_combinations, mie_ones,   mideleg_ones_zeros;
+    // cp_priority_mie_s:          cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_combinations, mip_ones,   mideleg_ones_zeros;
+    // cp_priority_both_s:         cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_combinations, mip_mie_eq, mideleg_ones_zeros;
+    // cp_priority_mideleg_m:      cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations, mip_ones_s, mie_ones;
+    // cp_priority_mideleg_s:      cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations, mip_ones_s, mideleg_mie_eq;
+    // cp_wfi_s:                   cross priv_mode_s, wfi, mstatus_mie, mstatus_sie, mideleg_ones_zeros, mstatus_tw, mie_mtie_one, mip_mtip_one; // could cause funky coverage since WFI often doesn't retire. Revisit later
+    // cp_wfi_timeout_s:           cross priv_mode_s, wfi, mstatus_mie, mstatus_sie, mideleg_ones_zeros, mstatus_tw_one, mie_mtie, timeout;
 
-    cp_interrupts_m:            cross priv_mode_m, mstatus_mie, mtvec_direct, mideleg_ones_zeros, mip_walking, mie_walking;
-    cp_vectored_m:              cross priv_mode_m, mstatus_mie_one, mtvec_vectored, mideleg_zeros, mip_s_walking, mie_s_ones;
-    cp_priority_mip_m:          cross priv_mode_m, mie_ones, mideleg_zeros, mip_combinations, mstatus_mie_rise;
-    cp_priority_mie_m:          cross priv_mode_m, mip_ones, mideleg_zeros, mie_combinations, mstatus_mie_rise;
-    cp_wfi_m:                   cross priv_mode_m, wfi, mstatus_mie, mstatus_sie, mideleg_ones, mstatus_tw, mie_mtie_one, mip_mtip_one;
-    cp_trigger_mti_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_mtip_one, csrrs, write_mstatus_mie;
-    cp_trigger_ssi_sip_m:       cross priv_mode_m, mstatus_mie, mie_ones, mideleg_ssi, csrrs, write_sip_ssip;
-    cp_trigger_msi_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_msip_one, csrrs, write_mstatus_mie;
-    cp_trigger_mei_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_meip_one, csrrs, write_mstatus_mie;
-    cp_trigger_sti_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_stip_one, csrrs, write_mstatus_mie;
-    cp_trigger_ssi_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_ssip_one, csrrs, write_mstatus_mie;
-    cp_trigger_sei_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_seip_one, csrrs, write_mstatus_mie;
-    cp_sei1:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_low, csrrw, write_mip_seip;
-    cp_sei2:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_low, csrrs, write_mip_seip;
-    cp_sei3:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_high;
-    cp_sei4:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, prev_mip_seip_one, s_ext_intr_low,  csrrc, write_mip_seip;
-    cp_sei5:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, prev_mip_seip_one, s_ext_intr_high, csrrc, write_mip_seip;
-    cp_sei6_7:                  cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr, mip_seip;
-    cp_global_ie:               cross priv_mode_m, mstatus_mie, mstatus_sie, mip_m_walking, mip_mie_eq;
+    // cp_interrupts_m:            cross priv_mode_m, mstatus_mie, mtvec_direct, mideleg_ones_zeros, mip_walking, mie_walking;
+    // cp_vectored_m:              cross priv_mode_m, mstatus_mie_one, mtvec_vectored, mideleg_zeros, mip_s_walking, mie_s_ones;
+    // cp_priority_mip_m:          cross priv_mode_m, mie_ones, mideleg_zeros, mip_combinations, mstatus_mie_rise;
+    // cp_priority_mie_m:          cross priv_mode_m, mip_ones, mideleg_zeros, mie_combinations, mstatus_mie_rise;
+    // cp_wfi_m:                   cross priv_mode_m, wfi, mstatus_mie, mstatus_sie, mideleg_ones, mstatus_tw, mie_mtie_one, mip_mtip_one;
+    // cp_trigger_mti_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_mtip_one, csrrs, write_mstatus_mie;
+    // cp_trigger_ssi_sip_m:       cross priv_mode_m, mstatus_mie, mie_ones, mideleg_ssi, csrrs, write_sip_ssip;
+    // cp_trigger_msi_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_msip_one, csrrs, write_mstatus_mie;
+    // cp_trigger_mei_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_meip_one, csrrs, write_mstatus_mie;
+    // cp_trigger_sti_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_stip_one, csrrs, write_mstatus_mie;
+    // cp_trigger_ssi_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_ssip_one, csrrs, write_mstatus_mie;
+    // cp_trigger_sei_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_seip_one, csrrs, write_mstatus_mie;
+    // cp_sei1:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_low, csrrw, write_mip_seip;
+    // cp_sei2:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_low, csrrs, write_mip_seip;
+    // cp_sei3:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_high;
+    // cp_sei4:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, prev_mip_seip_one, s_ext_intr_low,  csrrc, write_mip_seip;
+    // cp_sei5:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, prev_mip_seip_one, s_ext_intr_high, csrrc, write_mip_seip;
+    // cp_sei6_7:                  cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr, mip_seip;
+    // cp_global_ie:               cross priv_mode_m, mstatus_mie, mstatus_sie, mip_m_walking, mip_mie_eq;
 
-    cp_user_mti:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_mti_zero, mie_mtie, mip_mtip;
-    cp_user_msi:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_msi_zero, mie_msie, mip_msip;
-    cp_user_mei:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_mei_zero, mie_meie, mip_meip;
-    cp_user_sei:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_sei, mie_seie, mip_seip;
-    cp_wfi_timeout_u:           cross priv_mode_u, wfi, mstatus_mie, mstatus_sie, mideleg_ones, mstatus_tw_one, mie_mtie, timeout;
+    // cp_user_mti:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_mti_zero, mie_mtie, mip_mtip;
+    // cp_user_msi:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_msi_zero, mie_msie, mip_msip;
+    // cp_user_mei:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_mei_zero, mie_meie, mip_meip;
+    // cp_user_sei:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_sei, mie_seie, mip_seip;
+    // cp_wfi_timeout_u:           cross priv_mode_u, wfi, mstatus_mie, mstatus_sie, mideleg_ones, mstatus_tw_one, mie_mtie, timeout;
 endgroup
 
 function void interruptss_sample(int hart, int issue, ins_t ins);
@@ -341,4 +351,35 @@ function void interruptss_sample(int hart, int issue, ins_t ins);
     //             ins.current.csr[12'h304][15:0],
     //             ins.current.csr[12'h344][15:0]
     //         );
+
+    $display("=== InterruptsS Debug ===");
+    $display("PC: %h Instr: %s priv_mode=%b", ins.current.pc_rdata, ins.current.disass, ins.prev.mode);
+    $display("  mstatus: MIE=%b SIE=%b TW=%b mode: %b",
+                ins.prev.csr[12'h300][3], ins.prev.csr[12'h300][1],
+                ins.current.csr[12'h300][21], {ins.prev.mode_virt, ins.prev.mode});
+    $display(" NEW mstatus: MIE=%b SPIE=%b SIE=%b TW=%b mode: %b",
+            ins.current.csr[12'h300][3], ins.current.csr[12'h300][5],
+            ins.current.csr[12'h300][1],
+            ins.current.csr[12'h300][21], {ins.prev.mode_virt, ins.prev.mode});
+    $display("  mideleg: SEIE=%b STIE=%b SSIE=%b (full=%h)",
+                ins.current.csr[12'h303][9], ins.current.csr[12'h303][5],
+                ins.current.csr[12'h303][1], ins.current.csr[12'h303][15:0]);
+    $display("  mie: MEIE=%b SEIE=%b MTIE=%b STIE=%b MSIE=%b SSIE=%b (full=%h)",
+                ins.current.csr[12'h304][11], ins.current.csr[12'h304][9],
+                ins.current.csr[12'h304][7], ins.current.csr[12'h304][5],
+                ins.current.csr[12'h304][3], ins.current.csr[12'h304][1],
+                ins.current.csr[12'h304][15:0]);
+    $display("  mip: MEIP=%b SEIP=%b MTIP=%b STIP=%b MSIP=%b SSIP=%b (full=%h)",
+                ins.current.csr[12'h344][11], ins.current.csr[12'h344][9],
+                ins.current.csr[12'h344][7], ins.current.csr[12'h344][5],
+                ins.current.csr[12'h344][3], ins.current.csr[12'h344][1],
+                ins.current.csr[12'h344][15:0]);
+    $display("  sip: SEIP=%b STIP=%b SSIP=%b (full=%h)",
+                ins.current.csr[12'h144][9], ins.current.csr[12'h144][5],
+                ins.current.csr[12'h144][1], ins.current.csr[12'h144][15:0]);
+    $display("  mtvec.MODE=%b stvec.MODE=%b",
+                ins.current.csr[12'h305][1:0], ins.current.csr[12'h105][1:0]);
+    if (ins.current.trap)
+        $display("  TRAP! mcause=%h scause=%h", ins.current.csr[12'h342], ins.current.csr[12'h142]);
+    $display("");
 endfunction

--- a/coverpoints/priv/InterruptsS_coverage.svh
+++ b/coverpoints/priv/InterruptsS_coverage.svh
@@ -27,8 +27,9 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     mstatus_mie_one: coverpoint ins.prev.csr[12'h300][3] {
         bins one = {1};
     }
-    mstatus_mie_rise: coverpoint ins.prev.csr[12'h300][3] {
-        bins rise = (0 => 1);
+    mstatus_mpie: coverpoint ins.current.csr[12'h300][7] {
+        // bins zero = {0};
+        bins one = {1};
     }
     mstatus_sie: coverpoint ins.prev.csr[12'h300][1] {
         // autofill 0/1
@@ -71,10 +72,17 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     }
     mideleg_ones_zeros: coverpoint ins.current.csr[12'h303][15:0] {
         bins ones  = {16'b0000001000100010}; //  ones in every field that is not tied to zero (only supervisor delegable)
+        //bins zeros = {16'b0000000000000000}; // zeros in every field that is not tied to zero
+    }
+    mideleg_ones_zeros_real: coverpoint ins.current.csr[12'h303][15:0] {
+        bins ones  = {16'b0000001000100010}; //  ones in every field that is not tied to zero (only supervisor delegable)
         bins zeros = {16'b0000000000000000}; // zeros in every field that is not tied to zero
     }
     mie_msie: coverpoint ins.current.csr[12'h304][3] {
         // autofill 0/1
+    }
+    mie_msie_one: coverpoint ins.current.csr[12'h304][3] {
+        bins one = {1};
     }
     mie_mtie: coverpoint ins.current.csr[12'h304][7] {
         // autofill 0/1
@@ -82,8 +90,14 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     mie_seie: coverpoint ins.current.csr[12'h304][9] {
         // autofill 0/1
     }
+    mie_seie_one: coverpoint ins.current.csr[12'h304][9] {
+        bins one = {1};
+    }
     mie_meie: coverpoint ins.current.csr[12'h304][11] {
         // autofill 0/1
+    }
+    mie_meie_one: coverpoint ins.current.csr[12'h304][11] {
+        bins one = {1};
     }
     mie_mtie_one: coverpoint ins.current.csr[12'h304][7] {
         bins one = {1};
@@ -115,9 +129,6 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     mip_mtip_one: coverpoint ins.current.csr[12'h344][7] {
         bins one = {1};
     }
-    // mip_seip_zero: coverpoint ins.current.csr[12'h344][9] {
-    //     bins zero = {0};
-    // }
     mip_seip_one: coverpoint ins.current.csr[12'h344][9] {
         bins one = {1};
     }
@@ -133,8 +144,17 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     mip_ones: coverpoint ins.current.csr[12'h344][15:0] {
         wildcard bins ones = {16'b0000101010101010}; // ones in every field that is not tied to zero
     }
-    mip_ones_s: coverpoint ins.current.csr[12'h344][15:0] {
-        wildcard bins ones = {16'b0000001000100010}; // ones in every supervisor field that is not tied to zero
+    // All S-mode interrupts set: {SEIP, STIP, SSIP}
+    mip_ones_s: coverpoint {ins.current.csr[12'h344][9],   // SEIP
+                        ins.current.csr[12'h344][5],   // STIP
+                        ins.current.csr[12'h344][1]} { // SSIP
+        bins all_s_set = {3'b111};  // All three S-mode interrupts set
+    }
+    // All M-mode interrupts set: {MEIP, MTIP, MSIP}
+    mip_ones_m: coverpoint {ins.current.csr[12'h344][11],  // MEIP
+                        ins.current.csr[12'h344][7],   // MTIP
+                        ins.current.csr[12'h344][3]} { // MSIP
+        bins all_m_set = {3'b111};  // All three M-mode interrupts set
     }
     mie_walking: coverpoint {ins.current.csr[12'h304][11],
                              ins.current.csr[12'h304][9],
@@ -149,6 +169,13 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
         bins msie = {6'b000010};
         bins ssie = {6'b000001};
     }
+    mie_walking_s: coverpoint {ins.current.csr[12'h304][9],
+                             ins.current.csr[12'h304][5],
+                             ins.current.csr[12'h304][1]} {
+        bins seie = {3'b100};
+        bins stie = {3'b010};
+        bins ssie = {3'b001};
+    }
     mip_walking: coverpoint {ins.current.csr[12'h344][11],
                              ins.current.csr[12'h344][9],
                              ins.current.csr[12'h344][7],
@@ -162,17 +189,48 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
         bins msip = {6'b000010};
         bins ssip = {6'b000001};
     }
+    mip_walking_s: coverpoint {ins.current.csr[12'h344][9],
+                             ins.current.csr[12'h344][5],
+                             ins.current.csr[12'h344][1]} {
+        bins seip = {3'b100};
+        bins stip = {3'b010};
+        bins ssip = {3'b001};
+    }
+    mip_walking_m: coverpoint {ins.current.csr[12'h344][11],
+                             ins.current.csr[12'h344][7],
+                             ins.current.csr[12'h344][3]} {
+        bins meip = {3'b100};
+        bins mtip = {3'b010};
+        bins msip = {3'b001};
+    }
+    // Matched pairs only: mismatched mip/mie bits won't trigger a trap, so MRET (M->S transition) won't occur.
+    mip_mie_matched_m: coverpoint {ins.current.csr[12'h344][11], ins.current.csr[12'h344][7], ins.current.csr[12'h344][3],
+                               ins.current.csr[12'h304][11], ins.current.csr[12'h304][7], ins.current.csr[12'h304][3]} {
+        bins msip_msie = {6'b001001};  // MSIP=1, MSIE=1
+        bins mtip_mtie = {6'b010010};  // MTIP=1, MTIE=1
+        bins meip_meie = {6'b100100};  // MEIP=1, MEIE=1
+    }
+    // Check if instruction is MRET
+    mret_insn: coverpoint ins.current.insn {
+        bins mret = {32'h30200073};
+    }
+    sret_insn: coverpoint ins.current.insn {
+        bins sret = {32'h10200073};
+    }
+    // Check if mstatus.MPP is 01 (supervisor mode)
+    mstatus_mpp_s: coverpoint ins.current.csr[12'h300][12:11] {
+        bins s_mode = {2'b01};
+    }
+    mstatus_mpp_u: coverpoint ins.current.csr[12'h300][12:11] {
+        bins u_mode = {2'b00};
+    }
+    sstatus_spp_u: coverpoint ins.current.csr[12'h100][8] {
+        bins u_mode = {1'b0};
+    }
     mie_s_ones: coverpoint {ins.current.csr[12'h304][9],
                             ins.current.csr[12'h304][5],
                             ins.current.csr[12'h304][1]} {
         bins ones = {3'b111};
-    }
-    mip_s_walking: coverpoint {ins.current.csr[12'h344][9],
-                               ins.current.csr[12'h344][5],
-                               ins.current.csr[12'h344][1]}  {
-        bins seip = {3'b100};
-        bins stip = {3'b010};
-        bins ssip = {3'b001};
     }
     mie_m_walking: coverpoint {ins.current.csr[12'h304][11],
                                ins.current.csr[12'h304][7],
@@ -181,12 +239,12 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
         bins mtie = {3'b010};
         bins msie = {3'b001};
     }
-    mip_m_walking: coverpoint {ins.current.csr[12'h344][11],
-                               ins.current.csr[12'h344][7],
-                               ins.current.csr[12'h344][3]} {
-        bins meip = {3'b100};
-        bins mtip = {3'b010};
-        bins msip = {3'b001};
+    mie_s_walking: coverpoint {ins.current.csr[12'h304][9],
+                               ins.current.csr[12'h304][5],
+                               ins.current.csr[12'h304][1]} {
+        bins seie = {3'b100};
+        bins stie = {3'b010};
+        bins ssie = {3'b001};
     }
     mie_combinations: coverpoint {ins.current.csr[12'h304][11],
                                   ins.current.csr[12'h304][9],
@@ -196,6 +254,32 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
                                   ins.current.csr[12'h304][1]} {
         // auto fills all 2^6 combinations
     }
+    // S-mode enable combinations: {SEIE, STIE, SSIE}
+    mie_combinations_s: coverpoint {ins.current.csr[12'h304][9],  // SEIE
+                                ins.current.csr[12'h304][5],  // STIE
+                                ins.current.csr[12'h304][1]} { // SSIE
+        bins combo_000 = {3'b000};  // No enables (valid - interrupts pending but not enabled)
+        bins combo_001 = {3'b001};
+        bins combo_010 = {3'b010};
+        bins combo_011 = {3'b011};
+        bins combo_100 = {3'b100};
+        bins combo_101 = {3'b101};
+        bins combo_110 = {3'b110};
+        bins combo_111 = {3'b111};
+    }
+    // M-mode enable combinations: {MEIE, MTIE, MSIE}
+    mie_combinations_m: coverpoint {ins.current.csr[12'h304][11], // MEIE
+                                    ins.current.csr[12'h304][7],  // MTIE
+                                    ins.current.csr[12'h304][3]} { // MSIE
+        // bins combo_000 = {3'b000};  // Remove - no enables = no interrupt = no MRET
+        bins combo_001 = {3'b001};  // MSIE only
+        bins combo_010 = {3'b010};  // MTIE only
+        bins combo_011 = {3'b011};
+        bins combo_100 = {3'b100};  // MEIE only
+        bins combo_101 = {3'b101};
+        bins combo_110 = {3'b110};
+        bins combo_111 = {3'b111};
+    }
     mip_combinations: coverpoint {ins.current.csr[12'h344][11],
                                   ins.current.csr[12'h344][9],
                                   ins.current.csr[12'h344][7],
@@ -204,15 +288,94 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
                                   ins.current.csr[12'h344][1]} {
         // auto fills all 2^6 combinations
     }
+    // S-mode priority: combinations of SSIP, STIP, SEIP (2^3 = 8 combinations)
+    mip_combinations_s: coverpoint {ins.current.csr[12'h344][9],  // SEIP
+                                    ins.current.csr[12'h344][5],  // STIP
+                                    ins.current.csr[12'h344][1]} { // SSIP
+        bins combo_000 = {3'b000};
+        bins combo_001 = {3'b001};  // SSIP only
+        bins combo_010 = {3'b010};  // STIP only
+        bins combo_011 = {3'b011};  // SSIP+STIP
+        bins combo_100 = {3'b100};  // SEIP only
+        bins combo_101 = {3'b101};  // SSIP+SEIP
+        bins combo_110 = {3'b110};  // STIP+SEIP
+        bins combo_111 = {3'b111};  // All three
+    }
+    mip_combinations_m: coverpoint {ins.current.csr[12'h344][11], // MEIP
+                                    ins.current.csr[12'h344][7],  // MTIP
+                                    ins.current.csr[12'h344][3]} { // MSIP
+        // bins combo_000 = {3'b000}; // removing this because this is not an interrupt so mret would not execute
+        bins combo_001 = {3'b001};  // MSIP only
+        bins combo_010 = {3'b010};  // MTIP only
+        bins combo_011 = {3'b011};  // MSIP+MTIP
+        bins combo_100 = {3'b100};  // MEIP only
+        bins combo_101 = {3'b101};  // MSIP+MEIP
+        bins combo_110 = {3'b110};  // MTIP+MEIP
+        bins combo_111 = {3'b111};  // All three
+    }
     mideleg_combinations: coverpoint {ins.current.csr[12'h303][9],
                                       ins.current.csr[12'h303][5],
                                       ins.current.csr[12'h303][1]} {
         // auto fills all 2^3 combinations (assuming only supervisor interrupts are delegable)
     }
+    // S-mode sampling: SEIP must be delegated (highest priority; traps to M-mode first otherwise).
+    // Only combinations with SEIE delegated (bit 9 set) are valid for S-mode entry.
+    // Priority order: SEIP > SSIP > STIP
+    mideleg_combinations_s: coverpoint {ins.current.csr[12'h303][9],
+                                        ins.current.csr[12'h303][5],
+                                        ins.current.csr[12'h303][1]} {
+        bins combo_100 = {3'b100};  // SEIE only
+        bins combo_101 = {3'b101};  // SSIE+SEIE
+        bins combo_110 = {3'b110};  // STIE+SEIE
+        bins combo_111 = {3'b111};  // All delegated
+    }
+
+    // Patterns where at least one S-interrupt is NOT delegated (for M-mode sampling)
+    mideleg_combinations_m: coverpoint {ins.current.csr[12'h303][9],
+                                        ins.current.csr[12'h303][5],
+                                        ins.current.csr[12'h303][1]} {
+        bins combo_000 = {3'b000};  // None delegated
+        bins combo_001 = {3'b001};  // SSIE only (STIP/SEIP not delegated)
+        bins combo_010 = {3'b010};  // STIE only (SSIP/SEIP not delegated)
+        bins combo_011 = {3'b011};  // SSIE+STIE (SEIP not delegated)
+        bins combo_100 = {3'b100};  // SEIE only (SSIP/STIP not delegated)
+        bins combo_101 = {3'b101};  // SSIE+SEIE (STIP not delegated)
+        bins combo_110 = {3'b110};  // STIE+SEIE (SSIP not delegated)
+    }
     mip_mie_eq: coverpoint (ins.current.csr[12'h304][11:0] == ins.current.csr[12'h344][11:0]) {
         bins equal = {1};
     }
+    // S-mode: Check if S-mode interrupt bits match
+    mip_mie_eq_s: coverpoint ({ins.current.csr[12'h344][9], ins.current.csr[12'h344][5], ins.current.csr[12'h344][1]} ==
+                            {ins.current.csr[12'h304][9], ins.current.csr[12'h304][5], ins.current.csr[12'h304][1]}) {
+        bins equal = {1};
+    }
+
+    // M-mode: Check if M-mode interrupt bits match
+    mip_mie_eq_m: coverpoint ({ins.current.csr[12'h344][11], ins.current.csr[12'h344][7], ins.current.csr[12'h344][3]} ==
+                            {ins.current.csr[12'h304][11], ins.current.csr[12'h304][7], ins.current.csr[12'h304][3]}) {
+        bins equal = {1};
+    }
     mideleg_mie_eq: coverpoint (ins.current.csr[12'h303][11:0] == ins.current.csr[12'h344][11:0]) {
+        bins equal = {1};
+    }
+    // S-mode: Priority among delegated interrupts
+    // Exclude combo_000 (nothing enabled = no interrupt)
+    mideleg_combinations_delegated: coverpoint {ins.current.csr[12'h303][9],
+                                                ins.current.csr[12'h303][5],
+                                                ins.current.csr[12'h303][1]} {
+        bins combo_001 = {3'b001};  // SSIE only
+        bins combo_010 = {3'b010};  // STIE only
+        bins combo_011 = {3'b011};  // SSIE+STIE
+        bins combo_100 = {3'b100};  // SEIE only
+        bins combo_101 = {3'b101};  // SSIE+SEIE
+        bins combo_110 = {3'b110};  // STIE+SEIE
+        bins combo_111 = {3'b111};  // All
+    }
+
+    // Check mideleg == mie (only S-mode bits)
+    mideleg_mie_eq_s: coverpoint ({ins.current.csr[12'h303][9], ins.current.csr[12'h303][5], ins.current.csr[12'h303][1]} ==
+                                {ins.current.csr[12'h304][9], ins.current.csr[12'h304][5], ins.current.csr[12'h304][1]}) {
         bins equal = {1};
     }
     stvec_mode: coverpoint ins.current.csr[12'h105][1:0] {
@@ -240,11 +403,21 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     write_mip_seip: coverpoint ins.current.rs1_val[9] iff (ins.current.insn[31:20] == 12'h344) {
         bins write_seip = {1};
     }
+    sip_seip_one: coverpoint ins.current.csr[12'h144][9] {
+        bins one = {1};
+    }
     write_sip_ssip: coverpoint ins.current.rs1_val[1] iff (ins.current.insn[31:20] == 12'h144) {
         bins write_ssip = {1};
     }
+    sip_ssip_one: coverpoint ins.current.csr[12'h144][1] {
+        bins one = {1};
+    }
     write_sstatus_sie: coverpoint ins.current.rs1_val[1] iff ( ins.current.insn[31:20] == 12'h100) {
         bins write_sie = {1};
+    }
+    sstatus_sie: coverpoint ins.current.csr[12'h100][1] {
+        bins one = {1};
+        bins zero = {0};
     }
     write_mstatus_mie: coverpoint ins.current.rs1_val[3] iff ( ins.current.insn[31:20] == 12'h300) {
         bins write_mie = {1};
@@ -255,15 +428,15 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     timeout: coverpoint ins.current.csr[12'h344][7] iff (ins.trap == 1) {
         bins no_timer_int = {0};
     }
-    // m_ext_intr: coverpoint ins.current.m_ext_intr {
-    //     bins mei = {1};
-    // }
-    // m_timer_intr: coverpoint ins.current.m_timer_intr {
-    //     bins mti = {1};
-    // }
-    // m_soft_intr: coverpoint ins.current.m_soft_intr {
-    //     bins msi = {1};
-    // }
+    mstatus_tw_zero: coverpoint ins.current.csr[12'h300][21] {
+        bins zero = {0};
+    }
+    mideleg_sei_zero: coverpoint ins.current.csr[12'h303][9] {
+        bins zero = {0};
+    }
+    mideleg_sei_one: coverpoint ins.current.csr[12'h303][9] {
+        bins one = {1};
+    }
     s_ext_intr: coverpoint ins.current.s_ext_intr {
         // autofill 0/1
     }
@@ -275,62 +448,77 @@ covergroup InterruptsS_cg with function sample(ins_t ins);
     }
 
     // main coverpoints
-    cp_trigger_sti1:             cross mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_stip_one;
-    cp_trigger_sti2:             cross priv_mode_s, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_stip_one;
-    cp_trigger_sti3:             cross priv_mode_s, mstatus_mie_zero, mie_ones, mideleg_ones_zeros, mip_stip_one;
-    cp_trigger_sti4:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mideleg_ones_zeros, mip_stip_one;
-    cp_trigger_sti5:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mip_stip_one;
-    cp_trigger_sti6:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros;
 
-    cp_trigger_sti7:             cross priv_mode_s, mstatus_mie_zero, mie_ones, mideleg_ones_zeros;
+    // S-mode tests
+    cp_trigger_sti_s:            cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones, mip_stip_one;
+    cp_trigger_sti_m:            cross priv_mode_m, mret_insn, mstatus_mpp_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_zeros, mip_stip_one;
+    cp_trigger_ssi_mip:          cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones, mip_ssip_one;
+    cp_trigger_ssi_mip_m:        cross priv_mode_m, mret_insn, mstatus_mpp_s, mstatus_mie_zero, mie_ones, mideleg_zeros, mip_ssip_one;
+    cp_trigger_ssi_sip:          cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones, sip_ssip_one, csrrs, write_sip_ssip;
+    cp_trigger_sei:              cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones, mip_seip_one;
+    cp_trigger_sei_m:            cross priv_mode_m, mret_insn, mstatus_mpp_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_zeros, mip_seip_one;
+    cp_trigger_sei_seip:         cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones, sip_seip_one;
+    cp_trigger_changingtos_sti:  cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_stip_one, sstatus_sie;
+    cp_trigger_changingtos_ssi:  cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_ssip_one, sstatus_sie;
+    cp_trigger_changingtos_sei:  cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_seip_one, sstatus_sie;
+    cp_interrupts_s:             cross priv_mode_s, mstatus_mie_zero, mideleg_ones, mtvec_direct, mip_walking_s, mie_walking_s;
+    cp_interrupts_s_m:           cross priv_mode_m, mret_insn, mstatus_mpp_s, mstatus_mie_zero, mideleg_zeros, mtvec_direct, mip_mie_matched_m;
+    cp_vectored_s:               cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_ones, mideleg_ones, stvec_mode, mip_walking_s;
+    cp_vectored_s_m:             cross priv_mode_m, mret_insn, mstatus_mpp_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_ones, mideleg_ones, stvec_mode, mip_walking_m;
 
+    // S-mode priority tests
+    cp_priority_mip_s:           cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mip_combinations_s, mie_ones, mideleg_ones;
+    cp_priority_mip_s_m:         cross priv_mode_m, mret_insn, mstatus_mpp_s, mstatus_mie_zero, prev_mstatus_sie_one, mip_combinations_m, mie_ones, mideleg_zeros;
+    cp_priority_mie_s:           cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_combinations_s, mip_ones_s, mideleg_ones;
+    cp_priority_mie_s_m:         cross priv_mode_m, mret_insn, mstatus_mpp_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_combinations_m, mip_ones_m, mideleg_zeros;
+    cp_priority_both_s:          cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_combinations_s, mip_mie_eq_s, mideleg_ones;
+    cp_priority_both_m:          cross priv_mode_m, mret_insn, mstatus_mpp_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_combinations_m, mip_mie_eq_m, mideleg_zeros;
+    cp_priority_mideleg_m:       cross priv_mode_m, mret_insn, mstatus_mpp_s, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations_m, mip_ones_s, mie_ones;
+    cp_priority_mideleg_s:       cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations_s, mip_ones_s, mie_ones;
+    cp_priority_mideleg_s_eq:    cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations_delegated, mip_ones_s, mideleg_mie_eq_s;
+    cp_wfi_s:                    cross priv_mode_s, wfi, mstatus_mie, mstatus_sie, mideleg_ones_zeros_real, mstatus_tw, mie_mtie_one;
+    cp_wfi_timeout_s:            cross priv_mode_m, mstatus_mie, mstatus_sie, mideleg_ones_zeros_real, mstatus_tw_one, mie_mtie;
 
-    // cp_trigger_mti:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_mtip_one;
-    // cp_trigger_msi:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_msip_one;
-    // cp_trigger_mei:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_meip_one;
-    cp_trigger_sti:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_stip_one;
-    // cp_trigger_ssi_mip:         cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_ssip_one;
-    // cp_trigger_ssi_sip:         cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, csrrs, write_sip_ssip;
-    // cp_trigger_sei:             cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_seip_one, s_ext_intr_high;
-    // cp_trigger_sei_seip:        cross priv_mode_s, mstatus_mie_zero, mstatus_sie, mie_ones, mideleg_ones_zeros, mip_seip_one, s_ext_intr_low;
-    // cp_trigger_changingtos_sti: cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_stip_one, csrrs, write_sstatus_sie;
-    // cp_trigger_changingtos_ssi: cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_ssip_one, csrrs, write_sstatus_sie;
-    // cp_trigger_changingtos_sei: cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_zero, mie_ones, mideleg_ones, mip_seip_one, csrrs, write_sstatus_sie;
-    // cp_interrupts_s:            cross priv_mode_s, mstatus_mie_zero, mideleg_ones_zeros, mtvec_direct, mip_walking, mie_walking;
-    // cp_vectored_s:              cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_ones, mideleg_ones, stvec_mode, mip_walking;
-    // cp_priority_mip_s:          cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mip_combinations, mie_ones,   mideleg_ones_zeros;
-    // cp_priority_mie_s:          cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_combinations, mip_ones,   mideleg_ones_zeros;
-    // cp_priority_both_s:         cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mie_combinations, mip_mie_eq, mideleg_ones_zeros;
-    // cp_priority_mideleg_m:      cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations, mip_ones_s, mie_ones;
-    // cp_priority_mideleg_s:      cross priv_mode_s, mstatus_mie_zero, prev_mstatus_sie_one, mideleg_combinations, mip_ones_s, mideleg_mie_eq;
-    // cp_wfi_s:                   cross priv_mode_s, wfi, mstatus_mie, mstatus_sie, mideleg_ones_zeros, mstatus_tw, mie_mtie_one, mip_mtip_one; // could cause funky coverage since WFI often doesn't retire. Revisit later
-    // cp_wfi_timeout_s:           cross priv_mode_s, wfi, mstatus_mie, mstatus_sie, mideleg_ones_zeros, mstatus_tw_one, mie_mtie, timeout;
+    // M-mode tests
+    cp_interrupts_m:            cross priv_mode_m, mstatus_mie, mtvec_direct, mideleg_ones_zeros_real, mip_walking, mie_walking;
+    cp_vectored_m:              cross priv_mode_m, mstatus_mie_one, mtvec_vectored, mideleg_zeros, mip_walking_s, mie_s_ones;
+    cp_priority_mip_m:          cross priv_mode_m, mie_ones, mideleg_zeros, mip_combinations;
+    cp_priority_mie_m:          cross priv_mode_m, mip_ones, mideleg_zeros, mie_combinations;
+    cp_wfi_m:                   cross priv_mode_m, wfi, mstatus_mie, mstatus_sie, mideleg_ones, mstatus_tw, mie_mtie_one; // NOTE: wfi still exits early so doesn't work
+    cp_trigger_mti_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_mtip_one, csrrs, write_mstatus_mie;
+    cp_trigger_ssi_sip_m:       cross priv_mode_m, mstatus_mie, mie_ones, mideleg_ssi, csrrs, write_sip_ssip;
+    cp_trigger_msi_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_msip_one, csrrs, write_mstatus_mie;
+    cp_trigger_mei_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_meip_one, csrrs, write_mstatus_mie;
+    cp_trigger_sti_M_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_stip_one, csrrs, write_mstatus_mie;
+    cp_trigger_ssi_M_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_ssip_one, csrrs, write_mstatus_mie;
+    cp_trigger_sei_M_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_seip_one, csrrs, write_mstatus_mie;
+    cp_sei1:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_low, csrrw, write_mip_seip;
+    cp_sei2:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_low, csrrs, write_mip_seip;
+    cp_sei3:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_high;
+    cp_sei4:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, prev_mip_seip_one, s_ext_intr_low,  csrrc, write_mip_seip;
+    cp_sei5:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, prev_mip_seip_one, s_ext_intr_high, csrrc, write_mip_seip;
+    cp_sei6_7:                  cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr, mip_seip;
+    cp_global_ie:               cross priv_mode_m, mstatus_mie, mstatus_sie, mip_walking_m, mip_mie_eq;
 
-    // cp_interrupts_m:            cross priv_mode_m, mstatus_mie, mtvec_direct, mideleg_ones_zeros, mip_walking, mie_walking;
-    // cp_vectored_m:              cross priv_mode_m, mstatus_mie_one, mtvec_vectored, mideleg_zeros, mip_s_walking, mie_s_ones;
-    // cp_priority_mip_m:          cross priv_mode_m, mie_ones, mideleg_zeros, mip_combinations, mstatus_mie_rise;
-    // cp_priority_mie_m:          cross priv_mode_m, mip_ones, mideleg_zeros, mie_combinations, mstatus_mie_rise;
-    // cp_wfi_m:                   cross priv_mode_m, wfi, mstatus_mie, mstatus_sie, mideleg_ones, mstatus_tw, mie_mtie_one, mip_mtip_one;
-    // cp_trigger_mti_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_mtip_one, csrrs, write_mstatus_mie;
-    // cp_trigger_ssi_sip_m:       cross priv_mode_m, mstatus_mie, mie_ones, mideleg_ssi, csrrs, write_sip_ssip;
-    // cp_trigger_msi_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_msip_one, csrrs, write_mstatus_mie;
-    // cp_trigger_mei_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_meip_one, csrrs, write_mstatus_mie;
-    // cp_trigger_sti_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_stip_one, csrrs, write_mstatus_mie;
-    // cp_trigger_ssi_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_ssip_one, csrrs, write_mstatus_mie;
-    // cp_trigger_sei_m:           cross priv_mode_m, mideleg_zeros, mie_ones, mip_seip_one, csrrs, write_mstatus_mie;
-    // cp_sei1:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_low, csrrw, write_mip_seip;
-    // cp_sei2:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_low, csrrs, write_mip_seip;
-    // cp_sei3:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr_high;
-    // cp_sei4:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, prev_mip_seip_one, s_ext_intr_low,  csrrc, write_mip_seip;
-    // cp_sei5:                    cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, prev_mip_seip_one, s_ext_intr_high, csrrc, write_mip_seip;
-    // cp_sei6_7:                  cross priv_mode_m, mideleg_zeros, mstatus_mie_zero, s_ext_intr, mip_seip;
-    // cp_global_ie:               cross priv_mode_m, mstatus_mie, mstatus_sie, mip_m_walking, mip_mie_eq;
+    // U-mode tests
+    cp_user_mti:                cross priv_mode_m, mret_insn, mstatus_mpp_u, mstatus_mie_zero, mstatus_sie, stvec_mode, mideleg_mti_zero, mie_mtie_one, mip_mtip;
+    cp_user_mti_m:              cross priv_mode_m, mstatus_mie_one, mstatus_sie, stvec_mode, mideleg_mti_zero, mie_mtie_one, mip_mtip;
+    cp_user_msi:                cross priv_mode_m, mret_insn, mstatus_mpp_u, mstatus_mie_zero, mstatus_sie, stvec_mode, mideleg_msi_zero, mie_msie_one, mip_msip;
+    cp_user_msi_m:              cross priv_mode_m, mstatus_mie_one, mstatus_sie, stvec_mode, mideleg_msi_zero, mie_msie_one, mip_msip;
+    cp_user_mei:                cross priv_mode_m, mret_insn, mstatus_mpp_u, mstatus_mie_zero, mstatus_sie, stvec_mode, mideleg_mei_zero, mie_meie_one, mip_meip;
+    cp_user_mei_m:              cross priv_mode_m, mstatus_mie_one, mstatus_sie, stvec_mode, mideleg_mei_zero, mie_meie_one, mip_meip;
+    // Need to split into S-mode for delegated and M-mode when not
+    // Not delegated: Trap to M-mode from U-mode
+    cp_user_sei_m_nd: cross priv_mode_m, mret_insn, mstatus_mpp_u, mstatus_mie_zero, mstatus_sie, stvec_mode, mideleg_sei_zero, mie_seie_one, mip_seip;
+    // Delegated: Trap to S-mode from U-mode
+    cp_user_sei_s_d: cross priv_mode_s, sret_insn, sstatus_spp_u, mstatus_mie_zero, mstatus_sie, stvec_mode, mideleg_sei_one, mie_seie_one, mip_seip;
+    // MIE=1, not delegated: M-mode
+    cp_user_sei_m: cross priv_mode_m, mstatus_mie_one, mstatus_sie, stvec_mode, mideleg_sei_zero, mie_seie_one, mip_seip;
+    // MIE=1, delegated: S-mode
+    cp_user_sei_s: cross priv_mode_s, sret_insn, sstatus_spp_u, mstatus_mie_one, mstatus_sie, stvec_mode, mideleg_sei_one, mie_seie_one, mip_seip;
+    cp_wfi_u: cross priv_mode_m, mstatus_mie, mstatus_sie, mideleg_ones_zeros_real, mstatus_tw, mie_mtie_one;
+    cp_wfi_timeout_u: cross priv_mode_m, mstatus_mie, mstatus_sie, mideleg_ones, mstatus_tw_one, mie_mtie_one;
 
-    // cp_user_mti:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_mti_zero, mie_mtie, mip_mtip;
-    // cp_user_msi:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_msi_zero, mie_msie, mip_msip;
-    // cp_user_mei:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_mei_zero, mie_meie, mip_meip;
-    // cp_user_sei:                cross priv_mode_u, mstatus_mie, mstatus_sie, stvec_mode, mideleg_sei, mie_seie, mip_seip;
-    // cp_wfi_timeout_u:           cross priv_mode_u, wfi, mstatus_mie, mstatus_sie, mideleg_ones, mstatus_tw_one, mie_mtie, timeout;
 endgroup
 
 function void interruptss_sample(int hart, int issue, ins_t ins);
@@ -352,34 +540,34 @@ function void interruptss_sample(int hart, int issue, ins_t ins);
     //             ins.current.csr[12'h344][15:0]
     //         );
 
-    $display("=== InterruptsS Debug ===");
-    $display("PC: %h Instr: %s priv_mode=%b", ins.current.pc_rdata, ins.current.disass, ins.prev.mode);
-    $display("  mstatus: MIE=%b SIE=%b TW=%b mode: %b",
-                ins.prev.csr[12'h300][3], ins.prev.csr[12'h300][1],
-                ins.current.csr[12'h300][21], {ins.prev.mode_virt, ins.prev.mode});
-    $display(" NEW mstatus: MIE=%b SPIE=%b SIE=%b TW=%b mode: %b",
-            ins.current.csr[12'h300][3], ins.current.csr[12'h300][5],
-            ins.current.csr[12'h300][1],
-            ins.current.csr[12'h300][21], {ins.prev.mode_virt, ins.prev.mode});
-    $display("  mideleg: SEIE=%b STIE=%b SSIE=%b (full=%h)",
-                ins.current.csr[12'h303][9], ins.current.csr[12'h303][5],
-                ins.current.csr[12'h303][1], ins.current.csr[12'h303][15:0]);
-    $display("  mie: MEIE=%b SEIE=%b MTIE=%b STIE=%b MSIE=%b SSIE=%b (full=%h)",
-                ins.current.csr[12'h304][11], ins.current.csr[12'h304][9],
-                ins.current.csr[12'h304][7], ins.current.csr[12'h304][5],
-                ins.current.csr[12'h304][3], ins.current.csr[12'h304][1],
-                ins.current.csr[12'h304][15:0]);
-    $display("  mip: MEIP=%b SEIP=%b MTIP=%b STIP=%b MSIP=%b SSIP=%b (full=%h)",
-                ins.current.csr[12'h344][11], ins.current.csr[12'h344][9],
-                ins.current.csr[12'h344][7], ins.current.csr[12'h344][5],
-                ins.current.csr[12'h344][3], ins.current.csr[12'h344][1],
-                ins.current.csr[12'h344][15:0]);
-    $display("  sip: SEIP=%b STIP=%b SSIP=%b (full=%h)",
-                ins.current.csr[12'h144][9], ins.current.csr[12'h144][5],
-                ins.current.csr[12'h144][1], ins.current.csr[12'h144][15:0]);
-    $display("  mtvec.MODE=%b stvec.MODE=%b",
-                ins.current.csr[12'h305][1:0], ins.current.csr[12'h105][1:0]);
-    if (ins.current.trap)
-        $display("  TRAP! mcause=%h scause=%h", ins.current.csr[12'h342], ins.current.csr[12'h142]);
-    $display("");
+    // $display("=== InterruptsS Debug ===");
+    // $display("PC: %h Instr: %s priv_mode=%b", ins.current.pc_rdata, ins.current.disass, ins.prev.mode);
+    // $display("  mstatus: MIE=%b SIE=%b TW=%b mode: %b",
+    //             ins.prev.csr[12'h300][3], ins.prev.csr[12'h300][1],
+    //             ins.current.csr[12'h300][21], {ins.prev.mode_virt, ins.prev.mode});
+    // $display(" NEW mstatus: MIE=%b SPIE=%b SIE=%b TW=%b mode: %b",
+    //         ins.current.csr[12'h300][3], ins.current.csr[12'h300][5],
+    //         ins.current.csr[12'h300][1],
+    //         ins.current.csr[12'h300][21], {ins.prev.mode_virt, ins.prev.mode});
+    // $display("  mideleg: SEIE=%b STIE=%b SSIE=%b (full=%h)",
+    //             ins.current.csr[12'h303][9], ins.current.csr[12'h303][5],
+    //             ins.current.csr[12'h303][1], ins.current.csr[12'h303][15:0]);
+    // $display("  mie: MEIE=%b SEIE=%b MTIE=%b STIE=%b MSIE=%b SSIE=%b (full=%h)",
+    //             ins.current.csr[12'h304][11], ins.current.csr[12'h304][9],
+    //             ins.current.csr[12'h304][7], ins.current.csr[12'h304][5],
+    //             ins.current.csr[12'h304][3], ins.current.csr[12'h304][1],
+    //             ins.current.csr[12'h304][15:0]);
+    // $display("  mip: MEIP=%b SEIP=%b MTIP=%b STIP=%b MSIP=%b SSIP=%b (full=%h)",
+    //             ins.current.csr[12'h344][11], ins.current.csr[12'h344][9],
+    //             ins.current.csr[12'h344][7], ins.current.csr[12'h344][5],
+    //             ins.current.csr[12'h344][3], ins.current.csr[12'h344][1],
+    //             ins.current.csr[12'h344][15:0]);
+    // $display("  sip: SEIP=%b STIP=%b SSIP=%b (full=%h)",
+    //             ins.current.csr[12'h144][9], ins.current.csr[12'h144][5],
+    //             ins.current.csr[12'h144][1], ins.current.csr[12'h144][15:0]);
+    // $display("  mtvec.MODE=%b stvec.MODE=%b",
+    //             ins.current.csr[12'h305][1:0], ins.current.csr[12'h105][1:0]);
+    // if (ins.current.trap)
+    //     $display("  TRAP! mcause=%h scause=%h", ins.current.csr[12'h342], ins.current.csr[12'h142]);
+    // $display("");
 endfunction

--- a/coverpoints/priv/InterruptsSstc_coverage.svh
+++ b/coverpoints/priv/InterruptsSstc_coverage.svh
@@ -18,16 +18,13 @@ covergroup InterruptsSstc_cg with function sample(ins_t ins);
 
     // building blocks for the main coverpoints
 
-    sip_stip_one: coverpoint ins.current.csr[12'h144][5]{
-        bins one = {1};
-    }
     stimecmp_zero: coverpoint ins.current.csr[12'h14D] {
         bins zero = {0};
     }
-    mstatus_mie: coverpoint ins.current.csr[12'h300][3]  {
+    mstatus_mie: coverpoint ins.prev.csr[12'h300][3]  {
         // autofill 0/1
     }
-    mstatus_mie_one: coverpoint ins.current.csr[12'h300][3] {
+    mstatus_mie_one: coverpoint ins.prev.csr[12'h300][3] {
         bins one = {1};
     }
     mstatus_sie: coverpoint ins.current.csr[12'h300][1] {
@@ -35,6 +32,12 @@ covergroup InterruptsSstc_cg with function sample(ins_t ins);
     }
     mideleg_sti: coverpoint ins.current.csr[12'h303][5] {
         // autofill 0/1
+    }
+    mideleg_sti_zero: coverpoint ins.current.csr[12'h303][5] {
+        bins zero = {0};
+    }
+    mideleg_sti_one: coverpoint ins.current.csr[12'h303][5] {
+        bins one = {1};
     }
     mie_stie: coverpoint ins.current.csr[12'h304][5] {
         // autofill 0/1
@@ -68,10 +71,13 @@ covergroup InterruptsSstc_cg with function sample(ins_t ins);
     cp_machine_sti:     cross priv_mode_m, menvcfg_stce_one, mstatus_mie_one, mideleg_sti, mie_stie, stimecmp_zero;
     cp_machine_tm:      cross priv_mode_m, csrr, read_stimecmp, mcounteren_tm;
     cp_machine_stce:    cross priv_mode_m, csrr, read_stimecmp, menvcfg_stce;
-    cp_supervisor_sti:  cross priv_mode_s, menvcfg_stce, mstatus_mie, mstatus_sie, mideleg_sti, mie_stie, stimecmp_zero;
+
+    cp_supervisor_sti_deleg:   cross priv_mode_s, mstatus_mie, mstatus_sie, mideleg_sti_one, mie_stie, stimecmp_zero;
+    cp_supervisor_sti_nodeleg: cross priv_mode_m, menvcfg_stce, mstatus_mie_one, mideleg_sti_zero, mie_stie, stimecmp_zero;
     cp_supervisor_tm:   cross priv_mode_s, csrr, read_stimecmp, mcounteren_tm;
     cp_supervisor_stce: cross priv_mode_s, csrr, read_stimecmp, menvcfg_stce;
-    cp_user_sti:        cross priv_mode_u, menvcfg_stce, mstatus_mie, mstatus_sie, mideleg_sti, mie_stie, sip_stip_one;
+
+    cp_user_sti:         cross priv_mode_u, menvcfg_stce, mstatus_mie, mstatus_sie, mideleg_sti, mie_stie;
     cp_user_tm:         cross priv_mode_u, csrr, read_stimecmp, mcounteren_tm;
     cp_user_stce:       cross priv_mode_u, csrr, read_stimecmp, menvcfg_stce;
 

--- a/coverpoints/priv/InterruptsU_coverage.svh
+++ b/coverpoints/priv/InterruptsU_coverage.svh
@@ -17,8 +17,8 @@ covergroup InterruptsU_cg with function sample(ins_t ins);
 
     // building blocks for the main coverpoints
 
-    // Uses ins.prev instead of ins.current because Sail tracer updates CSRs after instruction retirement, so .current shows
-    // post-trap state. May revert to .current depending on implementation consensus
+    // Uses ins.prev instead of ins.current because RVVI updates CSRs after instruction retirement,
+    // so ins.current shows post-trap state while ins.prev shows pre-trap state.
     mstatus_mie: coverpoint ins.prev.csr[12'h300][3]  {
         // autofill 0/1
     }

--- a/coverpoints/priv/InterruptsU_coverage.svh
+++ b/coverpoints/priv/InterruptsU_coverage.svh
@@ -82,4 +82,3 @@ function void interruptsu_sample(int hart, int issue, ins_t ins);
     //     $display("  TRAP! mcause=%h", ins.current.csr[12'h342]);
     // $display("");
 endfunction
-

--- a/coverpoints/priv/InterruptsU_coverage.svh
+++ b/coverpoints/priv/InterruptsU_coverage.svh
@@ -16,9 +16,11 @@ covergroup InterruptsU_cg with function sample(ins_t ins);
     `include "general/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
-    mstatus_mie: coverpoint ins.prev.csr[12'h300][3]  { // TODO: I MADE IT PREV HERE
+
+    // Uses ins.prev instead of ins.current because Sail tracer updates CSRs after instruction retirement, so .current shows
+    // post-trap state. May revert to .current depending on implementation consensus
+    mstatus_mie: coverpoint ins.prev.csr[12'h300][3]  {
         // autofill 0/1
-        // bins one = {1}; // with this we are at full coverage
     }
     mstatus_tw:  coverpoint ins.current.csr[12'h300][21] {
         // autofill 0/1
@@ -54,26 +56,6 @@ covergroup InterruptsU_cg with function sample(ins_t ins);
     wfi: coverpoint ins.current.insn {
         bins wfi = {32'b0001000_00101_00000_000_00000_1110011};
     }
-    // timeout: coverpoint ins.current.csr[12'h344][7] iff (ins.trap == 1) {
-    //     bins no_timer_int = {0};
-    // }
-    // m_ext_intr: coverpoint ins.current.m_ext_intr {
-    //     bins mei = {1};
-    // }
-    // m_timer_intr: coverpoint ins.current.m_timer_intr {
-    //     bins mti = {1};
-    // }
-    // m_soft_intr: coverpoint ins.current.m_soft_intr {
-    //     bins msi = {1};
-    //}
-
-    // main coverpoints
-    // OG
-    // cp_user_mti:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_mtie_one, m_timer_intr, mip_mtip;
-    // cp_user_msi:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_msie_one, m_soft_intr,  mip_msip;
-    // cp_user_mei:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_meie_one, m_ext_intr,   mip_meip;
-    // cp_wfi:         cross priv_mode_u, wfi,        mstatus_mie, mstatus_tw, mie_mtie_one, m_timer_intr;
-    // cp_wfi_timeout: cross priv_mode_u, wfi,        mstatus_mie, mstatus_tw, mie_mtie_one, timeout;
 
     cp_user_mti:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_mtie_one, mip_mtip;
     cp_user_msi:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_msie_one,  mip_msip;
@@ -86,18 +68,18 @@ endgroup
 function void interruptsu_sample(int hart, int issue, ins_t ins);
     InterruptsU_cg.sample(ins);
 
-    $display("=== InterruptsU Debug ===");
-    $display("PC: %h Instr: %s", ins.current.pc_rdata, ins.current.disass);
-    $display("  mstatus.MIE=%b mstatus.TW=%b mode: %b, vector: %b",
-                ins.prev.csr[12'h300][3], ins.current.csr[12'h300][21], {ins.prev.mode_virt, ins.prev.mode}, {ins.current.csr[12'h305][1:0]});
-    $display("  mie: MEIE=%b MTIE=%b MSIE=%b (full=%h)",
-                ins.current.csr[12'h304][11], ins.current.csr[12'h304][7],
-                ins.current.csr[12'h304][3], ins.current.csr[12'h304][15:0]);
-    $display("  mip: MEIP=%b MTIP=%b MSIP=%b (full=%h)",
-                ins.current.csr[12'h344][11], ins.current.csr[12'h344][7],
-                ins.current.csr[12'h344][3], ins.current.csr[12'h344]);
-    if (ins.current.trap)
-        $display("  TRAP! mcause=%h", ins.current.csr[12'h342]);
-    $display("");
+    // $display("=== InterruptsU Debug ===");
+    // $display("PC: %h Instr: %s", ins.current.pc_rdata, ins.current.disass);
+    // $display("  mstatus.MIE=%b mstatus.TW=%b mode: %b, vector: %b",
+    //             ins.prev.csr[12'h300][3], ins.current.csr[12'h300][21], {ins.prev.mode_virt, ins.prev.mode}, {ins.current.csr[12'h305][1:0]});
+    // $display("  mie: MEIE=%b MTIE=%b MSIE=%b (full=%h)",
+    //             ins.current.csr[12'h304][11], ins.current.csr[12'h304][7],
+    //             ins.current.csr[12'h304][3], ins.current.csr[12'h304][15:0]);
+    // $display("  mip: MEIP=%b MTIP=%b MSIP=%b (full=%h)",
+    //             ins.current.csr[12'h344][11], ins.current.csr[12'h344][7],
+    //             ins.current.csr[12'h344][3], ins.current.csr[12'h344]);
+    // if (ins.current.trap)
+    //     $display("  TRAP! mcause=%h", ins.current.csr[12'h342]);
+    // $display("");
 endfunction
 

--- a/coverpoints/priv/InterruptsU_coverage.svh
+++ b/coverpoints/priv/InterruptsU_coverage.svh
@@ -16,11 +16,9 @@ covergroup InterruptsU_cg with function sample(ins_t ins);
     `include "general/RISCV_coverage_standard_coverpoints.svh"
 
     // building blocks for the main coverpoints
-
-    // Uses ins.prev instead of ins.current because RVVI updates CSRs after instruction retirement,
-    // so ins.current shows post-trap state while ins.prev shows pre-trap state.
-    mstatus_mie: coverpoint ins.prev.csr[12'h300][3]  {
+    mstatus_mie: coverpoint ins.prev.csr[12'h300][3]  { // TODO: I MADE IT PREV HERE
         // autofill 0/1
+        // bins one = {1}; // with this we are at full coverage
     }
     mstatus_tw:  coverpoint ins.current.csr[12'h300][21] {
         // autofill 0/1
@@ -56,32 +54,50 @@ covergroup InterruptsU_cg with function sample(ins_t ins);
     wfi: coverpoint ins.current.insn {
         bins wfi = {32'b0001000_00101_00000_000_00000_1110011};
     }
+    // timeout: coverpoint ins.current.csr[12'h344][7] iff (ins.trap == 1) {
+    //     bins no_timer_int = {0};
+    // }
+    // m_ext_intr: coverpoint ins.current.m_ext_intr {
+    //     bins mei = {1};
+    // }
+    // m_timer_intr: coverpoint ins.current.m_timer_intr {
+    //     bins mti = {1};
+    // }
+    // m_soft_intr: coverpoint ins.current.m_soft_intr {
+    //     bins msi = {1};
+    //}
 
+    // main coverpoints
+    // OG
+    // cp_user_mti:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_mtie_one, m_timer_intr, mip_mtip;
+    // cp_user_msi:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_msie_one, m_soft_intr,  mip_msip;
+    // cp_user_mei:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_meie_one, m_ext_intr,   mip_meip;
+    // cp_wfi:         cross priv_mode_u, wfi,        mstatus_mie, mstatus_tw, mie_mtie_one, m_timer_intr;
+    // cp_wfi_timeout: cross priv_mode_u, wfi,        mstatus_mie, mstatus_tw, mie_mtie_one, timeout;
 
     cp_user_mti:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_mtie_one, mip_mtip;
     cp_user_msi:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_msie_one,  mip_msip;
-
-    // Note: External interrupts (MEI) not supported in Sail simulator yet
     cp_user_mei:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_meie_one,   mip_meip;
     cp_wfi:         cross priv_mode_u, wfi,        mstatus_mie, mstatus_tw, mie_mtie_one;
-    cp_wfi_timeout: cross priv_mode_u, wfi,        mstatus_mie, mstatus_tw_one, mie_mtie;
+    cp_wfi_timeout: cross priv_mode_u, wfi,        mstatus_mie, mstatus_tw, mie_mtie_one;
 
 endgroup
 
 function void interruptsu_sample(int hart, int issue, ins_t ins);
     InterruptsU_cg.sample(ins);
 
-    // $display("=== InterruptsU Debug ===");
-    // $display("PC: %h Instr: %s", ins.current.pc_rdata, ins.current.disass);
-    // $display("  mstatus.MIE=%b mstatus.TW=%b mode: %b, vector: %b",
-    //             ins.prev.csr[12'h300][3], ins.current.csr[12'h300][21], {ins.prev.mode_virt, ins.prev.mode}, {ins.current.csr[12'h305][1:0]});
-    // $display("  mie: MEIE=%b MTIE=%b MSIE=%b (full=%h)",
-    //             ins.current.csr[12'h304][11], ins.current.csr[12'h304][7],
-    //             ins.current.csr[12'h304][3], ins.current.csr[12'h304][15:0]);
-    // $display("  mip: MEIP=%b MTIP=%b MSIP=%b (full=%h)",
-    //             ins.current.csr[12'h344][11], ins.current.csr[12'h344][7],
-    //             ins.current.csr[12'h344][3], ins.current.csr[12'h344]);
-    // if (ins.current.trap)
-    //     $display("  TRAP! mcause=%h", ins.current.csr[12'h342]);
-    // $display("");
+    $display("=== InterruptsU Debug ===");
+    $display("PC: %h Instr: %s", ins.current.pc_rdata, ins.current.disass);
+    $display("  mstatus.MIE=%b mstatus.TW=%b mode: %b, vector: %b",
+                ins.prev.csr[12'h300][3], ins.current.csr[12'h300][21], {ins.prev.mode_virt, ins.prev.mode}, {ins.current.csr[12'h305][1:0]});
+    $display("  mie: MEIE=%b MTIE=%b MSIE=%b (full=%h)",
+                ins.current.csr[12'h304][11], ins.current.csr[12'h304][7],
+                ins.current.csr[12'h304][3], ins.current.csr[12'h304][15:0]);
+    $display("  mip: MEIP=%b MTIP=%b MSIP=%b (full=%h)",
+                ins.current.csr[12'h344][11], ins.current.csr[12'h344][7],
+                ins.current.csr[12'h344][3], ins.current.csr[12'h344]);
+    if (ins.current.trap)
+        $display("  TRAP! mcause=%h", ins.current.csr[12'h342]);
+    $display("");
 endfunction
+

--- a/coverpoints/priv/InterruptsU_coverage.svh
+++ b/coverpoints/priv/InterruptsU_coverage.svh
@@ -57,11 +57,14 @@ covergroup InterruptsU_cg with function sample(ins_t ins);
         bins wfi = {32'b0001000_00101_00000_000_00000_1110011};
     }
 
+
     cp_user_mti:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_mtie_one, mip_mtip;
     cp_user_msi:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_msie_one,  mip_msip;
+
+    // Note: External interrupts (MEI) not supported in Sail simulator yet
     cp_user_mei:    cross priv_mode_u, mtvec_mode, mstatus_mie, mie_meie_one,   mip_meip;
     cp_wfi:         cross priv_mode_u, wfi,        mstatus_mie, mstatus_tw, mie_mtie_one;
-    cp_wfi_timeout: cross priv_mode_u, wfi,        mstatus_mie, mstatus_tw, mie_mtie_one;
+    cp_wfi_timeout: cross priv_mode_u, wfi,        mstatus_mie, mstatus_tw_one, mie_mtie;
 
 endgroup
 

--- a/generators/testgen/src/testgen/asm/interrupts.py
+++ b/generators/testgen/src/testgen/asm/interrupts.py
@@ -28,7 +28,6 @@ def set_mtimer_int(r_mtime: int, r_mtimecmp: int, r_temp: int, r_temp2: int) -> 
         f"LREG x{r_temp}, 0(x{r_mtime})",
         f"SREG x{r_temp}, 0(x{r_mtimecmp})",
         "#elif __riscv_xlen == 32",
-<<<<<<< HEAD
         "# Write sequence to prevent spurious interrupts",
         "# Read mtime (new comparand will be in temp2:temp)",
         f"lw x{r_temp}, 0(x{r_mtime}) # mtime[31:0] -> low word",
@@ -38,7 +37,6 @@ def set_mtimer_int(r_mtime: int, r_mtimecmp: int, r_temp: int, r_temp2: int) -> 
         f"sw x{r_mtime}, 0(x{r_mtimecmp}) # Step 1: Write -1 to low (no smaller than old)",
         f"sw x{r_temp2}, 4(x{r_mtimecmp}) # Step 2: Write high word (no smaller than new)",
         f"sw x{r_temp}, 0(x{r_mtimecmp}) # Step 3: Write low word (new value)",
-=======
         # Write sequence to prevent spurious interrupts
         # Read mtime (new comparand will be in temp2:temp)
         f"lw x{r_temp}, 0(x{r_mtime})",  # mtime[31:0] -> low word
@@ -75,6 +73,70 @@ def clr_mtimer_int(r_temp: int, r_mtimecmp: int) -> list[str]:
     ]
 
 
+# def set_mtimer_int_soon(
+#     r_mtime: int, r_mtimecmp: int, r_temp1: int, r_temp2: int, r_temp3: int, r_temp4: int
+# ) -> list[str]:
+#     """Generate assembly to set timer to fire soon (mtimecmp = mtime + DELAY).
+
+#     Uses LI + add to handle delays > 2047 (addi 12-bit immediate limit).
+
+
+#     Args:
+#         r_mtime: Register for MTIME address
+#         r_mtimecmp: Register for MTIMECMP address
+#         r_temp1, r_temp2, r_temp3, r_temp4: Temp registers for calculations
+#     """
+#     return [
+#         f"{INDENT}# Cause machine timer interrupt soon",
+#         f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
+#         f"LA(x{r_mtimecmp}, RVMODEL_MTIMECMP_ADDRESS)",
+#         "#if __riscv_xlen == 64",
+#         "# Read current time and add delay",
+#         "# Load delay first for more accurate timing",
+#         f"LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",
+#         "# Then read mtime",
+#         f"ld x{r_temp1}, 0(x{r_mtime})",
+#         f"add x{r_temp1}, x{r_temp1}, x{r_temp2}",
+#         f"sd x{r_temp1}, 0(x{r_mtimecmp})",
+#         "#elif __riscv_xlen == 32",
+#         f"LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
+#         "# Read current time (64-bit on RV32)",
+#         f"lw x{r_temp1}, 0(x{r_mtime})",  # mtime[31:0]
+#         f"lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32]
+#         "# Add delay to 64-bit value",
+#         f"add x{r_temp3}, x{r_temp1}, x{r_temp4}",  # new_low = mtime_low + delay
+#         f"sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",  # carry bit
+#         f"add x{r_temp2}, x{r_temp2}, x{r_temp4}",  # new_high = mtime_high + carry
+#         "# Per RISC-V Spec 3.2.1: Write sequence to prevent spurious interrupt",
+#         "# New comparand is in temp2:temp3",
+#         f"LI(x{r_temp1}, -1)",
+#         f"sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
+#         f"sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
+#         f"sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
+#         # Read current time and add delay
+#         # Load delay first for more accurate timing
+#         f"LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",
+#         # Then read mtime
+#         f"ld x{r_temp1}, 0(x{r_mtime})",
+#         f"add x{r_temp1}, x{r_temp1}, x{r_temp2}",
+#         f"sd x{r_temp1}, 0(x{r_mtimecmp})",
+#         "#elif __riscv_xlen == 32",
+#         f"LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
+#         # Read current time (64-bit on RV32)
+#         f"lw x{r_temp1}, 0(x{r_mtime})",  # mtime[31:0]
+#         f"lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32]
+#         # Add delay to 64-bit value
+#         f"add x{r_temp3}, x{r_temp1}, x{r_temp4}",  # new_low = mtime_low + delay
+#         f"sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",  # carry bit
+#         f"add x{r_temp2}, x{r_temp2}, x{r_temp4}",  # new_high = mtime_high + carry
+#         # Per RISC-V Spec 3.2.1: Write sequence to prevent spurious interrupt
+#         # New comparand is in temp2:temp3
+#         f"LI(x{r_temp1}, -1)",
+#         f"sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
+#         f"sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
+#         f"sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
+#         "#endif",
+#     ]
 def set_mtimer_int_soon(
     r_mtime: int, r_mtimecmp: int, r_temp1: int, r_temp2: int, r_temp3: int, r_temp4: int
 ) -> list[str]:
@@ -93,52 +155,25 @@ def set_mtimer_int_soon(
         f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
         f"LA(x{r_mtimecmp}, RVMODEL_MTIMECMP_ADDRESS)",
         "#if __riscv_xlen == 64",
-<<<<<<< HEAD
         "# Read current time and add delay",
-        "# Load delay first for more accurate timing",
         f"LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",
-        "# Then read mtime",
-        f"ld x{r_temp1}, 0(x{r_mtime})",
+        f"LREG x{r_temp1}, 0(x{r_mtime})",  # Use LREG macro
         f"add x{r_temp1}, x{r_temp1}, x{r_temp2}",
-        f"sd x{r_temp1}, 0(x{r_mtimecmp})",
+        f"SREG x{r_temp1}, 0(x{r_mtimecmp})",  # Use SREG macro
         "#elif __riscv_xlen == 32",
-        f"LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
+        f"LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",
         "# Read current time (64-bit on RV32)",
-        f"lw x{r_temp1}, 0(x{r_mtime})",  # mtime[31:0]
-        f"lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32]
+        f"lw x{r_temp1}, 0(x{r_mtime})",
+        f"lw x{r_temp2}, 4(x{r_mtime})",
         "# Add delay to 64-bit value",
-        f"add x{r_temp3}, x{r_temp1}, x{r_temp4}",  # new_low = mtime_low + delay
-        f"sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",  # carry bit
-        f"add x{r_temp2}, x{r_temp2}, x{r_temp4}",  # new_high = mtime_high + carry
+        f"add x{r_temp3}, x{r_temp1}, x{r_temp4}",
+        f"sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",
+        f"add x{r_temp2}, x{r_temp2}, x{r_temp4}",
         "# Per RISC-V Spec 3.2.1: Write sequence to prevent spurious interrupt",
-        "# New comparand is in temp2:temp3",
         f"LI(x{r_temp1}, -1)",
-        f"sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
-        f"sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
-        f"sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
-=======
-        # Read current time and add delay
-        # Load delay first for more accurate timing
-        f"LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",
-        # Then read mtime
-        f"ld x{r_temp1}, 0(x{r_mtime})",
-        f"add x{r_temp1}, x{r_temp1}, x{r_temp2}",
-        f"sd x{r_temp1}, 0(x{r_mtimecmp})",
-        "#elif __riscv_xlen == 32",
-        f"LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
-        # Read current time (64-bit on RV32)
-        f"lw x{r_temp1}, 0(x{r_mtime})",  # mtime[31:0]
-        f"lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32]
-        # Add delay to 64-bit value
-        f"add x{r_temp3}, x{r_temp1}, x{r_temp4}",  # new_low = mtime_low + delay
-        f"sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",  # carry bit
-        f"add x{r_temp2}, x{r_temp2}, x{r_temp4}",  # new_high = mtime_high + carry
-        # Per RISC-V Spec 3.2.1: Write sequence to prevent spurious interrupt
-        # New comparand is in temp2:temp3
-        f"LI(x{r_temp1}, -1)",
-        f"sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
-        f"sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
-        f"sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
+        f"sw x{r_temp1}, 0(x{r_mtimecmp})",
+        f"sw x{r_temp2}, 4(x{r_mtimecmp})",
+        f"sw x{r_temp3}, 0(x{r_mtimecmp})",
         "#endif",
         "#endif",
     ]
@@ -442,4 +477,44 @@ def set_stimer_int_soon_sstc(r_mtime: int, r_temp1: int, r_temp2: int, r_temp3: 
         f"csrw stimecmp, x{r_temp3}",
         f"csrw stimecmph, x{r_temp2}",
         "#endif",
+    ]
+
+
+def set_stimer_mmode(r_scratch: int) -> list[str]:
+    """Set supervisor timer interrupt in M-mode (direct mip write).
+
+    This function directly writes mip.STIP without mode transitions.
+    Must be called from M-mode.
+
+    Args:
+        r_scratch: Scratch register for loading immediate
+
+    Returns:
+        List of assembly instructions
+    """
+    return [
+        f"{INDENT}# Set supervisor timer interrupt (M-mode direct)",
+        f"LI(x{r_scratch}, 0x20)",  # STIP bit (bit 5)
+        f"CSRS(mip, x{r_scratch})",
+        "nop",
+    ]
+
+
+def clr_stimer_mmode(r_scratch: int) -> list[str]:
+    """Clear supervisor timer interrupt in M-mode (direct mip write).
+
+    This function directly clears mip.STIP without mode transitions.
+    Must be called from M-mode.
+
+    Args:
+        r_scratch: Scratch register for loading immediate
+
+    Returns:
+        List of assembly instructions
+    """
+    return [
+        f"{INDENT}# Clear supervisor timer interrupt (M-mode direct)",
+        f"LI(x{r_scratch}, 0x20)",  # STIP bit (bit 5)
+        f"CSRC(mip, x{r_scratch})",
+        "nop",
     ]

--- a/generators/testgen/src/testgen/asm/interrupts.py
+++ b/generators/testgen/src/testgen/asm/interrupts.py
@@ -41,14 +41,13 @@ def set_mtimer_int(r_mtime: int, r_mtimecmp: int, r_temp: int, r_temp2: int) -> 
 =======
         # Write sequence to prevent spurious interrupts
         # Read mtime (new comparand will be in temp2:temp)
-        f"    lw x{r_temp}, 0(x{r_mtime})",  # mtime[31:0] -> low word
-        f"    lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32] -> high word
+        f"lw x{r_temp}, 0(x{r_mtime})",  # mtime[31:0] -> low word
+        f"lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32] -> high word
         # 3-step write sequence (new comparand is in temp2:temp)
-        f"    LI(x{r_mtime}, -1)",  # Reuse r_mtime for -1
-        f"    sw x{r_mtime}, 0(x{r_mtimecmp})",  # Step 1: Write -1 to low (no smaller than old)
-        f"    sw x{r_temp2}, 4(x{r_mtimecmp})",  # Step 2: Write high word (no smaller than new)
-        f"    sw x{r_temp}, 0(x{r_mtimecmp})",  # Step 3: Write low word (new value)
->>>>>>> 9e4cabd7a (udpated interrupt tests)
+        f"LI(x{r_mtime}, -1)",  # Reuse r_mtime for -1
+        f"sw x{r_mtime}, 0(x{r_mtimecmp})",  # Step 1: Write -1 to low (no smaller than old)
+        f"sw x{r_temp2}, 4(x{r_mtimecmp})",  # Step 2: Write high word (no smaller than new)
+        f"sw x{r_temp}, 0(x{r_mtimecmp})",  # Step 3: Write low word (new value)
         "#endif",
         "#endif",
     ]
@@ -120,27 +119,26 @@ def set_mtimer_int_soon(
 =======
         # Read current time and add delay
         # Load delay first for more accurate timing
-        f"    LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",
+        f"LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",
         # Then read mtime
-        f"    ld x{r_temp1}, 0(x{r_mtime})",
-        f"    add x{r_temp1}, x{r_temp1}, x{r_temp2}",
-        f"    sd x{r_temp1}, 0(x{r_mtimecmp})",
+        f"ld x{r_temp1}, 0(x{r_mtime})",
+        f"add x{r_temp1}, x{r_temp1}, x{r_temp2}",
+        f"sd x{r_temp1}, 0(x{r_mtimecmp})",
         "#elif __riscv_xlen == 32",
-        f"    LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
+        f"LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
         # Read current time (64-bit on RV32)
-        f"    lw x{r_temp1}, 0(x{r_mtime})",  # mtime[31:0]
-        f"    lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32]
+        f"lw x{r_temp1}, 0(x{r_mtime})",  # mtime[31:0]
+        f"lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32]
         # Add delay to 64-bit value
-        f"    add x{r_temp3}, x{r_temp1}, x{r_temp4}",  # new_low = mtime_low + delay
-        f"    sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",  # carry bit
-        f"    add x{r_temp2}, x{r_temp2}, x{r_temp4}",  # new_high = mtime_high + carry
+        f"add x{r_temp3}, x{r_temp1}, x{r_temp4}",  # new_low = mtime_low + delay
+        f"sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",  # carry bit
+        f"add x{r_temp2}, x{r_temp2}, x{r_temp4}",  # new_high = mtime_high + carry
         # Per RISC-V Spec 3.2.1: Write sequence to prevent spurious interrupt
         # New comparand is in temp2:temp3
-        f"    LI(x{r_temp1}, -1)",
-        f"    sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
-        f"    sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
-        f"    sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
->>>>>>> 9e4cabd7a (udpated interrupt tests)
+        f"LI(x{r_temp1}, -1)",
+        f"sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
+        f"sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
+        f"sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
         "#endif",
         "#endif",
     ]

--- a/generators/testgen/src/testgen/asm/interrupts.py
+++ b/generators/testgen/src/testgen/asm/interrupts.py
@@ -73,70 +73,6 @@ def clr_mtimer_int(r_temp: int, r_mtimecmp: int) -> list[str]:
     ]
 
 
-# def set_mtimer_int_soon(
-#     r_mtime: int, r_mtimecmp: int, r_temp1: int, r_temp2: int, r_temp3: int, r_temp4: int
-# ) -> list[str]:
-#     """Generate assembly to set timer to fire soon (mtimecmp = mtime + DELAY).
-
-#     Uses LI + add to handle delays > 2047 (addi 12-bit immediate limit).
-
-
-#     Args:
-#         r_mtime: Register for MTIME address
-#         r_mtimecmp: Register for MTIMECMP address
-#         r_temp1, r_temp2, r_temp3, r_temp4: Temp registers for calculations
-#     """
-#     return [
-#         f"{INDENT}# Cause machine timer interrupt soon",
-#         f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
-#         f"LA(x{r_mtimecmp}, RVMODEL_MTIMECMP_ADDRESS)",
-#         "#if __riscv_xlen == 64",
-#         "# Read current time and add delay",
-#         "# Load delay first for more accurate timing",
-#         f"LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",
-#         "# Then read mtime",
-#         f"ld x{r_temp1}, 0(x{r_mtime})",
-#         f"add x{r_temp1}, x{r_temp1}, x{r_temp2}",
-#         f"sd x{r_temp1}, 0(x{r_mtimecmp})",
-#         "#elif __riscv_xlen == 32",
-#         f"LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
-#         "# Read current time (64-bit on RV32)",
-#         f"lw x{r_temp1}, 0(x{r_mtime})",  # mtime[31:0]
-#         f"lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32]
-#         "# Add delay to 64-bit value",
-#         f"add x{r_temp3}, x{r_temp1}, x{r_temp4}",  # new_low = mtime_low + delay
-#         f"sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",  # carry bit
-#         f"add x{r_temp2}, x{r_temp2}, x{r_temp4}",  # new_high = mtime_high + carry
-#         "# Per RISC-V Spec 3.2.1: Write sequence to prevent spurious interrupt",
-#         "# New comparand is in temp2:temp3",
-#         f"LI(x{r_temp1}, -1)",
-#         f"sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
-#         f"sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
-#         f"sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
-#         # Read current time and add delay
-#         # Load delay first for more accurate timing
-#         f"LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",
-#         # Then read mtime
-#         f"ld x{r_temp1}, 0(x{r_mtime})",
-#         f"add x{r_temp1}, x{r_temp1}, x{r_temp2}",
-#         f"sd x{r_temp1}, 0(x{r_mtimecmp})",
-#         "#elif __riscv_xlen == 32",
-#         f"LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
-#         # Read current time (64-bit on RV32)
-#         f"lw x{r_temp1}, 0(x{r_mtime})",  # mtime[31:0]
-#         f"lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32]
-#         # Add delay to 64-bit value
-#         f"add x{r_temp3}, x{r_temp1}, x{r_temp4}",  # new_low = mtime_low + delay
-#         f"sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",  # carry bit
-#         f"add x{r_temp2}, x{r_temp2}, x{r_temp4}",  # new_high = mtime_high + carry
-#         # Per RISC-V Spec 3.2.1: Write sequence to prevent spurious interrupt
-#         # New comparand is in temp2:temp3
-#         f"LI(x{r_temp1}, -1)",
-#         f"sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
-#         f"sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
-#         f"sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
-#         "#endif",
-#     ]
 def set_mtimer_int_soon(
     r_mtime: int, r_mtimecmp: int, r_temp1: int, r_temp2: int, r_temp3: int, r_temp4: int
 ) -> list[str]:
@@ -177,112 +113,6 @@ def set_mtimer_int_soon(
         "#endif",
         "#endif",
     ]
-
-
-# def set_stimer_int(r_mtime: int, r_temp: int, r_temp2: int, r_scratch: int) -> list[str]:
-#     """Set supervisor timer interrupt.
-
-#     Checks menvcfg.STCE at runtime:
-#     - If STCE=1: Use Sstc method (write stimecmp from S-mode)
-#     - If STCE=0: Use legacy method (write mip.STIP from M-mode)
-#     """
-#     return [
-#         f"{INDENT}# Set supervisor timer interrupt",
-#         f"{INDENT}# Check if Sstc is enabled",
-#         f"CSRR x{r_scratch}, menvcfg",
-#         "#if __riscv_xlen == 64",
-#         f"SRLI x{r_scratch}, x{r_scratch}, 63",  # STCE is bit 63
-#         "#else",
-#         f"SRLI x{r_scratch}, x{r_scratch}, 31",  # STCE is bit 31 on RV32
-#         "#endif",
-#         f"ANDI x{r_scratch}, x{r_scratch}, 0x1",
-#         f"BEQZ x{r_scratch}, 1f # If STCE=0, use non sstc method",
-#         "",
-#         f"{INDENT}# Sstc method: Write stimecmp",
-#         f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
-#         f"LREG x{r_temp}, 0(x{r_mtime})",
-#         f"csrw stimecmp, x{r_temp}",
-#         "nop",
-#         "#if __riscv_xlen == 32",
-#         f"LI(x{r_temp}, -1)",
-#         f"csrw stimecmp, x{r_temp}",
-#         f"lw x{r_temp2}, 4(x{r_mtime})",
-#         f"lw x{r_temp}, 0(x{r_mtime})",
-#         f"csrw stimecmph, x{r_temp2}",
-#         f"csrw stimecmp, x{r_temp}",
-#         "nop",
-#         "#endif",
-#         "j 2f",
-#         "",
-#         "1: # Legacy method: Set mip.STIP from M-mode",
-#         f"LI(x{r_temp}, 0x20)",  # STIP = bit 5
-#         f"csrrs x{r_temp}, mip, x{r_temp}",
-#         "",
-#         "2: # Continue",
-#     ]
-
-# def set_stimer_int(r_mtime: int, r_temp: int, r_temp2: int, r_scratch: int, r_stce: int = None) -> list[str]:
-#     """Set supervisor timer interrupt.
-
-#     Args:
-#         r_stce: Optional - register containing pre-read menvcfg.STCE value (0 or 1)
-#                 If None, will read menvcfg in M-mode
-
-#     If STCE=1: Use Sstc method (write stimecmp - works in S-mode)
-#     If STCE=0: Use legacy method (write mip.STIP - requires M-mode)
-#     """
-#     lines = [
-#         f"{INDENT}# Set supervisor timer interrupt",
-#     ]
-
-#     # If STCE not pre-read, read menvcfg (assumes M-mode)
-#     if r_stce is None:
-#         lines.extend([
-#             f"{INDENT}# Check if Sstc is enabled",
-#             f"CSRR x{r_scratch}, menvcfg",
-#             "#if __riscv_xlen == 64",
-#             f"SRLI x{r_scratch}, x{r_scratch}, 63",  # STCE is bit 63
-#             "#else",
-#             f"SRLI x{r_scratch}, x{r_scratch}, 31",  # STCE is bit 31
-#             "#endif",
-#             f"ANDI x{r_scratch}, x{r_scratch}, 0x1",
-#         ])
-#         check_reg = r_scratch
-#     else:
-#         check_reg = r_stce
-
-#     lines.extend([
-#         f"BEQZ x{check_reg}, 1f # If STCE=0, use legacy method",
-#         "",
-#         f"{INDENT}# Sstc method: Write stimecmp (works in S-mode)",
-#         f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
-#         f"LREG x{r_temp}, 0(x{r_mtime})",
-#         f"csrw stimecmp, x{r_temp}",
-#         "nop",
-#         "#if __riscv_xlen == 32",
-#         f"LI(x{r_temp}, -1)",
-#         f"csrw stimecmp, x{r_temp}",
-#         f"lw x{r_temp2}, 4(x{r_mtime})",
-#         f"lw x{r_temp}, 0(x{r_mtime})",
-#         f"csrw stimecmph, x{r_temp2}",
-#         f"csrw stimecmp, x{r_temp}",
-#         "nop",
-#         "#endif",
-#         "j 2f",
-#         "",
-#         "1: # Legacy method: Set mip.STIP (requires M-mode)",
-#         "RVTEST_GOTO_MMODE",
-#         f"LI(x{r_temp}, 0x20)",  # STIP bit
-#         f"csrrs x{r_temp}, mip, x{r_temp}",
-#         "# Clear MPIE to prevent MIE=1 after mret back to S-mode",
-#         f"LI(x{r_temp}, 0x80)",  # MPIE bit (bit 7)
-#         f"csrc mstatus, x{r_temp}",
-#         "RVTEST_GOTO_LOWER_MODE Smode",
-#         "",
-#         "2: # Continue",
-#     ])
-
-#     return lines
 
 
 def set_stimer_int(r_mtime: int, r_temp: int, r_temp2: int, r_scratch: int, r_stce: int) -> list[str]:
@@ -357,40 +187,6 @@ def set_stimer_int(r_mtime: int, r_temp: int, r_temp2: int, r_scratch: int, r_st
     return lines
 
 
-# def clr_stimer_int(r_temp: int, r_stimecmp: int, r_scratch: int) -> list[str]:
-#     """Clear supervisor timer interrupt.
-
-
-#     Checks menvcfg.STCE at runtime:
-#     - If STCE=1: Use Sstc method (write stimecmp = -1)
-#     - If STCE=0: Use legacy method (clear mip.STIP from M-mode)
-#     """
-#     return [
-#         f"{INDENT}# Clear supervisor timer interrupt",
-#         f"{INDENT}# Check if Sstc is enabled",
-#         f"CSRR x{r_scratch}, menvcfg",
-#         "#if __riscv_xlen == 64",
-#         f"SRLI x{r_scratch}, x{r_scratch}, 63",  # STCE is bit 63
-#         "#else",
-#         f"SRLI x{r_scratch}, x{r_scratch}, 31",  # STCE is bit 31 on RV32
-#         "#endif",
-#         f"ANDI x{r_scratch}, x{r_scratch}, 0x1",
-#         f"BEQZ x{r_scratch}, 1f # If STCE=0, use non sstc method",
-#         "",
-#         f"{INDENT}# Sstc method: Write stimecmp = -1 (max value)",
-#         f"LI(x{r_temp}, -1)",
-#         f"csrw stimecmp, x{r_temp}",
-#         "#if __riscv_xlen == 32",
-#         f"csrw stimecmph, x{r_temp}",  # Also clear high word
-#         "#endif",
-#         "j 2f",
-#         "",
-#         "1: # Legacy method: Clear mip.STIP from M-mode",
-#         f"LI(x{r_temp}, 0x20)",  # STIP = bit 5
-#         f"csrrc x{r_temp}, mip, x{r_temp}",
-#         "",
-#         "2: # Continue",
-#     ]
 def clr_stimer_int(r_temp: int, r_stimecmp: int, r_scratch: int, r_stce: int) -> list[str]:
     """Clear supervisor timer interrupt.
 
@@ -517,4 +313,159 @@ def clr_stimer_mmode(r_scratch: int) -> list[str]:
         f"LI(x{r_scratch}, 0x20)",  # STIP bit (bit 5)
         f"CSRC(mip, x{r_scratch})",
         "nop",
+    ]
+
+
+def set_menvcfg_stce(r_scratch: int, enable: bool) -> list[str]:
+    """Set or clear menvcfg.STCE (bit 63 on RV64, bit 31 of menvcfgh on RV32).
+
+    Must be called from M-mode.
+
+    Args:
+        r_scratch: Scratch register
+        enable: True to set STCE=1, False to clear STCE=0
+    """
+    op = "CSRS" if enable else "CSRC"
+    return [
+        f"{INDENT}# {'Enable' if enable else 'Disable'} menvcfg.STCE",
+        "#if __riscv_xlen == 64",
+        f"    LI(x{r_scratch}, 1)",
+        f"    slli x{r_scratch}, x{r_scratch}, 63",
+        f"    {op}(menvcfg, x{r_scratch})",
+        "#else",
+        f"    LI(x{r_scratch}, 0x80000000)",
+        f"    {op}(menvcfgh, x{r_scratch})",
+        "#endif",
+    ]
+
+
+def set_stimecmp_max(r_scratch: int) -> list[str]:
+    """Write stimecmp = -1 (max) to disable Sstc timer interrupt. M-mode only."""
+    return [
+        f"{INDENT}# Disable Sstc timer: stimecmp = -1",
+        f"LI(x{r_scratch}, -1)",
+        f"CSRW(stimecmp, x{r_scratch})",
+        "#if __riscv_xlen == 32",
+        f"    CSRW(stimecmph, x{r_scratch})",
+        "#endif",
+    ]
+
+
+def set_stimecmp_zero() -> list[str]:
+    """Write stimecmp = 0 to immediately assert Sstc timer interrupt.
+
+    stimecmp=0 guarantees mtime > stimecmp (mtime is always > 0 after reset).
+    This can serve as the coverage sample instruction: the write makes
+    ins.current.csr[stimecmp]=0 visible to the coverage model, while the
+    interrupt fires at the NEXT instruction boundary, not before.
+    """
+    return [
+        f"{INDENT}# Assert Sstc timer: stimecmp = 0  (interrupt fires at next boundary)",
+        "CSRW(stimecmp, zero)",
+    ]
+
+
+def set_stimecmp_soon(r_scratch: int, r_time: int, r_hi: int) -> list[str]:
+    """Write stimecmp = TIME + 500 from M-mode so the interrupt fires after entering U-mode.
+
+    Disables stimecmp first (-1) to prevent a spurious interrupt during
+    the read-modify-write sequence.  Falls back to stimecmp=0 if
+    RVMODEL_MTIME_ADDRESS is not defined.
+
+    Args:
+        r_scratch: scratch register (clobbered)
+        r_time:    scratch for MTIME address / RV32 new_lo (clobbered)
+        r_hi:      scratch for RV32 old_hi / new_hi (clobbered; unused on RV64)
+    """
+    return [
+        f"{INDENT}# stimecmp = TIME + 500: interrupt fires after entering U-mode",
+        *set_stimecmp_max(r_scratch),
+        "#ifdef RVMODEL_MTIME_ADDRESS",
+        "    #if __riscv_xlen == 64",
+        f"        LA(x{r_time}, RVMODEL_MTIME_ADDRESS)",
+        f"        LREG x{r_scratch}, 0(x{r_time})",
+        f"        addi x{r_scratch}, x{r_scratch}, 500",
+        f"        CSRW(stimecmp, x{r_scratch})",
+        "    #else",
+        f"        LA(x{r_time}, RVMODEL_MTIME_ADDRESS)",
+        f"        lw x{r_scratch}, 0(x{r_time})",  # old_lo
+        f"        lw x{r_hi}, 4(x{r_time})",  # old_hi
+        f"        addi x{r_time}, x{r_scratch}, 500",  # new_lo (reuse r_time)
+        f"        sltu x{r_scratch}, x{r_time}, x{r_scratch}",  # carry
+        f"        add x{r_hi}, x{r_hi}, x{r_scratch}",  # new_hi
+        f"        CSRW(stimecmph, x{r_hi})",
+        f"        CSRW(stimecmp, x{r_time})",
+        "    #endif",
+        "#else",
+        "    CSRW(stimecmp, zero)",
+        "#endif",
+    ]
+
+
+def set_mpie(r_scratch: int, enable: bool) -> list[str]:
+    """Set or clear mstatus.MPIE (bit 7) to control MIE after the next mret.
+
+    Must be called from M-mode before RVTEST_GOTO_LOWER_MODE.
+    After mret: MIE = old MPIE.
+    Uses csrrs/csrrc with a register because bit 7 exceeds the 5-bit CSRxI immediate limit.
+
+    Args:
+        r_scratch: Scratch register to hold the MPIE bitmask
+        enable: True → MPIE=1 (MIE=1 in lower mode), False → MPIE=0 (MIE=0)
+    """
+    op = "CSRS" if enable else "CSRC"
+    comment = "MPIE=1 -> MIE=1 after mret" if enable else "MPIE=0 -> MIE=0 after mret"
+    return [
+        f"LI(x{r_scratch}, 0x80)  # {comment}",
+        f"{op}(mstatus, x{r_scratch})",
+    ]
+
+
+def mmode_sti_setup(r_scratch: int, r_stce: int, mideleg_sti: int, mie_stie: int) -> list[str]:
+    """Common M-mode setup for Sstc STI tests: disable interrupts, set mideleg/mie/STCE, stimecmp=max.
+
+    Leaves interrupts globally disabled (MIE=0, SIE=0) with stimecmp=-1 (no pending STI).
+    Caller must enable MIE/SIE as needed for the specific test.
+
+    Args:
+        r_scratch: Scratch register
+        r_stce: Register for STCE bit manipulation
+        mideleg_sti: 1 to delegate STI to S-mode, 0 for M-mode handling
+        mie_stie: 1 to enable STIE in mie, 0 to disable
+    """
+    lines = [
+        "RVTEST_GOTO_MMODE",
+        "CSRW(mie, zero)",
+        "csrci mstatus, 8",  # MIE=0
+        "csrci mstatus, 2",  # SIE=0
+        f"LI(x{r_scratch}, 0x20)",
+        f"CSRC(mip, x{r_scratch})",  # clear any pending STIP
+        *set_stimecmp_max(r_scratch),
+        *set_menvcfg_stce(r_stce, True),  # STCE=1
+    ]
+    # mideleg
+    if mideleg_sti:
+        lines += [f"LI(x{r_scratch}, 0x20)", f"CSRW(mideleg, x{r_scratch})"]
+    else:
+        lines.append("CSRW(mideleg, zero)")
+    # mie.STIE
+    if mie_stie:
+        lines += [f"LI(x{r_scratch}, 0x20)", f"CSRW(mie, x{r_scratch})"]
+    else:
+        lines.append("CSRW(mie, zero)")
+    return lines
+
+
+def mmode_sti_cleanup(r_scratch: int, r_stce: int) -> list[str]:
+    """Restore M-mode state after an Sstc STI test."""
+    return [
+        "RVTEST_GOTO_MMODE",
+        "csrci mstatus, 8",
+        "csrci mstatus, 2",
+        "CSRW(mideleg, zero)",
+        "CSRW(mie, zero)",
+        *set_stimecmp_max(r_scratch),
+        f"LI(x{r_scratch}, 0x20)",
+        f"CSRC(mip, x{r_scratch})",
+        *set_menvcfg_stce(r_stce, False),  # STCE=0
     ]

--- a/generators/testgen/src/testgen/asm/interrupts.py
+++ b/generators/testgen/src/testgen/asm/interrupts.py
@@ -28,6 +28,7 @@ def set_mtimer_int(r_mtime: int, r_mtimecmp: int, r_temp: int, r_temp2: int) -> 
         f"LREG x{r_temp}, 0(x{r_mtime})",
         f"SREG x{r_temp}, 0(x{r_mtimecmp})",
         "#elif __riscv_xlen == 32",
+<<<<<<< HEAD
         "# Write sequence to prevent spurious interrupts",
         "# Read mtime (new comparand will be in temp2:temp)",
         f"lw x{r_temp}, 0(x{r_mtime}) # mtime[31:0] -> low word",
@@ -37,6 +38,17 @@ def set_mtimer_int(r_mtime: int, r_mtimecmp: int, r_temp: int, r_temp2: int) -> 
         f"sw x{r_mtime}, 0(x{r_mtimecmp}) # Step 1: Write -1 to low (no smaller than old)",
         f"sw x{r_temp2}, 4(x{r_mtimecmp}) # Step 2: Write high word (no smaller than new)",
         f"sw x{r_temp}, 0(x{r_mtimecmp}) # Step 3: Write low word (new value)",
+=======
+        # Write sequence to prevent spurious interrupts
+        # Read mtime (new comparand will be in temp2:temp)
+        f"    lw x{r_temp}, 0(x{r_mtime})",  # mtime[31:0] -> low word
+        f"    lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32] -> high word
+        # 3-step write sequence (new comparand is in temp2:temp)
+        f"    li x{r_mtime}, -1",  # Reuse r_mtime for -1
+        f"    sw x{r_mtime}, 0(x{r_mtimecmp})",  # Step 1: Write -1 to low (no smaller than old)
+        f"    sw x{r_temp2}, 4(x{r_mtimecmp})",  # Step 2: Write high word (no smaller than new)
+        f"    sw x{r_temp}, 0(x{r_mtimecmp})",  # Step 3: Write low word (new value)
+>>>>>>> 9e4cabd7a (udpated interrupt tests)
         "#endif",
         "#endif",
     ]
@@ -82,6 +94,7 @@ def set_mtimer_int_soon(
         f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
         f"LA(x{r_mtimecmp}, RVMODEL_MTIMECMP_ADDRESS)",
         "#if __riscv_xlen == 64",
+<<<<<<< HEAD
         "# Read current time and add delay",
         "# Load delay first for more accurate timing",
         f"LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",
@@ -104,6 +117,28 @@ def set_mtimer_int_soon(
         f"sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
         f"sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
         f"sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
+=======
+        # Read current time and add delay
+        f"    ld x{r_temp1}, 0(x{r_mtime})",
+        f"    LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
+        f"    add x{r_temp1}, x{r_temp1}, x{r_temp2}",  # mtime + delay
+        f"    sd x{r_temp1}, 0(x{r_mtimecmp})",
+        "#elif __riscv_xlen == 32",
+        # Read current time (64-bit on RV32)
+        f"    lw x{r_temp1}, 0(x{r_mtime})",  # mtime[31:0]
+        f"    lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32]
+        # Add delay to 64-bit value
+        f"    LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
+        f"    add x{r_temp3}, x{r_temp1}, x{r_temp4}",  # new_low = mtime_low + delay
+        f"    sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",  # carry bit
+        f"    add x{r_temp2}, x{r_temp2}, x{r_temp4}",  # new_high = mtime_high + carry
+        # Per RISC-V Spec 3.2.1: Write sequence to prevent spurious interrupt
+        # New comparand is in temp2:temp3
+        f"    li x{r_temp1}, -1",
+        f"    sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
+        f"    sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
+        f"    sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
+>>>>>>> 9e4cabd7a (udpated interrupt tests)
         "#endif",
         "#endif",
     ]

--- a/generators/testgen/src/testgen/asm/interrupts.py
+++ b/generators/testgen/src/testgen/asm/interrupts.py
@@ -44,7 +44,7 @@ def set_mtimer_int(r_mtime: int, r_mtimecmp: int, r_temp: int, r_temp2: int) -> 
         f"    lw x{r_temp}, 0(x{r_mtime})",  # mtime[31:0] -> low word
         f"    lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32] -> high word
         # 3-step write sequence (new comparand is in temp2:temp)
-        f"    li x{r_mtime}, -1",  # Reuse r_mtime for -1
+        f"    LI(x{r_mtime}, -1)",  # Reuse r_mtime for -1
         f"    sw x{r_mtime}, 0(x{r_mtimecmp})",  # Step 1: Write -1 to low (no smaller than old)
         f"    sw x{r_temp2}, 4(x{r_mtimecmp})",  # Step 2: Write high word (no smaller than new)
         f"    sw x{r_temp}, 0(x{r_mtimecmp})",  # Step 3: Write low word (new value)
@@ -119,22 +119,24 @@ def set_mtimer_int_soon(
         f"sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)
 =======
         # Read current time and add delay
+        # Load delay first for more accurate timing
+        f"    LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",
+        # Then read mtime
         f"    ld x{r_temp1}, 0(x{r_mtime})",
-        f"    LI(x{r_temp2}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
-        f"    add x{r_temp1}, x{r_temp1}, x{r_temp2}",  # mtime + delay
+        f"    add x{r_temp1}, x{r_temp1}, x{r_temp2}",
         f"    sd x{r_temp1}, 0(x{r_mtimecmp})",
         "#elif __riscv_xlen == 32",
+        f"    LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
         # Read current time (64-bit on RV32)
         f"    lw x{r_temp1}, 0(x{r_mtime})",  # mtime[31:0]
         f"    lw x{r_temp2}, 4(x{r_mtime})",  # mtime[63:32]
         # Add delay to 64-bit value
-        f"    LI(x{r_temp4}, RVMODEL_TIMER_INT_SOON_DELAY)",  # Load delay into register
         f"    add x{r_temp3}, x{r_temp1}, x{r_temp4}",  # new_low = mtime_low + delay
         f"    sltu x{r_temp4}, x{r_temp3}, x{r_temp1}",  # carry bit
         f"    add x{r_temp2}, x{r_temp2}, x{r_temp4}",  # new_high = mtime_high + carry
         # Per RISC-V Spec 3.2.1: Write sequence to prevent spurious interrupt
         # New comparand is in temp2:temp3
-        f"    li x{r_temp1}, -1",
+        f"    LI(x{r_temp1}, -1)",
         f"    sw x{r_temp1}, 0(x{r_mtimecmp})",  # Write -1 to low word first
         f"    sw x{r_temp2}, 4(x{r_mtimecmp})",  # Write high word
         f"    sw x{r_temp3}, 0(x{r_mtimecmp})",  # Write low word (final value)

--- a/generators/testgen/src/testgen/asm/interrupts.py
+++ b/generators/testgen/src/testgen/asm/interrupts.py
@@ -144,82 +144,271 @@ def set_mtimer_int_soon(
     ]
 
 
-def set_stimer_int(r_mtime: int, r_temp: int, r_temp2: int, r_scratch: int) -> list[str]:
+# def set_stimer_int(r_mtime: int, r_temp: int, r_temp2: int, r_scratch: int) -> list[str]:
+#     """Set supervisor timer interrupt.
+
+#     Checks menvcfg.STCE at runtime:
+#     - If STCE=1: Use Sstc method (write stimecmp from S-mode)
+#     - If STCE=0: Use legacy method (write mip.STIP from M-mode)
+#     """
+#     return [
+#         f"{INDENT}# Set supervisor timer interrupt",
+#         f"{INDENT}# Check if Sstc is enabled",
+#         f"CSRR x{r_scratch}, menvcfg",
+#         "#if __riscv_xlen == 64",
+#         f"SRLI x{r_scratch}, x{r_scratch}, 63",  # STCE is bit 63
+#         "#else",
+#         f"SRLI x{r_scratch}, x{r_scratch}, 31",  # STCE is bit 31 on RV32
+#         "#endif",
+#         f"ANDI x{r_scratch}, x{r_scratch}, 0x1",
+#         f"BEQZ x{r_scratch}, 1f # If STCE=0, use non sstc method",
+#         "",
+#         f"{INDENT}# Sstc method: Write stimecmp",
+#         f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
+#         f"LREG x{r_temp}, 0(x{r_mtime})",
+#         f"csrw stimecmp, x{r_temp}",
+#         "nop",
+#         "#if __riscv_xlen == 32",
+#         f"LI(x{r_temp}, -1)",
+#         f"csrw stimecmp, x{r_temp}",
+#         f"lw x{r_temp2}, 4(x{r_mtime})",
+#         f"lw x{r_temp}, 0(x{r_mtime})",
+#         f"csrw stimecmph, x{r_temp2}",
+#         f"csrw stimecmp, x{r_temp}",
+#         "nop",
+#         "#endif",
+#         "j 2f",
+#         "",
+#         "1: # Legacy method: Set mip.STIP from M-mode",
+#         f"LI(x{r_temp}, 0x20)",  # STIP = bit 5
+#         f"csrrs x{r_temp}, mip, x{r_temp}",
+#         "",
+#         "2: # Continue",
+#     ]
+
+# def set_stimer_int(r_mtime: int, r_temp: int, r_temp2: int, r_scratch: int, r_stce: int = None) -> list[str]:
+#     """Set supervisor timer interrupt.
+
+#     Args:
+#         r_stce: Optional - register containing pre-read menvcfg.STCE value (0 or 1)
+#                 If None, will read menvcfg in M-mode
+
+#     If STCE=1: Use Sstc method (write stimecmp - works in S-mode)
+#     If STCE=0: Use legacy method (write mip.STIP - requires M-mode)
+#     """
+#     lines = [
+#         f"{INDENT}# Set supervisor timer interrupt",
+#     ]
+
+#     # If STCE not pre-read, read menvcfg (assumes M-mode)
+#     if r_stce is None:
+#         lines.extend([
+#             f"{INDENT}# Check if Sstc is enabled",
+#             f"CSRR x{r_scratch}, menvcfg",
+#             "#if __riscv_xlen == 64",
+#             f"SRLI x{r_scratch}, x{r_scratch}, 63",  # STCE is bit 63
+#             "#else",
+#             f"SRLI x{r_scratch}, x{r_scratch}, 31",  # STCE is bit 31
+#             "#endif",
+#             f"ANDI x{r_scratch}, x{r_scratch}, 0x1",
+#         ])
+#         check_reg = r_scratch
+#     else:
+#         check_reg = r_stce
+
+#     lines.extend([
+#         f"BEQZ x{check_reg}, 1f # If STCE=0, use legacy method",
+#         "",
+#         f"{INDENT}# Sstc method: Write stimecmp (works in S-mode)",
+#         f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
+#         f"LREG x{r_temp}, 0(x{r_mtime})",
+#         f"csrw stimecmp, x{r_temp}",
+#         "nop",
+#         "#if __riscv_xlen == 32",
+#         f"LI(x{r_temp}, -1)",
+#         f"csrw stimecmp, x{r_temp}",
+#         f"lw x{r_temp2}, 4(x{r_mtime})",
+#         f"lw x{r_temp}, 0(x{r_mtime})",
+#         f"csrw stimecmph, x{r_temp2}",
+#         f"csrw stimecmp, x{r_temp}",
+#         "nop",
+#         "#endif",
+#         "j 2f",
+#         "",
+#         "1: # Legacy method: Set mip.STIP (requires M-mode)",
+#         "RVTEST_GOTO_MMODE",
+#         f"LI(x{r_temp}, 0x20)",  # STIP bit
+#         f"csrrs x{r_temp}, mip, x{r_temp}",
+#         "# Clear MPIE to prevent MIE=1 after mret back to S-mode",
+#         f"LI(x{r_temp}, 0x80)",  # MPIE bit (bit 7)
+#         f"csrc mstatus, x{r_temp}",
+#         "RVTEST_GOTO_LOWER_MODE Smode",
+#         "",
+#         "2: # Continue",
+#     ])
+
+#     return lines
+
+
+def set_stimer_int(r_mtime: int, r_temp: int, r_temp2: int, r_scratch: int, r_stce: int) -> list[str]:
     """Set supervisor timer interrupt.
 
-    Checks menvcfg.STCE at runtime:
-    - If STCE=1: Use Sstc method (write stimecmp from S-mode)
-    - If STCE=0: Use legacy method (write mip.STIP from M-mode)
+    Args:
+        r_stce: Optional - register containing pre-read menvcfg.STCE value (0 or 1)
+                If None, will read menvcfg in M-mode
+
+    If STCE=1: Use Sstc method (write stimecmp - works in S-mode)
+    If STCE=0: Use legacy method (write mip.STIP - requires M-mode)
     """
-    return [
+    lines = [
         f"{INDENT}# Set supervisor timer interrupt",
-        f"{INDENT}# Check if Sstc is enabled",
-        f"CSRR x{r_scratch}, menvcfg",
-        "#if __riscv_xlen == 64",
-        f"SRLI x{r_scratch}, x{r_scratch}, 63",  # STCE is bit 63
-        "#else",
-        f"SRLI x{r_scratch}, x{r_scratch}, 31",  # STCE is bit 31 on RV32
-        "#endif",
-        f"ANDI x{r_scratch}, x{r_scratch}, 0x1",
-        f"BEQZ x{r_scratch}, 1f # If STCE=0, use non sstc method",
-        "",
-        f"{INDENT}# Sstc method: Write stimecmp",
-        f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS) # NOTE: This will need to be replaced by a SBI call because MTIME might not exist or be accessible",
-        f"LREG x{r_temp}, 0(x{r_mtime})",
-        f"csrw stimecmp, x{r_temp}",
-        "nop",
-        "#if __riscv_xlen == 32",
-        f"LI(x{r_temp}, -1)",
-        f"csrw stimecmp, x{r_temp}",
-        f"lw x{r_temp2}, 4(x{r_mtime})",
-        f"lw x{r_temp}, 0(x{r_mtime})",
-        f"csrw stimecmph, x{r_temp2}",
-        f"csrw stimecmp, x{r_temp}",
-        "nop",
-        "#endif",
-        "j 2f",
-        "",
-        "1: # Legacy method: Set mip.STIP from M-mode",
-        f"LI(x{r_temp}, 0x20)",  # STIP = bit 5
-        f"csrrs x{r_temp}, mip, x{r_temp}",
-        "",
-        "2: # Continue",
     ]
 
+    # If STCE not pre-read, read menvcfg (assumes M-mode)
+    if r_stce is None:
+        lines.extend(
+            [
+                f"{INDENT}# Check if Sstc is enabled",
+                f"CSRR x{r_scratch}, menvcfg",
+                "#if __riscv_xlen == 64",
+                f"SRLI x{r_scratch}, x{r_scratch}, 63",  # STCE is bit 63
+                "#else",
+                f"SRLI x{r_scratch}, x{r_scratch}, 31",  # STCE is bit 31
+                "#endif",
+                f"ANDI x{r_scratch}, x{r_scratch}, 0x1",
+            ]
+        )
+        check_reg = r_scratch
+    else:
+        check_reg = r_stce
 
-def clr_stimer_int(r_temp: int, r_stimecmp: int, r_scratch: int) -> list[str]:
+    lines.extend(
+        [
+            f"BEQZ x{check_reg}, 1f # If STCE=0, use legacy method",
+            "",
+            f"{INDENT}# Sstc method: Write stimecmp (works in S-mode)",
+            f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
+            f"LREG x{r_temp}, 0(x{r_mtime})",
+            f"addi x{r_temp}, x{r_temp}, 100",  # Add 100 cycle delay
+            f"csrw stimecmp, x{r_temp}",
+            "nop",
+            "#if __riscv_xlen == 32",
+            f"LI(x{r_temp}, -1)",
+            f"csrw stimecmp, x{r_temp}",
+            f"lw x{r_temp2}, 4(x{r_mtime})",
+            f"lw x{r_temp}, 0(x{r_mtime})",
+            f"addi x{r_temp}, x{r_temp}, 100",  # Add 100 cycle delay to low word
+            f"sltu x{r_scratch}, x{r_temp}, x{r_temp}",  # Check for overflow
+            f"add x{r_temp2}, x{r_temp2}, x{r_scratch}",  # Add carry to high word
+            f"csrw stimecmph, x{r_temp2}",
+            f"csrw stimecmp, x{r_temp}",
+            "nop",
+            "#endif",
+            "j 2f",
+            "",
+            "1: # Legacy method: Set mip.STIP (requires M-mode)",
+            "RVTEST_GOTO_MMODE",
+            f"LI(x{r_temp}, 0x20)",  # STIP bit
+            f"csrrs x{r_temp}, mip, x{r_temp}",
+            "# Clear MPIE to prevent MIE=1 after mret back to S-mode",
+            f"LI(x{r_temp}, 0x80)",  # MPIE bit (bit 7)
+            f"csrc mstatus, x{r_temp}",
+            "RVTEST_GOTO_LOWER_MODE Smode",
+            "",
+            "2: # Continue",
+        ]
+    )
+
+    return lines
+
+
+# def clr_stimer_int(r_temp: int, r_stimecmp: int, r_scratch: int) -> list[str]:
+#     """Clear supervisor timer interrupt.
+
+
+#     Checks menvcfg.STCE at runtime:
+#     - If STCE=1: Use Sstc method (write stimecmp = -1)
+#     - If STCE=0: Use legacy method (clear mip.STIP from M-mode)
+#     """
+#     return [
+#         f"{INDENT}# Clear supervisor timer interrupt",
+#         f"{INDENT}# Check if Sstc is enabled",
+#         f"CSRR x{r_scratch}, menvcfg",
+#         "#if __riscv_xlen == 64",
+#         f"SRLI x{r_scratch}, x{r_scratch}, 63",  # STCE is bit 63
+#         "#else",
+#         f"SRLI x{r_scratch}, x{r_scratch}, 31",  # STCE is bit 31 on RV32
+#         "#endif",
+#         f"ANDI x{r_scratch}, x{r_scratch}, 0x1",
+#         f"BEQZ x{r_scratch}, 1f # If STCE=0, use non sstc method",
+#         "",
+#         f"{INDENT}# Sstc method: Write stimecmp = -1 (max value)",
+#         f"LI(x{r_temp}, -1)",
+#         f"csrw stimecmp, x{r_temp}",
+#         "#if __riscv_xlen == 32",
+#         f"csrw stimecmph, x{r_temp}",  # Also clear high word
+#         "#endif",
+#         "j 2f",
+#         "",
+#         "1: # Legacy method: Clear mip.STIP from M-mode",
+#         f"LI(x{r_temp}, 0x20)",  # STIP = bit 5
+#         f"csrrc x{r_temp}, mip, x{r_temp}",
+#         "",
+#         "2: # Continue",
+#     ]
+def clr_stimer_int(r_temp: int, r_stimecmp: int, r_scratch: int, r_stce: int) -> list[str]:
     """Clear supervisor timer interrupt.
 
-    Checks menvcfg.STCE at runtime:
-    - If STCE=1: Use Sstc method (write stimecmp = -1)
-    - If STCE=0: Use legacy method (clear mip.STIP from M-mode)
+    Args:
+        r_stce: Optional - register containing pre-read menvcfg.STCE value (0 or 1)
+                If None, will read menvcfg (assumes M-mode)
+
+    If STCE=1: Use Sstc method (write stimecmp = -1)
+    If STCE=0: Use legacy method (clear mip.STIP - requires M-mode)
     """
-    return [
+    lines = [
         f"{INDENT}# Clear supervisor timer interrupt",
-        f"{INDENT}# Check if Sstc is enabled",
-        f"CSRR x{r_scratch}, menvcfg",
-        "#if __riscv_xlen == 64",
-        f"SRLI x{r_scratch}, x{r_scratch}, 63",  # STCE is bit 63
-        "#else",
-        f"SRLI x{r_scratch}, x{r_scratch}, 31",  # STCE is bit 31 on RV32
-        "#endif",
-        f"ANDI x{r_scratch}, x{r_scratch}, 0x1",
-        f"BEQZ x{r_scratch}, 1f # If STCE=0, use non sstc method",
-        "",
-        f"{INDENT}# Sstc method: Write stimecmp = -1 (max value)",
-        f"LI(x{r_temp}, -1)",
-        f"csrw stimecmp, x{r_temp}",
-        "#if __riscv_xlen == 32",
-        f"csrw stimecmph, x{r_temp}",  # Also clear high word
-        "#endif",
-        "j 2f",
-        "",
-        "1: # Legacy method: Clear mip.STIP from M-mode",
-        f"LI(x{r_temp}, 0x20)",  # STIP = bit 5
-        f"csrrc x{r_temp}, mip, x{r_temp}",
-        "",
-        "2: # Continue",
     ]
+
+    # If STCE not pre-read, read menvcfg (assumes M-mode)
+    if r_stce is None:
+        lines.extend(
+            [
+                f"{INDENT}# Check if Sstc is enabled",
+                f"CSRR x{r_scratch}, menvcfg",
+                "#if __riscv_xlen == 64",
+                f"SRLI x{r_scratch}, x{r_scratch}, 63",  # STCE is bit 63
+                "#else",
+                f"SRLI x{r_scratch}, x{r_scratch}, 31",  # STCE is bit 31
+                "#endif",
+                f"ANDI x{r_scratch}, x{r_scratch}, 0x1",
+            ]
+        )
+        check_reg = r_scratch
+    else:
+        check_reg = r_stce
+
+    lines.extend(
+        [
+            f"BEQZ x{check_reg}, 1f # If STCE=0, use legacy method",
+            "",
+            f"{INDENT}# Sstc method: Write stimecmp = -1 (max value)",
+            f"LI(x{r_temp}, -1)",
+            f"csrw stimecmp, x{r_temp}",
+            "#if __riscv_xlen == 32",
+            f"csrw stimecmph, x{r_temp}",  # Also clear high word
+            "#endif",
+            "j 2f",
+            "",
+            "1: # Legacy method: Clear mip.STIP (must be in M-mode)",
+            f"LI(x{r_temp}, 0x20)",  # STIP = bit 5
+            f"csrrc x{r_temp}, mip, x{r_temp}",
+            "",
+            "2: # Continue",
+        ]
+    )
+
+    return lines
 
 
 def set_stimer_int_soon_sstc(r_mtime: int, r_temp1: int, r_temp2: int, r_temp3: int, r_temp4: int) -> list[str]:

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -59,11 +59,6 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     # Priv tests use x1/ra as the return address for function calls, so reserve it before generating the test
     test_data.int_regs.consume_registers([1])
 
-    # Consume t2 and t5 (x7, x30) - reserved by trap handler in arch_test.h for interrupt clearing
-    # The trap handler uses these registers when calling RVMODEL_CLR_*_INT macros
-    # See: tests/env/arch_test.h, trap handler interrupt dispatch logic
-    test_data.int_regs.consume_registers([7, 30])
-
     # Seed the RNG for reproducible test generation
     seed(reproducible_hash(testsuite))
 
@@ -72,7 +67,7 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     body_lines = priv_test_generator(test_data)
 
     # Return x1/ra
-    test_data.int_regs.return_registers([1, 7, 30])
+    test_data.int_regs.return_register(1)
 
     # Save test chunk
     tc.code = "\n".join(body_lines)

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -56,8 +56,13 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     # so they can be split for long priv tests (e.g. Ssstrict)
     tc = test_data.begin_test_chunk()
 
-    # Priv tests use x1/ra as the return address for function calls, so reserve it before generating the test
-    test_data.int_regs.consume_registers([1, 5, 6, 7, 8, 9, 11, 28, 29, 30, 31])
+    # Reserve registers for priv tests:
+    #   - x0: avoid so desired values are actually loaded into registers
+    #   - x1/ra: used as the return address for function calls
+    #   - x6, x7, x9: used by the RVTEST_GOTO_LOWER_MODE macro
+    #   - x16-x31: ensure the same test can be used for I or E bases
+    priv_exclude_regs = [0, 1, 6, 7, 9, *range(16, 32)]
+    test_data.int_regs.consume_registers(priv_exclude_regs)
 
     # Seed the RNG for reproducible test generation
     seed(reproducible_hash(testsuite))
@@ -66,9 +71,8 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     priv_test_generator = get_priv_test_generator(testsuite)
     body_lines = priv_test_generator(test_data)
 
-    # Return x1/ra
-    # test_data.int_regs.return_register(1)
-    test_data.int_regs.return_registers([1, 5, 6, 7, 8, 9, 11, 28, 29, 30, 31])
+    # Return x0/zero and x1/ra
+    test_data.int_regs.return_registers(priv_exclude_regs)
 
     # Save test chunk
     tc.code = "\n".join(body_lines)

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -56,13 +56,13 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     # so they can be split for long priv tests (e.g. Ssstrict)
     tc = test_data.begin_test_chunk()
 
-    # Reserve registers for priv tests:
-    #   - x0: avoid so desired values are actually loaded into registers
-    #   - x1/ra: used as the return address for function calls
-    #   - x6, x7, x9: used by the RVTEST_GOTO_LOWER_MODE macro
-    #   - x16-x31: ensure the same test can be used for I or E bases
-    priv_exclude_regs = [0, 1, 6, 7, 9, *range(16, 32)]
-    test_data.int_regs.consume_registers(priv_exclude_regs)
+    # Priv tests use x1/ra as the return address for function calls, so reserve it before generating the test
+    test_data.int_regs.consume_registers([1])
+
+    # Consume t2 and t5 (x7, x30) - reserved by trap handler in arch_test.h for interrupt clearing
+    # The trap handler uses these registers when calling RVMODEL_CLR_*_INT macros
+    # See: tests/env/arch_test.h, trap handler interrupt dispatch logic
+    test_data.int_regs.consume_registers([7, 30])
 
     # Seed the RNG for reproducible test generation
     seed(reproducible_hash(testsuite))
@@ -71,8 +71,8 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     priv_test_generator = get_priv_test_generator(testsuite)
     body_lines = priv_test_generator(test_data)
 
-    # Return x0/zero and x1/ra
-    test_data.int_regs.return_registers(priv_exclude_regs)
+    # Return x1/ra
+    test_data.int_regs.return_registers([1, 7, 30])
 
     # Save test chunk
     tc.code = "\n".join(body_lines)

--- a/generators/testgen/src/testgen/generate/priv.py
+++ b/generators/testgen/src/testgen/generate/priv.py
@@ -57,7 +57,7 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     tc = test_data.begin_test_chunk()
 
     # Priv tests use x1/ra as the return address for function calls, so reserve it before generating the test
-    test_data.int_regs.consume_registers([1])
+    test_data.int_regs.consume_registers([1, 5, 6, 7, 8, 9, 11, 28, 29, 30, 31])
 
     # Seed the RNG for reproducible test generation
     seed(reproducible_hash(testsuite))
@@ -67,7 +67,8 @@ def generate_priv_test(testsuite: str, output_test_dir: Path) -> None:
     body_lines = priv_test_generator(test_data)
 
     # Return x1/ra
-    test_data.int_regs.return_register(1)
+    # test_data.int_regs.return_register(1)
+    test_data.int_regs.return_registers([1, 5, 6, 7, 8, 9, 11, 28, 29, 30, 31])
 
     # Save test chunk
     tc.code = "\n".join(body_lines)

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
@@ -1,9 +1,10 @@
-"""Supervisor-mode interrupt test generator for RISC-V privileged architecture.
-
-This module generates tests for supervisor-mode interrupts (STIP, SSIP, SEIP),
-covering both non-delegated (fires in M-mode) and delegated (fires in S-mode)
-interrupt handling across a wide range of mideleg, mie, and mstatus configurations.
-"""
+##################################
+# priv/extensions/interruptsS.py
+#
+# InterruptsS privileged extension test generator.
+# sanarayanan@hmc.edu April 2026
+# SPDX-License-Identifier: Apache-2.0
+##################################
 
 from testgen.asm.helpers import comment_banner
 from testgen.asm.interrupts import (

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
@@ -243,7 +243,8 @@ def _generate_trigger_ssi_mip_tests(test_data: TestData) -> list[str]:
             lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
             lines.extend(
                 [
-                    "RVTEST_SET_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",  # SSIP bit
+                    f"CSRS(mip, x{r_scratch})",  # Set via CSR write
                     "nop",
                     "nop",
                 ]
@@ -267,7 +268,8 @@ def _generate_trigger_ssi_mip_tests(test_data: TestData) -> list[str]:
                     "csrci mstatus, 2",  # Clear SIE
                     "CSRW(mideleg, zero)",  # Clear delegation
                     "CSRW(mie, zero)",  # Clear all interrupt enables
-                    "RVTEST_CLR_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
                 ]
             )
 
@@ -662,7 +664,12 @@ def _generate_changingtos_ssi_tests(test_data: TestData) -> list[str]:
     ]
 
     # Clear SSIP
-    lines.append("RVTEST_CLR_SSW_INT")
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mip, x{r_scratch})",
+        ]
+    )
 
     # Set mideleg (delegate STI+SEI+SSI)
     lines.extend(
@@ -684,7 +691,8 @@ def _generate_changingtos_ssi_tests(test_data: TestData) -> list[str]:
     lines.extend(
         [
             test_data.add_testcase("changingtos_ssi", coverpoint, covergroup),
-            "RVTEST_SET_SSW_INT",
+            f"LI(x{r_scratch}, 0x2)",  # SSIP bit
+            f"CSRS(mip, x{r_scratch})",  # Set via CSR write
             "nop",
         ]
     )
@@ -709,7 +717,8 @@ def _generate_changingtos_ssi_tests(test_data: TestData) -> list[str]:
             "csrci mstatus, 2",
             "CSRW(mideleg, zero)",
             "CSRW(mie, zero)",
-            "RVTEST_CLR_SSW_INT",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mip, x{r_scratch})",
         ]
     )
 
@@ -773,7 +782,7 @@ def _generate_interrupts_s_tests(test_data: TestData) -> list[str]:
 
     # ALL 6 interrupts
     mip_interrupts = [
-        ("ssip", 0x002, "RVTEST_SET_SSW_INT", "RVTEST_CLR_SSW_INT", False),
+        ("ssip", 0x002, None, None, False),
         ("msip", 0x008, "RVTEST_SET_MSW_INT", "RVTEST_CLR_MSW_INT", False),
         ("stip", 0x020, None, None, True),
         ("mtip", 0x080, None, None, True),
@@ -813,7 +822,8 @@ def _generate_interrupts_s_tests(test_data: TestData) -> list[str]:
                 # Clear all interrupts
                 lines.extend(
                     [
-                        "RVTEST_CLR_SSW_INT",
+                        f"LI(x{r_scratch}, 0x2)",
+                        f"CSRC(mip, x{r_scratch})",
                         "RVTEST_CLR_MSW_INT",
                         "RVTEST_CLR_SEXT_INT",
                         "RVTEST_CLR_MEXT_INT",
@@ -886,6 +896,13 @@ def _generate_interrupts_s_tests(test_data: TestData) -> list[str]:
                         lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
                     else:  # mtip
                         lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+                elif mip_name == "ssip":
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x2)",
+                            f"CSRS(mip, x{r_scratch})",
+                        ]
+                    )
                 else:
                     lines.extend([mip_set, "nop"])
 
@@ -927,6 +944,14 @@ def _generate_interrupts_s_tests(test_data: TestData) -> list[str]:
                         lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
                     else:
                         lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+                elif mip_name == "ssip":
+                    # Clear both ways for SSIP
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x2)",
+                            f"CSRC(mip, x{r_scratch})",
+                        ]
+                    )
                 else:
                     lines.append(mip_clr)
 
@@ -955,7 +980,7 @@ def _generate_vectored_s_tests(test_data: TestData) -> list[str]:
 
     # ALL 6 interrupts (including M-mode ones!)
     interrupts = [
-        ("ssip", 0x002, "RVTEST_SET_SSW_INT", "RVTEST_CLR_SSW_INT", False),
+        ("ssip", 0x002, None, None, False),
         ("msip", 0x008, "RVTEST_SET_MSW_INT", "RVTEST_CLR_MSW_INT", False),
         ("stip", 0x020, None, None, True),
         ("mtip", 0x080, None, None, True),
@@ -983,7 +1008,8 @@ def _generate_vectored_s_tests(test_data: TestData) -> list[str]:
             # Clear all interrupts
             lines.extend(
                 [
-                    "RVTEST_CLR_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
                     "RVTEST_CLR_MSW_INT",
                     "RVTEST_CLR_SEXT_INT",
                     "RVTEST_CLR_MEXT_INT",
@@ -1054,6 +1080,14 @@ def _generate_vectored_s_tests(test_data: TestData) -> list[str]:
                     lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
                 else:  # mtip
                     lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+            elif int_name == "ssip":
+                # Override macro with CSR for SSIP
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x2)",
+                        f"CSRS(mip, x{r_scratch})",
+                    ]
+                )
             else:
                 lines.extend([int_set, "nop"])
 
@@ -1094,6 +1128,14 @@ def _generate_vectored_s_tests(test_data: TestData) -> list[str]:
                     lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
                 else:
                     lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+            elif int_name == "ssip":
+                # Clear both ways for SSIP
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x2)",
+                        f"CSRC(mip, x{r_scratch})",
+                    ]
+                )
             else:
                 lines.append(int_clr)
 
@@ -1156,7 +1198,8 @@ def _generate_priority_mip_s_tests(test_data: TestData) -> list[str]:
             # Clear all interrupts
             lines.extend(
                 [
-                    "RVTEST_CLR_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
                     "RVTEST_CLR_MSW_INT",
                     "RVTEST_CLR_SEXT_INT",
                     "RVTEST_CLR_MEXT_INT",
@@ -1207,7 +1250,12 @@ def _generate_priority_mip_s_tests(test_data: TestData) -> list[str]:
 
             # Set each interrupt according to the pattern
             if ssip_set:
-                lines.append("RVTEST_SET_SSW_INT")
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x2)",
+                        f"CSRS(mip, x{r_scratch})",
+                    ]
+                )
             if msip_set:
                 lines.append("RVTEST_SET_MSW_INT")
             if stip_set:
@@ -1257,7 +1305,12 @@ def _generate_priority_mip_s_tests(test_data: TestData) -> list[str]:
 
             # Clear all interrupts that were set
             if ssip_set:
-                lines.append("RVTEST_CLR_SSW_INT")
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x2)",
+                        f"CSRC(mip, x{r_scratch})",
+                    ]
+                )
             if msip_set:
                 lines.append("RVTEST_CLR_MSW_INT")
             if stip_set:
@@ -1321,7 +1374,8 @@ def _generate_priority_mie_s_tests(test_data: TestData) -> list[str]:
             # Clear all interrupts
             lines.extend(
                 [
-                    "RVTEST_CLR_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
                     "RVTEST_CLR_MSW_INT",
                     "RVTEST_CLR_SEXT_INT",
                     "RVTEST_CLR_MEXT_INT",
@@ -1371,7 +1425,8 @@ def _generate_priority_mie_s_tests(test_data: TestData) -> list[str]:
             lines.append(test_data.add_testcase(binname, coverpoint_s, covergroup))
             lines.extend(
                 [
-                    "RVTEST_SET_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRS(mip, x{r_scratch})",
                     f"CSRR x{r_stce}, menvcfg",
                     "#if __riscv_xlen == 64",
                     f"    srli x{r_stce}, x{r_stce}, 63",
@@ -1409,7 +1464,8 @@ def _generate_priority_mie_s_tests(test_data: TestData) -> list[str]:
                     "csrci mstatus, 2",
                     "CSRW(mideleg, zero)",
                     "CSRW(mie, zero)",
-                    "RVTEST_CLR_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
                 ]
             )
             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
@@ -1439,7 +1495,8 @@ def _generate_priority_mie_s_tests(test_data: TestData) -> list[str]:
             # Clear all interrupts
             lines.extend(
                 [
-                    "RVTEST_CLR_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
                     "RVTEST_CLR_MSW_INT",
                     "RVTEST_CLR_SEXT_INT",
                     "RVTEST_CLR_MEXT_INT",
@@ -1578,7 +1635,8 @@ def _generate_priority_both_s_tests(test_data: TestData) -> list[str]:
             # Clear all interrupts
             lines.extend(
                 [
-                    "RVTEST_CLR_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
                     "RVTEST_CLR_SEXT_INT",
                 ]
             )
@@ -1625,7 +1683,12 @@ def _generate_priority_both_s_tests(test_data: TestData) -> list[str]:
             lines.append(test_data.add_testcase(binname, coverpoint_s, covergroup))
 
             if ssip:
-                lines.append("RVTEST_SET_SSW_INT")
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x2)",
+                        f"CSRS(mip, x{r_scratch})",
+                    ]
+                )
             if stip:
                 lines.extend(
                     [
@@ -1668,7 +1731,12 @@ def _generate_priority_both_s_tests(test_data: TestData) -> list[str]:
             )
 
             if ssip:
-                lines.append("RVTEST_CLR_SSW_INT")
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x2)",
+                        f"CSRC(mip, x{r_scratch})",
+                    ]
+                )
             if stip:
                 lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
             if seip:
@@ -1834,7 +1902,8 @@ def _generate_priority_mideleg_m_tests(test_data: TestData) -> list[str]:
         # Clear all interrupts
         lines.extend(
             [
-                "RVTEST_CLR_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRC(mip, x{r_scratch})",
                 "RVTEST_CLR_SEXT_INT",
             ]
         )
@@ -1878,7 +1947,8 @@ def _generate_priority_mideleg_m_tests(test_data: TestData) -> list[str]:
         lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
         lines.extend(
             [
-                "RVTEST_SET_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRS(mip, x{r_scratch})",
                 f"CSRR x{r_stce}, menvcfg",
                 "#if __riscv_xlen == 64",
                 f"    srli x{r_stce}, x{r_stce}, 63",
@@ -1916,7 +1986,8 @@ def _generate_priority_mideleg_m_tests(test_data: TestData) -> list[str]:
                 "csrci mstatus, 2",
                 "CSRW(mideleg, zero)",
                 "CSRW(mie, zero)",
-                "RVTEST_CLR_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRC(mip, x{r_scratch})",
             ]
         )
         lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
@@ -1970,7 +2041,8 @@ def _generate_priority_mideleg_s_tests(test_data: TestData) -> list[str]:
         # Clear all interrupts
         lines.extend(
             [
-                "RVTEST_CLR_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRC(mip, x{r_scratch})",
                 "RVTEST_CLR_SEXT_INT",
             ]
         )
@@ -2014,7 +2086,8 @@ def _generate_priority_mideleg_s_tests(test_data: TestData) -> list[str]:
         lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
         lines.extend(
             [
-                "RVTEST_SET_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRS(mip, x{r_scratch})",
                 f"CSRR x{r_stce}, menvcfg",
                 "#if __riscv_xlen == 64",
                 f"    srli x{r_stce}, x{r_stce}, 63",
@@ -2052,7 +2125,8 @@ def _generate_priority_mideleg_s_tests(test_data: TestData) -> list[str]:
                 "csrci mstatus, 2",
                 "CSRW(mideleg, zero)",
                 "CSRW(mie, zero)",
-                "RVTEST_CLR_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRC(mip, x{r_scratch})",
             ]
         )
         lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
@@ -2251,7 +2325,8 @@ def _generate_wfi_timeout_s_tests(test_data: TestData) -> list[str]:
                         # Clear all interrupts
                         lines.extend(
                             [
-                                "RVTEST_CLR_SSW_INT",
+                                f"LI(x{r_scratch}, 0x2)",
+                                f"CSRC(mip, x{r_scratch})",
                                 "RVTEST_CLR_MSW_INT",
                             ]
                         )
@@ -2359,7 +2434,7 @@ def _generate_interrupts_m_tests(test_data: TestData) -> list[str]:
 
     # 6 interrupts (walking 1s)
     interrupts = [
-        ("ssip", 0x002, 0x002, "RVTEST_SET_SSW_INT", "RVTEST_CLR_SSW_INT", False),
+        ("ssip", 0x002, 0x002, None, None, False),
         ("msip", 0x008, 0x008, "RVTEST_SET_MSW_INT", "RVTEST_CLR_MSW_INT", False),
         ("stip", 0x020, 0x020, None, None, True),
         ("mtip", 0x080, 0x080, None, None, True),
@@ -2399,7 +2474,8 @@ def _generate_interrupts_m_tests(test_data: TestData) -> list[str]:
                     # Clear all interrupts
                     lines.extend(
                         [
-                            "RVTEST_CLR_SSW_INT",
+                            f"LI(x{r_scratch}, 0x2)",
+                            f"CSRC(mip, x{r_scratch})",
                             "RVTEST_CLR_MSW_INT",
                             # Reset stimecmp to max unconditionally before clearing mip.STIP.
                             # clr_stimer_int(r_stce=0) always uses legacy csrrc path which does NOT
@@ -2476,7 +2552,15 @@ def _generate_interrupts_m_tests(test_data: TestData) -> list[str]:
                             else:
                                 lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
                     else:
-                        lines.extend([set_fn, "nop"])
+                        if mip_name == "ssip":
+                            lines.extend(
+                                [
+                                    f"LI(x{r_scratch}, 0x2)",
+                                    f"CSRS(mip, x{r_scratch})",
+                                ]
+                            )
+                        else:
+                            lines.extend([set_fn, "nop"])
 
                     # === WAIT FOR INTERRUPT ===
                     if is_delegated:
@@ -2528,7 +2612,15 @@ def _generate_interrupts_m_tests(test_data: TestData) -> list[str]:
                         else:
                             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
                     else:
-                        lines.append(clr_fn)
+                        if mip_name == "ssip":
+                            lines.extend(
+                                [
+                                    f"LI(x{r_scratch}, 0x2)",
+                                    f"CSRC(mip, x{r_scratch})",
+                                ]
+                            )
+                        else:
+                            lines.append(clr_fn)
 
     test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
     return lines
@@ -2555,7 +2647,7 @@ def _generate_vectored_m_tests(test_data: TestData) -> list[str]:
 
     # S-mode interrupts (fire in M-mode when not delegated)
     interrupts = [
-        ("ssip", 0x002, "RVTEST_SET_SSW_INT", "RVTEST_CLR_SSW_INT", False),
+        ("ssip", 0x002, None, None, False),
         ("stip", 0x020, None, None, True),
         ("seip", 0x200, "RVTEST_SET_SEXT_INT", "RVTEST_CLR_SEXT_INT", False),
     ]
@@ -2576,7 +2668,8 @@ def _generate_vectored_m_tests(test_data: TestData) -> list[str]:
         # Clear all interrupts
         lines.extend(
             [
-                "RVTEST_CLR_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRC(mip, x{r_scratch})",
                 "RVTEST_CLR_SEXT_INT",
             ]
         )
@@ -2612,6 +2705,13 @@ def _generate_vectored_m_tests(test_data: TestData) -> list[str]:
 
         if uses_timer:
             lines.extend(set_stimer_mmode(r_scratch))
+        elif int_name == "ssip":
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRS(mip, x{r_scratch})",
+                ]
+            )
         else:
             lines.extend([int_set, "nop"])
 
@@ -2638,6 +2738,13 @@ def _generate_vectored_m_tests(test_data: TestData) -> list[str]:
         # Clear interrupt
         if uses_timer:
             lines.extend(clr_stimer_mmode(r_scratch))
+        elif int_name == "ssip":
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
+                ]
+            )
         else:
             lines.append(int_clr)
 
@@ -2688,7 +2795,8 @@ def _generate_priority_mip_m_tests(test_data: TestData) -> list[str]:
         # Clear all interrupts
         lines.extend(
             [
-                "RVTEST_CLR_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRC(mip, x{r_scratch})",
                 "RVTEST_CLR_MSW_INT",
                 "RVTEST_CLR_SEXT_INT",
                 "RVTEST_CLR_MEXT_INT",
@@ -2712,7 +2820,12 @@ def _generate_priority_mip_m_tests(test_data: TestData) -> list[str]:
         lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
 
         if ssip:
-            lines.append("RVTEST_SET_SSW_INT")
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRS(mip, x{r_scratch})",
+                ]
+            )
         if msip:
             lines.append("RVTEST_SET_MSW_INT")
         if stip:
@@ -2750,7 +2863,12 @@ def _generate_priority_mip_m_tests(test_data: TestData) -> list[str]:
 
         # Clear interrupts
         if ssip:
-            lines.append("RVTEST_CLR_SSW_INT")
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
+                ]
+            )
         if msip:
             lines.append("RVTEST_CLR_MSW_INT")
         if stip:
@@ -2812,7 +2930,8 @@ def _generate_priority_mie_m_tests(test_data: TestData) -> list[str]:
         # Clear all interrupts
         lines.extend(
             [
-                "RVTEST_CLR_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRC(mip, x{r_scratch})",
                 "RVTEST_CLR_MSW_INT",
                 "RVTEST_CLR_SEXT_INT",
                 "RVTEST_CLR_MEXT_INT",
@@ -2836,7 +2955,8 @@ def _generate_priority_mie_m_tests(test_data: TestData) -> list[str]:
         lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
         lines.extend(
             [
-                "RVTEST_SET_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRS(mip, x{r_scratch})",
                 "RVTEST_SET_MSW_INT",
             ]
         )
@@ -2869,7 +2989,8 @@ def _generate_priority_mie_m_tests(test_data: TestData) -> list[str]:
                 "csrci mstatus, 8",
                 "CSRW(mideleg, zero)",
                 "CSRW(mie, zero)",
-                "RVTEST_CLR_SSW_INT",
+                f"LI(x{r_scratch}, 0x2)",
+                f"CSRC(mip, x{r_scratch})",
                 "RVTEST_CLR_MSW_INT",
             ]
         )
@@ -3110,7 +3231,12 @@ def _generate_trigger_ssi_sip_m_tests(test_data: TestData) -> list[str]:
             )
 
             # Clear SSIP
-            lines.append("RVTEST_CLR_SSW_INT")
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
+                ]
+            )
 
             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
@@ -3172,7 +3298,8 @@ def _generate_trigger_ssi_sip_m_tests(test_data: TestData) -> list[str]:
                 [
                     "RVTEST_GOTO_MMODE",
                     "csrci mstatus, 8",
-                    "RVTEST_CLR_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
                     "CSRW(mideleg, zero)",
                     "CSRW(mie, zero)",
                 ]
@@ -3216,7 +3343,8 @@ def _generate_trigger_msi_m_tests(test_data: TestData) -> list[str]:
     # Clear all interrupts
     lines.extend(
         [
-            "RVTEST_CLR_SSW_INT",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mip, x{r_scratch})",
             "RVTEST_CLR_MSW_INT",
         ]
     )
@@ -3309,7 +3437,8 @@ def _generate_trigger_mei_m_tests(test_data: TestData) -> list[str]:
     # Clear all interrupts
     lines.extend(
         [
-            "RVTEST_CLR_SSW_INT",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mip, x{r_scratch})",
             "RVTEST_CLR_MSW_INT",
             "RVTEST_CLR_SEXT_INT",
             "RVTEST_CLR_MEXT_INT",
@@ -3402,7 +3531,8 @@ def _generate_trigger_sti_m_tests(test_data: TestData) -> list[str]:
     # Clear all interrupts
     lines.extend(
         [
-            "RVTEST_CLR_SSW_INT",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mip, x{r_scratch})",
             "RVTEST_CLR_MSW_INT",
             "RVTEST_CLR_SEXT_INT",
             "RVTEST_CLR_MEXT_INT",
@@ -3492,7 +3622,8 @@ def _generate_trigger_ssi_m_tests(test_data: TestData) -> list[str]:
     # Clear all interrupts
     lines.extend(
         [
-            "RVTEST_CLR_SSW_INT",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mip, x{r_scratch})",
             "RVTEST_CLR_MSW_INT",
             "RVTEST_CLR_SEXT_INT",
             "RVTEST_CLR_MEXT_INT",
@@ -3516,7 +3647,8 @@ def _generate_trigger_ssi_m_tests(test_data: TestData) -> list[str]:
     lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
     lines.extend(
         [
-            "RVTEST_SET_SSW_INT",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRS(mip, x{r_scratch})",
         ]
     )
 
@@ -3545,7 +3677,8 @@ def _generate_trigger_ssi_m_tests(test_data: TestData) -> list[str]:
             "csrci mstatus, 8",
             "CSRW(mideleg, zero)",
             "CSRW(mie, zero)",
-            "RVTEST_CLR_SSW_INT",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mip, x{r_scratch})",
         ]
     )
 
@@ -3587,7 +3720,8 @@ def _generate_trigger_sei_m_tests(test_data: TestData) -> list[str]:
     # Clear all interrupts
     lines.extend(
         [
-            "RVTEST_CLR_SSW_INT",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mip, x{r_scratch})",
             "RVTEST_CLR_MSW_INT",
             "RVTEST_CLR_SEXT_INT",
             "RVTEST_CLR_MEXT_INT",
@@ -3856,7 +3990,8 @@ def _generate_global_ie_tests(test_data: TestData) -> list[str]:
                 # Clear all interrupts
                 lines.extend(
                     [
-                        "RVTEST_CLR_SSW_INT",
+                        f"LI(x{r_scratch}, 0x2)",
+                        f"CSRC(mip, x{r_scratch})",
                         "RVTEST_CLR_MSW_INT",
                         "RVTEST_CLR_SEXT_INT",
                         "RVTEST_CLR_MEXT_INT",
@@ -4589,7 +4724,8 @@ def _generate_wfi_timeout_u_tests(test_data: TestData) -> list[str]:
             # Clear all interrupts
             lines.extend(
                 [
-                    "RVTEST_CLR_SSW_INT",
+                    f"LI(x{r_scratch}, 0x2)",
+                    f"CSRC(mip, x{r_scratch})",
                     "RVTEST_CLR_MSW_INT",
                 ]
             )

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
@@ -1,0 +1,1063 @@
+"""Supervisor-mode interrupt test generator for RISC-V privileged architecture.
+
+This module generates tests for supervisor-mode interrupts (STIP, SSIP, SEIP)
+following the exact pattern of InterruptsSm and InterruptsU.
+"""
+
+from testgen.asm.helpers import comment_banner
+from testgen.asm.interrupts import (
+    clr_mtimer_int,
+    clr_stimer_int,
+    set_mtimer_int,
+    set_stimer_int,
+)
+from testgen.data.state import TestData
+from testgen.priv.registry import add_priv_test_generator
+
+# def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
+#     """Generate STIP trigger tests.
+
+#     With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
+#     and mie = 1s (all interrupt enables), trigger STIP and change to supervisor mode.
+#     Cross: mideleg x SIE (2x2 = 4 bins)
+#     """
+#     covergroup = "InterruptsS_S_cg"
+#     coverpoint = "cp_trigger_sti"
+
+#     r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+#     lines = [
+#         comment_banner(
+#             "cp_trigger_sti",
+#             "Trigger STIP (supervisor timer interrupt)\n"
+#             "Cross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}\n"
+#             "With mstatus.MIE=0, mie=all 1s",
+#         ),
+#         "",
+#     ]
+
+#     # Cross: mideleg x SIE
+#     for mideleg_val in [0, 1]:  # 0=no delegation, 1=delegate all S-interrupts
+#         for sie_val in [0, 1]:
+#             mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+#             sie_name = f"sie_{sie_val}"
+#             binname = f"{mideleg_name}_{sie_name}"
+
+#             lines.extend([
+#                 "",
+#                 "# Setup delegation and interrupt enables",
+#                 "csrci mstatus, 8",  # Clear MIE (MIE=0 required by test plan)
+#             ])
+
+#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch))
+#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+#             # Set mideleg
+#             if mideleg_val:
+#                 lines.extend([
+#                     f"LI(x{r_scratch}, 0x222)",
+#                     f"CSRW(mideleg, x{r_scratch})",
+#                 ])
+#             else:
+#                 lines.append("CSRW(mideleg, zero)")
+
+#             # Set SPIE (for SIE after sret)
+#             lines.extend([
+#                 f"LI(x{r_scratch}, 0x20)",
+#                 f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+#             ])
+
+#             # Enable ALL interrupts in mie
+#             lines.extend([
+#                 f"LI(x{r_scratch}, -1)",
+#                 f"CSRW(mie, x{r_scratch})",
+#             ])
+
+#             # In M-mode before entering S-mode: Read STCE
+#             lines.extend([
+#                 "# Pre-read menvcfg.STCE in M-mode",
+#                 f"CSRR x{r_stce}, menvcfg",
+#                 "#if __riscv_xlen == 64",
+#                 f"    srli x{r_stce}, x{r_stce}, 63",
+#                 "#else",
+#                 f"    srli x{r_stce}, x{r_stce}, 31",
+#                 "#endif",
+#                 f"andi x{r_stce}, x{r_stce}, 0x1",
+#             ])
+
+#             # Enter S-mode FIRST
+#             lines.extend([
+#                 test_data.add_testcase(binname, coverpoint, covergroup),
+#                 "RVTEST_GOTO_LOWER_MODE Smode",
+#             ])
+
+#             # NOPs in S-mode for STIP=0 coverage
+#             for _ in range(40):
+#                 lines.append("    nop")
+
+#             # NOW trigger STIP while already IN S-mode
+#             # Call with pre-read STCE value
+#             lines.extend(["    " + line for line in set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce)])
+
+#             lines.extend([
+#                 "RVTEST_IDLE_FOR_INTERRUPT",
+#                 # "RVTEST_GOTO_MMODE",
+#                 "nop",
+#             ])
+
+#             # NOPs in S-mode for STIP=0 coverage
+#             for _ in range(40):
+#                 lines.append("    nop")
+
+#             lines.extend([
+#                 # "RVTEST_IDLE_FOR_INTERRUPT",
+#                 "RVTEST_GOTO_MMODE",
+#                 "nop",
+#             ])
+
+#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch))
+
+#     test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+#     return lines
+
+# def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
+#     """Generate STIP trigger tests.
+
+#     With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
+#     and mie = 1s (all interrupt enables), trigger STIP and change to supervisor mode.
+#     Cross: mideleg x SIE (2x2 = 4 bins)
+#     """
+#     covergroup = "InterruptsS_S_cg"
+#     coverpoint = "cp_trigger_sti"
+
+#     r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+#     lines = [
+#         comment_banner(
+#             "cp_trigger_sti",
+#             "Trigger STIP (supervisor timer interrupt)\n"
+#             "Cross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}\n"
+#             "With mstatus.MIE=0, mie=all 1s",
+#         ),
+#         "",
+#     ]
+
+#     # Cross: mideleg x SIE
+#     for mideleg_val in [0, 1]:  # 0=no delegation, 1=delegate all S-interrupts
+#         for sie_val in [0, 1]:
+#             mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+#             sie_name = f"sie_{sie_val}"
+#             binname = f"{mideleg_name}_{sie_name}"
+
+#             # === M-MODE SETUP ===
+#             lines.extend([
+#                 "",
+#                 "# M-mode setup",
+#                 "csrci mstatus, 8",  # MIE=0
+#             ])
+
+#             # Clear all timers first
+#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch))
+#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+#             # Set mideleg
+#             if mideleg_val:
+#                 lines.extend([
+#                     f"LI(x{r_scratch}, 0x222)",  # Delegate STI+SEI+SSI
+#                     f"CSRW(mideleg, x{r_scratch})",
+#                 ])
+#             else:
+#                 lines.append("CSRW(mideleg, zero)")
+
+#             # Set SPIE (controls SIE after sret)
+#             lines.extend([
+#                 f"LI(x{r_scratch}, 0x20)",  # SPIE bit
+#                 f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+#             ])
+
+#             # Enable all interrupts in mie
+#             lines.extend([
+#                 f"LI(x{r_scratch}, -1)",  # All interrupts
+#                 f"CSRW(mie, x{r_scratch})",
+#             ])
+
+#             # Read menvcfg.STCE (needed for timer operations in S-mode)
+#             lines.extend([
+#                 "# Read menvcfg.STCE",
+#                 f"CSRR x{r_stce}, menvcfg",
+#                 "#if __riscv_xlen == 64",
+#                 f"    srli x{r_stce}, x{r_stce}, 63",
+#                 "#else",
+#                 f"    srli x{r_stce}, x{r_stce}, 31",
+#                 "#endif",
+#                 f"andi x{r_stce}, x{r_stce}, 0x1",
+#             ])
+
+#             # === ENTER S-MODE ===
+#             lines.extend([
+#                 test_data.add_testcase(binname, coverpoint, covergroup),
+#                 "RVTEST_GOTO_LOWER_MODE Smode",
+#             ])
+
+#             # NOPs in S-mode for STIP=0 coverage
+#             for _ in range(40):
+#                 lines.append("    nop")
+
+#             # Set timer WHILE IN S-mode (uses pre-read STCE)
+#             lines.extend(["    " + line for line in set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce)])
+
+#             # Wait for interrupt (or not)
+#             lines.append("RVTEST_IDLE_FOR_INTERRUPT")
+
+#             # Clear timer BEFORE returning to M-mode (prevents spurious interrupt)
+#             lines.extend([
+#                 "",
+#                 "# Clear timer before M-mode return",
+#                 f"beqz x{r_stce}, 3f",  # Skip if STCE=0 (legacy needs M-mode)
+#                 "# Sstc: Clear stimecmp from S-mode",
+#                 f"    LI(x{r_temp}, -1)",
+#                 f"    csrw stimecmp, x{r_temp}",
+#                 "#if __riscv_xlen == 32",
+#                 f"    csrw stimecmph, x{r_temp}",
+#                 "#endif",
+#                 "3:",
+#             ])
+
+#             # Return to M-mode
+#             lines.extend([
+#                 "RVTEST_GOTO_MMODE",
+#                 "csrci mstatus, 8",  # Immediately disable MIE
+#             ])
+
+#             # Final cleanup in M-mode
+#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch))
+#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+#     test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+#     return lines
+
+
+def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
+    """Generate STIP trigger tests.
+
+    With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
+    and mie = 1s (all interrupt enables), trigger STIP and change to supervisor mode.
+    Cross: mideleg x SIE (2x2 = 4 bins)
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_sti"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_sti",
+            "Trigger STIP (supervisor timer interrupt)\n"
+            "Cross: mideleg={0/STI+SEI+SSI}ma x mstatus.SIE={0/1}\n"
+            "With mstatus.MIE=0, mie=all 1s",
+        ),
+        "",
+    ]
+
+    # Cross: mideleg x SIE
+    for mideleg_val in [0, 1]:  # 0=no delegation, 1=delegate all S-interrupts
+        for sie_val in [0, 1]:
+            mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+            sie_name = f"sie_{sie_val}"
+            binname = f"{mideleg_name}_{sie_name}"
+
+            # === M-MODE SETUP ===
+            lines.extend(
+                [
+                    "",
+                    "# M-mode setup",
+                    "csrci mstatus, 8",  # MIE=0
+                ]
+            )
+
+            # Clear all timers first
+            lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+            # Set mideleg
+            if mideleg_val:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x222)",  # Delegate STI+SEI+SSI
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            # Set SPIE (controls SIE after sret)
+            # lines.extend([
+            #     f"LI(x{r_scratch}, 0x20)",  # SPIE bit
+            #     f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+            # ])
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x02)",  # SIE bit 1, not SPIE!
+                    f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+                ]
+            )
+
+            # Enable all interrupts in mie
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, -1)",  # All interrupts
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
+            # Read menvcfg.STCE (needed for timer operations in S-mode)
+            lines.extend(
+                [
+                    "# Read menvcfg.STCE",
+                    f"CSRR x{r_stce}, menvcfg",
+                    "#if __riscv_xlen == 64",
+                    f"    srli x{r_stce}, x{r_stce}, 63",
+                    "#else",
+                    f"    srli x{r_stce}, x{r_stce}, 31",
+                    "#endif",
+                    f"andi x{r_stce}, x{r_stce}, 0x1",
+                ]
+            )
+
+            # === ENTER S-MODE ===
+            lines.extend(
+                [
+                    test_data.add_testcase(binname, coverpoint, covergroup),
+                    "RVTEST_GOTO_LOWER_MODE Smode",
+                ]
+            )
+
+            # TODO: adding this for now to get sie in s-mode:
+            # NOW set SIE in S-mode based on sie_val
+            # if sie_val:
+            #     lines.append("    csrsi sstatus, 2")  # Set SIE (bit 1 of sstatus)
+            # else:
+            #     lines.append("    csrci sstatus, 2")  # Clear SIE (bit 1 of sstatus)
+
+            # NOPs in S-mode for STIP=0 coverage
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 20)",  # 2500 iterations × 2 instructions = 5000 cycles
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
+
+            # Set timer WHILE IN S-mode (pass r_stce explicitly)
+            lines.extend(["    " + line for line in set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce)])
+
+            # More NOPs for STIP=1 coverage before interrupt fires
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 2500)",  # 2500 iterations × 2 instructions = 5000 cycles
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
+
+            # Wait for interrupt (or not)
+            lines.append("RVTEST_IDLE_FOR_INTERRUPT")
+
+            # Clear timer BEFORE returning to M-mode (prevents spurious interrupt)
+            lines.extend(
+                [
+                    "",
+                    "# Clear timer before M-mode return",
+                    f"beqz x{r_stce}, 3f",  # Skip if STCE=0 (legacy needs M-mode)
+                    "# Sstc: Clear stimecmp from S-mode",
+                    f"    LI(x{r_temp}, -1)",
+                    f"    csrw stimecmp, x{r_temp}",
+                    "#if __riscv_xlen == 32",
+                    f"    csrw stimecmph, x{r_temp}",
+                    "#endif",
+                    "3:",
+                ]
+            )
+
+            # Return to M-mode
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "csrci mstatus, 8",  # Immediately disable MIE
+                ]
+            )
+
+            # Final cleanup in M-mode
+            lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_trigger_ssi_mip_tests(test_data: TestData) -> list[str]:
+    """Generate SSIP trigger tests via mip.
+
+    With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
+    set mip.SSIP and change to supervisor mode.
+    Cross: mideleg x SIE (2x2 = 4 bins)
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_ssi_mip"
+
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_ssi_mip",
+            "Trigger SSIP via mip.SSIP\nCross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}",
+        ),
+        "",
+    ]
+
+    for mideleg_val in [0, 1]:
+        for sie_val in [0, 1]:
+            mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+            sie_name = f"sie_{sie_val}"
+            binname = f"{mideleg_name}_{sie_name}"
+
+            lines.extend(
+                [
+                    "",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",
+                ]
+            )
+
+            if mideleg_val:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x222)",
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x20)",  # SPIE
+                    f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+                    f"LI(x{r_scratch}, 0x02)",  # SSIE bit (bit 1)
+                    f"CSRW(mie, x{r_scratch})",
+                    test_data.add_testcase(binname, coverpoint, covergroup),
+                    "# Set mip.SSIP",
+                    f"LI(x{r_scratch}, 0x02)",
+                    f"CSRS(mip, x{r_scratch})",
+                    "RVTEST_GOTO_LOWER_MODE Smode",
+                    "RVTEST_IDLE_FOR_INTERRUPT",
+                    "RVTEST_GOTO_MMODE",
+                    "nop",
+                    "# Clear mip.SSIP",
+                    f"LI(x{r_scratch}, 0x02)",
+                    f"CSRC(mip, x{r_scratch})",
+                ]
+            )
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_trigger_ssi_sip_tests(test_data: TestData) -> list[str]:
+    """Generate SSIP trigger tests via sip.
+
+    With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
+    write sip.SSIP and change to supervisor mode.
+    Cross: mideleg x SIE (2x2 = 4 bins)
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_ssi_sip"
+
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_ssi_sip",
+            "Trigger SSIP via sip.SSIP\nCross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}",
+        ),
+        "",
+    ]
+
+    for mideleg_val in [0, 1]:
+        for sie_val in [0, 1]:
+            mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+            sie_name = f"sie_{sie_val}"
+            binname = f"{mideleg_name}_{sie_name}"
+
+            lines.extend(
+                [
+                    "",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",
+                ]
+            )
+
+            if mideleg_val:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x222)",
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x20)",
+                    f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+                    f"LI(x{r_scratch}, 0x02)",
+                    f"CSRW(mie, x{r_scratch})",
+                    "RVTEST_GOTO_LOWER_MODE Smode",
+                    test_data.add_testcase(binname, coverpoint, covergroup),
+                    "# Write sip.SSIP from S-mode",
+                    f"LI(x{r_scratch}, 0x02)",
+                    f"csrs sip, x{r_scratch})",
+                    "RVTEST_IDLE_FOR_INTERRUPT",
+                    "# Clear sip.SSIP",
+                    f"csrc sip, x{r_scratch}",
+                    "RVTEST_GOTO_MMODE",
+                    "nop",
+                ]
+            )
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_trigger_sei_tests(test_data: TestData) -> list[str]:
+    """Generate SEIP trigger tests via external interrupt controller.
+
+    With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
+    use PLIC/EIC to trigger SEIP and change to supervisor mode.
+    Cross: mideleg x SIE (2x2 = 4 bins)
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_sei"
+
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_sei",
+            "Trigger SEIP via external interrupt controller\nCross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}",
+        ),
+        "",
+    ]
+
+    for mideleg_val in [0, 1]:
+        for sie_val in [0, 1]:
+            mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+            sie_name = f"sie_{sie_val}"
+            binname = f"{mideleg_name}_{sie_name}"
+
+            lines.extend(
+                [
+                    "",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",
+                ]
+            )
+
+            if mideleg_val:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x222)",
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x20)",
+                    f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+                    f"LI(x{r_scratch}, 0x200)",  # SEIE bit (bit 9)
+                    f"CSRW(mie, x{r_scratch})",
+                    test_data.add_testcase(binname, coverpoint, covergroup),
+                    "RVTEST_SET_SEXT_INT",  # Platform-specific macro
+                    "RVTEST_GOTO_LOWER_MODE Smode",
+                    "RVTEST_IDLE_FOR_INTERRUPT",
+                    "RVTEST_GOTO_MMODE",
+                    "nop",
+                    "RVTEST_CLR_SEXT_INT",
+                ]
+            )
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_trigger_sei_seip_tests(test_data: TestData) -> list[str]:
+    """Generate SEIP trigger tests via mip.SEIP.
+
+    With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
+    write mip.SEIP and change to supervisor mode.
+    Cross: mideleg x SIE (2x2 = 4 bins)
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_sei_seip"
+
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_sei_seip",
+            "Set SEIP via mip.SEIP\nCross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}",
+        ),
+        "",
+    ]
+
+    for mideleg_val in [0, 1]:
+        for sie_val in [0, 1]:
+            mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+            sie_name = f"sie_{sie_val}"
+            binname = f"{mideleg_name}_{sie_name}"
+
+            lines.extend(
+                [
+                    "",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",
+                ]
+            )
+
+            if mideleg_val:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x222)",
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x20)",
+                    f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+                    f"LI(x{r_scratch}, 0x200)",
+                    f"CSRW(mie, x{r_scratch})",
+                    test_data.add_testcase(binname, coverpoint, covergroup),
+                    "# Set mip.SEIP",
+                    f"LI(x{r_scratch}, 0x200)",
+                    f"CSRS(mip, x{r_scratch})",
+                    "RVTEST_GOTO_LOWER_MODE Smode",
+                    "RVTEST_IDLE_FOR_INTERRUPT",
+                    "RVTEST_GOTO_MMODE",
+                    "nop",
+                    "# Clear mip.SEIP",
+                    f"LI(x{r_scratch}, 0x200)",
+                    f"CSRC(mip, x{r_scratch})",
+                ]
+            )
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_changingtos_sti_tests(test_data: TestData) -> list[str]:
+    """Generate STI interrupt trigger when changing to S-mode.
+
+    With mstatus.MIE=0, mstatus.SIE=0, mideleg={STI+SEI+SSI}, mie=1s,
+    set mip.STIP, change to supervisor mode, then enable sstatus.SIE.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_changingtos_sti"
+
+    r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch = test_data.int_regs.get_registers(5, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_changingtos_sti",
+            "Trigger STIP when changing to S-mode\nSet STIP, enter S-mode with SIE=0, then enable SIE",
+        ),
+        "",
+        "# Setup: mideleg=all, mie=all, MIE=0, SIE=0",
+        f"LI(x{r_scratch}, 0x222)",
+        f"CSRW(mideleg, x{r_scratch})",
+        f"LI(x{r_scratch}, -1)",
+        f"CSRW(mie, x{r_scratch})",
+        "csrci mstatus, 8",  # MIE=0
+        f"LI(x{r_scratch}, 0x20)",  # SPIE
+        f"CSRC(mstatus, x{r_scratch})",  # SIE will be 0 after sret
+        test_data.add_testcase("sti_changingtos", coverpoint, covergroup),
+        "# Set STIP",
+        f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
+        f"LA(x{r_stimecmp}, RVMODEL_STIMECMP_ADDRESS)",
+    ]
+
+    lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+
+    lines.extend(
+        [
+            "# Enter S-mode with SIE=0",
+            "RVTEST_GOTO_LOWER_MODE Smode",
+            "# Now in S-mode, enable SIE",
+            "csrsi sstatus, 2",  # sstatus.SIE bit 1
+            "RVTEST_IDLE_FOR_INTERRUPT",
+            "RVTEST_GOTO_MMODE",
+            "nop",
+        ]
+    )
+
+    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    test_data.int_regs.return_registers([r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch])
+    return lines
+
+
+def _generate_changingtos_ssi_tests(test_data: TestData) -> list[str]:
+    """Generate SSI interrupt trigger when changing to S-mode."""
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_changingtos_ssi"
+
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_changingtos_ssi",
+            "Trigger SSIP when changing to S-mode",
+        ),
+        "",
+        f"LI(x{r_scratch}, 0x222)",
+        f"CSRW(mideleg, x{r_scratch})",
+        f"LI(x{r_scratch}, -1)",
+        f"CSRW(mie, x{r_scratch})",
+        "csrci mstatus, 8",
+        f"LI(x{r_scratch}, 0x20)",
+        f"CSRC(mstatus, x{r_scratch})",
+        test_data.add_testcase("ssi_changingtos", coverpoint, covergroup),
+        f"LI(x{r_scratch}, 0x02)",
+        f"CSRS(mip, x{r_scratch})",
+        "RVTEST_GOTO_LOWER_MODE Smode",
+        "csrsi sstatus, 2",
+        "RVTEST_IDLE_FOR_INTERRUPT",
+        "RVTEST_GOTO_MMODE",
+        "nop",
+        f"LI(x{r_scratch}, 0x02)",
+        f"CSRC(mip, x{r_scratch})",
+    ]
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_changingtos_sei_tests(test_data: TestData) -> list[str]:
+    """Generate SEI interrupt trigger when changing to S-mode."""
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_changingtos_sei"
+
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_changingtos_sei",
+            "Trigger SEIP when changing to S-mode",
+        ),
+        "",
+        f"LI(x{r_scratch}, 0x222)",
+        f"CSRW(mideleg, x{r_scratch})",
+        f"LI(x{r_scratch}, -1)",
+        f"CSRW(mie, x{r_scratch})",
+        "csrci mstatus, 8",
+        f"LI(x{r_scratch}, 0x20)",
+        f"CSRC(mstatus, x{r_scratch})",
+        test_data.add_testcase("sei_changingtos", coverpoint, covergroup),
+        f"LI(x{r_scratch}, 0x200)",
+        f"CSRS(mip, x{r_scratch})",
+        "RVTEST_GOTO_LOWER_MODE Smode",
+        "csrsi sstatus, 2",
+        "RVTEST_IDLE_FOR_INTERRUPT",
+        "RVTEST_GOTO_MMODE",
+        "nop",
+        f"LI(x{r_scratch}, 0x200)",
+        f"CSRC(mip, x{r_scratch})",
+    ]
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_interrupts_s_tests(test_data: TestData) -> list[str]:
+    """Generate interrupt cross-product tests.
+
+    Cross of mstatus.MIE = 0, mtvec.MODE = 00, mideleg={0/STI+SEI+SSI},
+    6 walking 1s in mie, 6 walking 1s in mip, change to supervisor mode.
+    (2 x 6 x 6 = 72 bins)
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_interrupts_s"
+
+    r_mtime, r_stimecmp, r_temp, r_temp2, r_mie_val, r_scratch = test_data.int_regs.get_registers(
+        6, exclude_regs=[0, 2]
+    )
+
+    lines = [
+        comment_banner(
+            "cp_interrupts_s",
+            "Cross product: mideleg x mie x mip\n2 x 6 x 6 = 72 bins",
+        ),
+        "",
+    ]
+
+    # mideleg: 0 (no delegation) or 1 (delegate all S-interrupts)
+    for mideleg_val in [0, 1]:
+        mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+
+        lines.extend(
+            [
+                "",
+                f"# mideleg = {mideleg_name}",
+                "csrci mstatus, 8",  # MIE=0
+            ]
+        )
+
+        if mideleg_val:
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x222)",
+                    f"CSRW(mideleg, x{r_scratch})",
+                ]
+            )
+        else:
+            lines.append("CSRW(mideleg, zero)")
+
+        # 6 walking 1s in mie: SSIE, STIE, SEIE and combinations
+        for s1 in range(6):
+            # s1: 0=none, 1=SSIE, 2=STIE, 3=SSIE+STIE, 4=SEIE, 5=SSIE+SEIE
+            mie_bits = 0
+            if s1 & 1:
+                mie_bits |= 0x02  # SSIE
+            if s1 & 2:
+                mie_bits |= 0x20  # STIE
+            if s1 & 4:
+                mie_bits |= 0x200  # SEIE
+
+            lines.extend(
+                [
+                    f"LI(x{r_mie_val}, {mie_bits})",
+                    f"CSRW(mie, x{r_mie_val})",
+                ]
+            )
+
+            # 6 walking 1s in mip: SSIP, STIP, SEIP and combinations
+            for s2 in range(6):
+                binname = f"{mideleg_name}_mie_{s1:03b}_mip_{s2:03b}"
+
+                lines.extend(
+                    [
+                        "",
+                        "CSRW(mie, zero)",  # Disable while setting interrupts
+                        test_data.add_testcase(binname, coverpoint, covergroup),
+                    ]
+                )
+
+                # Set interrupt pending bits based on s2
+                if s2 & 1:  # SSIP
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x02)",
+                            f"CSRS(mip, x{r_scratch})",
+                        ]
+                    )
+                if s2 & 2:  # STIP
+                    lines.extend(
+                        [
+                            f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
+                            f"LA(x{r_stimecmp}, RVMODEL_STIMECMP_ADDRESS)",
+                            *set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2),
+                        ]
+                    )
+                if s2 & 4:  # SEIP
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x200)",
+                            f"CSRS(mip, x{r_scratch})",
+                        ]
+                    )
+
+                # Settling delay
+                for _ in range(5):
+                    lines.append("    nop")
+
+                # Enable interrupts and enter S-mode
+                lines.extend(
+                    [
+                        f"CSRW(mie, x{r_mie_val})",
+                        "RVTEST_GOTO_LOWER_MODE Smode",
+                        "RVTEST_IDLE_FOR_INTERRUPT",
+                        "RVTEST_GOTO_MMODE",
+                        "nop",
+                    ]
+                )
+
+                # Clear all interrupts
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x202)",  # Clear SSIP and SEIP
+                        f"CSRC(mip, x{r_scratch})",
+                        *clr_mtimer_int(r_temp, r_stimecmp),
+                    ]
+                )
+
+    test_data.int_regs.return_registers([r_mtime, r_stimecmp, r_temp, r_temp2, r_mie_val, r_scratch])
+    return lines
+
+
+def _generate_vectored_s_tests(test_data: TestData) -> list[str]:
+    """Generate vectored interrupt mode tests.
+
+    Cross of stvec.MODE = 00/01, mstatus.MIE=0, mstatus.SIE = 1, mie = 1s,
+    mideleg = {STI+SEI+SSI}, 6 different interrupts walking in mip.
+    (2 x 6 = 12 bins)
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_vectored_s"
+
+    r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch, r_csr_tmp = test_data.int_regs.get_registers(
+        6, exclude_regs=[0, 2]
+    )
+
+    lines = [
+        comment_banner(
+            "cp_vectored_s",
+            "Vectored interrupt mode tests\nCross: stvec.MODE x interrupt type (2 x 6 = 12 bins)",
+        ),
+        "",
+    ]
+
+    # Test both direct (00) and vectored (01) modes
+    for mode in [0, 1]:
+        mode_name = ["direct", "vectored"][mode]
+
+        lines.extend(
+            [
+                "",
+                f"# stvec.MODE = {mode:02b} ({mode_name})",
+                "# Setup: delegate all S-interrupts, enable all",
+                f"LI(x{r_scratch}, 0x222)",
+                f"CSRW(mideleg, x{r_scratch})",
+                "csrci mstatus, 8",  # MIE=0
+                f"LI(x{r_scratch}, 0x20)",  # SPIE=1 (SIE will be 1 in S-mode)
+                f"CSRS(mstatus, x{r_scratch})",
+                f"LI(x{r_scratch}, -1)",
+                f"CSRW(mie, x{r_scratch})",
+                "# Set stvec.MODE",
+                "csrci stvec, 3",
+                f"csrsi stvec, {mode}",
+            ]
+        )
+
+        # 6 interrupt types: SSIP, STIP, SEIP, SSIP+STIP, SSIP+SEIP, STIP+SEIP
+        for s2 in range(6):
+            int_name = f"int_{s2:03b}"
+            binname = f"{mode_name}_{int_name}"
+
+            lines.extend(
+                [
+                    "",
+                    "CSRW(mie, zero)",
+                    test_data.add_testcase(binname, coverpoint, covergroup),
+                ]
+            )
+
+            # Trigger interrupts based on s2
+            if s2 & 1:  # SSIP
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x02)",
+                        f"CSRS(mip, x{r_scratch})",
+                    ]
+                )
+            if s2 & 2:  # STIP
+                lines.extend(
+                    [
+                        f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
+                        f"LA(x{r_stimecmp}, RVMODEL_STIMECMP_ADDRESS)",
+                        *set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2),
+                    ]
+                )
+            if s2 & 4:  # SEIP
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x200)",
+                        f"CSRS(mip, x{r_scratch})",
+                    ]
+                )
+
+            # Settling delay
+            for _ in range(5):
+                lines.append("    nop")
+
+            # Enable all S-interrupts and enter S-mode
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x222)",
+                    f"CSRW(mie, x{r_scratch})",
+                    "RVTEST_GOTO_LOWER_MODE Smode",
+                    "RVTEST_IDLE_FOR_INTERRUPT",
+                    "RVTEST_GOTO_MMODE",
+                    "nop",
+                ]
+            )
+
+            # Clear all interrupts
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x202)",
+                    f"CSRC(mip, x{r_scratch})",
+                    *clr_mtimer_int(r_temp, r_stimecmp),
+                ]
+            )
+
+        # Restore stvec.MODE to direct
+        lines.append("csrci stvec, 1")
+
+    test_data.int_regs.return_registers([r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch, r_csr_tmp])
+    return lines
+
+
+@add_priv_test_generator("InterruptsS", required_extensions=["Sm", "S", "I", "Zicsr"])
+def make_interruptss_s(test_data: TestData) -> list[str]:
+    """Generate supervisor-mode interrupt tests.
+
+    Test supervisor-mode interrupts with delegation from M-mode.
+    All tests execute in S-mode after proper mideleg setup.
+    """
+    r_temp = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "InterruptsS_S",
+            "Supervisor-mode interrupt tests\nTests S-mode interrupts (STIP, SSIP, SEIP) with M→S delegation",
+        ),
+        "",
+        "# Initial setup - clear mideleg (no U-mode delegation)",
+        "CSRW(mideleg, zero)",
+        f"LI(x{r_temp}, 0x200000)",  # Clear TW bit
+        f"CSRC(mstatus, x{r_temp})",
+        "",
+    ]
+
+    test_data.int_regs.return_registers([r_temp])
+
+    # Generate all test functions
+    lines.extend(_generate_trigger_sti_tests(test_data))
+    # lines.extend(_generate_trigger_ssi_mip_tests(test_data))
+    # lines.extend(_generate_trigger_ssi_sip_tests(test_data))
+    # lines.extend(_generate_trigger_sei_tests(test_data))
+    # lines.extend(_generate_trigger_sei_seip_tests(test_data))
+    # lines.extend(_generate_changingtos_sti_tests(test_data))
+    # lines.extend(_generate_changingtos_ssi_tests(test_data))
+    # lines.extend(_generate_changingtos_sei_tests(test_data))
+    # lines.extend(_generate_interrupts_s_tests(test_data))
+    # lines.extend(_generate_vectored_s_tests(test_data))
+
+    return lines

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
@@ -1,489 +1,22 @@
 """Supervisor-mode interrupt test generator for RISC-V privileged architecture.
 
-This module generates tests for supervisor-mode interrupts (STIP, SSIP, SEIP)
-following the exact pattern of InterruptsSm and InterruptsU.
+This module generates tests for supervisor-mode interrupts (STIP, SSIP, SEIP),
+covering both non-delegated (fires in M-mode) and delegated (fires in S-mode)
+interrupt handling across a wide range of mideleg, mie, and mstatus configurations.
 """
 
 from testgen.asm.helpers import comment_banner
 from testgen.asm.interrupts import (
     clr_mtimer_int,
     clr_stimer_int,
+    clr_stimer_mmode,
     set_mtimer_int,
+    set_mtimer_int_soon,
+    set_stimer_int,
+    set_stimer_mmode,
 )
 from testgen.data.state import TestData
 from testgen.priv.registry import add_priv_test_generator
-
-# def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
-#     """Generate STIP trigger tests.
-
-#     With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
-#     and mie = 1s (all interrupt enables), trigger STIP and change to supervisor mode.
-#     Cross: mideleg x SIE (2x2 = 4 bins)
-#     """
-#     covergroup = "InterruptsS_S_cg"
-#     coverpoint = "cp_trigger_sti"
-
-#     r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
-
-#     lines = [
-#         comment_banner(
-#             "cp_trigger_sti",
-#             "Trigger STIP (supervisor timer interrupt)\n"
-#             "Cross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}\n"
-#             "With mstatus.MIE=0, mie=all 1s",
-#         ),
-#         "",
-#     ]
-
-#     # Cross: mideleg x SIE
-#     for mideleg_val in [0, 1]:  # 0=no delegation, 1=delegate all S-interrupts
-#         for sie_val in [0, 1]:
-#             mideleg_name = ["nodeleg", "deleg"][mideleg_val]
-#             sie_name = f"sie_{sie_val}"
-#             binname = f"{mideleg_name}_{sie_name}"
-
-#             lines.extend([
-#                 "",
-#                 "# Setup delegation and interrupt enables",
-#                 "csrci mstatus, 8",  # Clear MIE (MIE=0 required by test plan)
-#             ])
-
-#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch))
-#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
-
-#             # Set mideleg
-#             if mideleg_val:
-#                 lines.extend([
-#                     f"LI(x{r_scratch}, 0x222)",
-#                     f"CSRW(mideleg, x{r_scratch})",
-#                 ])
-#             else:
-#                 lines.append("CSRW(mideleg, zero)")
-
-#             # Set SPIE (for SIE after sret)
-#             lines.extend([
-#                 f"LI(x{r_scratch}, 0x20)",
-#                 f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-#             ])
-
-#             # Enable ALL interrupts in mie
-#             lines.extend([
-#                 f"LI(x{r_scratch}, -1)",
-#                 f"CSRW(mie, x{r_scratch})",
-#             ])
-
-#             # In M-mode before entering S-mode: Read STCE
-#             lines.extend([
-#                 "# Pre-read menvcfg.STCE in M-mode",
-#                 f"CSRR x{r_stce}, menvcfg",
-#                 "#if __riscv_xlen == 64",
-#                 f"    srli x{r_stce}, x{r_stce}, 63",
-#                 "#else",
-#                 f"    srli x{r_stce}, x{r_stce}, 31",
-#                 "#endif",
-#                 f"andi x{r_stce}, x{r_stce}, 0x1",
-#             ])
-
-#             # Enter S-mode FIRST
-#             lines.extend([
-#                 test_data.add_testcase(binname, coverpoint, covergroup),
-#                 "RVTEST_GOTO_LOWER_MODE Smode",
-#             ])
-
-#             # NOPs in S-mode for STIP=0 coverage
-#             for _ in range(40):
-#                 lines.append("    nop")
-
-#             # NOW trigger STIP while already IN S-mode
-#             # Call with pre-read STCE value
-#             lines.extend(["    " + line for line in set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce)])
-
-#             lines.extend([
-#                 "RVTEST_IDLE_FOR_INTERRUPT",
-#                 # "RVTEST_GOTO_MMODE",
-#                 "nop",
-#             ])
-
-#             # NOPs in S-mode for STIP=0 coverage
-#             for _ in range(40):
-#                 lines.append("    nop")
-
-#             lines.extend([
-#                 # "RVTEST_IDLE_FOR_INTERRUPT",
-#                 "RVTEST_GOTO_MMODE",
-#                 "nop",
-#             ])
-
-#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch))
-
-#     test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
-#     return lines
-
-# def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
-#     """Generate STIP trigger tests.
-
-#     With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
-#     and mie = 1s (all interrupt enables), trigger STIP and change to supervisor mode.
-#     Cross: mideleg x SIE (2x2 = 4 bins)
-#     """
-#     covergroup = "InterruptsS_S_cg"
-#     coverpoint = "cp_trigger_sti"
-
-#     r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
-
-#     lines = [
-#         comment_banner(
-#             "cp_trigger_sti",
-#             "Trigger STIP (supervisor timer interrupt)\n"
-#             "Cross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}\n"
-#             "With mstatus.MIE=0, mie=all 1s",
-#         ),
-#         "",
-#     ]
-
-#     # Cross: mideleg x SIE
-#     for mideleg_val in [0, 1]:  # 0=no delegation, 1=delegate all S-interrupts
-#         for sie_val in [0, 1]:
-#             mideleg_name = ["nodeleg", "deleg"][mideleg_val]
-#             sie_name = f"sie_{sie_val}"
-#             binname = f"{mideleg_name}_{sie_name}"
-
-#             # === M-MODE SETUP ===
-#             lines.extend([
-#                 "",
-#                 "# M-mode setup",
-#                 "csrci mstatus, 8",  # MIE=0
-#             ])
-
-#             # Clear all timers first
-#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch))
-#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
-
-#             # Set mideleg
-#             if mideleg_val:
-#                 lines.extend([
-#                     f"LI(x{r_scratch}, 0x222)",  # Delegate STI+SEI+SSI
-#                     f"CSRW(mideleg, x{r_scratch})",
-#                 ])
-#             else:
-#                 lines.append("CSRW(mideleg, zero)")
-
-#             # Set SPIE (controls SIE after sret)
-#             lines.extend([
-#                 f"LI(x{r_scratch}, 0x20)",  # SPIE bit
-#                 f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-#             ])
-
-#             # Enable all interrupts in mie
-#             lines.extend([
-#                 f"LI(x{r_scratch}, -1)",  # All interrupts
-#                 f"CSRW(mie, x{r_scratch})",
-#             ])
-
-#             # Read menvcfg.STCE (needed for timer operations in S-mode)
-#             lines.extend([
-#                 "# Read menvcfg.STCE",
-#                 f"CSRR x{r_stce}, menvcfg",
-#                 "#if __riscv_xlen == 64",
-#                 f"    srli x{r_stce}, x{r_stce}, 63",
-#                 "#else",
-#                 f"    srli x{r_stce}, x{r_stce}, 31",
-#                 "#endif",
-#                 f"andi x{r_stce}, x{r_stce}, 0x1",
-#             ])
-
-#             # === ENTER S-MODE ===
-#             lines.extend([
-#                 test_data.add_testcase(binname, coverpoint, covergroup),
-#                 "RVTEST_GOTO_LOWER_MODE Smode",
-#             ])
-
-#             # NOPs in S-mode for STIP=0 coverage
-#             for _ in range(40):
-#                 lines.append("    nop")
-
-#             # Set timer WHILE IN S-mode (uses pre-read STCE)
-#             lines.extend(["    " + line for line in set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce)])
-
-#             # Wait for interrupt (or not)
-#             lines.append("RVTEST_IDLE_FOR_INTERRUPT")
-
-#             # Clear timer BEFORE returning to M-mode (prevents spurious interrupt)
-#             lines.extend([
-#                 "",
-#                 "# Clear timer before M-mode return",
-#                 f"beqz x{r_stce}, 3f",  # Skip if STCE=0 (legacy needs M-mode)
-#                 "# Sstc: Clear stimecmp from S-mode",
-#                 f"    LI(x{r_temp}, -1)",
-#                 f"    csrw stimecmp, x{r_temp}",
-#                 "#if __riscv_xlen == 32",
-#                 f"    csrw stimecmph, x{r_temp}",
-#                 "#endif",
-#                 "3:",
-#             ])
-
-#             # Return to M-mode
-#             lines.extend([
-#                 "RVTEST_GOTO_MMODE",
-#                 "csrci mstatus, 8",  # Immediately disable MIE
-#             ])
-
-#             # Final cleanup in M-mode
-#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch))
-#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
-
-#     test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
-#     return lines
-
-
-# def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
-#     """Generate STIP trigger tests.
-
-#     With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
-#     and mie = 1s (all interrupt enables), trigger STIP and change to supervisor mode.
-#     Cross: mideleg x SIE (2x2 = 4 bins)
-#     """
-#     covergroup = "InterruptsS_S_cg"
-#     coverpoint = "cp_trigger_sti"
-
-#     r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
-
-#     lines = [
-#         comment_banner(
-#             "cp_trigger_sti",
-#             "Trigger STIP (supervisor timer interrupt)\n"
-#             "Cross: mideleg={0/STI+SEI+SSI}ma x mstatus.SIE={0/1}\n"
-#             "With mstatus.MIE=0, mie=all 1s",
-#         ),
-#         "",
-#     ]
-
-#     # Cross: mideleg x SIE
-#     for mideleg_val in [0, 1]:  # 0=no delegation, 1=delegate all S-interrupts
-#         for sie_val in [0, 1]:
-#             mideleg_name = ["nodeleg", "deleg"][mideleg_val]
-#             sie_name = f"sie_{sie_val}"
-#             binname = f"{mideleg_name}_{sie_name}"
-
-#             # === M-MODE SETUP ===
-#             lines.extend(
-#                 [
-#                     "",
-#                     "# M-mode setup",
-#                     "csrci mstatus, 8",  # MIE=0
-#                 ]
-#             )
-
-#             # Clear all timers first
-#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
-#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
-
-#             # Set mideleg
-#             if mideleg_val:
-#                 lines.extend(
-#                     [
-#                         f"LI(x{r_scratch}, 0x222)",  # Delegate STI+SEI+SSI
-#                         f"CSRW(mideleg, x{r_scratch})",
-#                     ]
-#                 )
-#             else:
-#                 lines.append("CSRW(mideleg, zero)")
-
-#             # Set SPIE (controls SIE after sret)
-#             # lines.extend([
-#             #     f"LI(x{r_scratch}, 0x20)",  # SPIE bit
-#             #     f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-#             # ])
-#             lines.extend(
-#                 [
-#                     f"LI(x{r_scratch}, 0x02)",  # SIE bit 1, not SPIE!
-#                     f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-#                 ]
-#             )
-
-#             # Enable all interrupts in mie
-#             lines.extend(
-#                 [
-#                     f"LI(x{r_scratch}, -1)",  # All interrupts
-#                     f"CSRW(mie, x{r_scratch})",
-#                 ]
-#             )
-
-#             # Read menvcfg.STCE (needed for timer operations in S-mode)
-#             lines.extend(
-#                 [
-#                     "# Read menvcfg.STCE",
-#                     f"CSRR x{r_stce}, menvcfg",
-#                     "#if __riscv_xlen == 64",
-#                     f"    srli x{r_stce}, x{r_stce}, 63",
-#                     "#else",
-#                     f"    srli x{r_stce}, x{r_stce}, 31",
-#                     "#endif",
-#                     f"andi x{r_stce}, x{r_stce}, 0x1",
-#                 ]
-#             )
-
-#             # === ENTER S-MODE ===
-#             lines.extend(
-#                 [
-#                     test_data.add_testcase(binname, coverpoint, covergroup),
-#                     "RVTEST_GOTO_LOWER_MODE Smode",
-#                 ]
-#             )
-
-#             # TODO: adding this for now to get sie in s-mode:
-#             # NOW set SIE in S-mode based on sie_val
-#             # if sie_val:
-#             #     lines.append("    csrsi sstatus, 2")  # Set SIE (bit 1 of sstatus)
-#             # else:
-#             #     lines.append("    csrci sstatus, 2")  # Clear SIE (bit 1 of sstatus)
-
-#             # NOPs in S-mode for STIP=0 coverage
-#             lines.extend(
-#                 [
-#                     f"    LI(x{r_scratch}, 20)",  # 2500 iterations × 2 instructions = 5000 cycles
-#                     f"1:  addi x{r_scratch}, x{r_scratch}, -1",
-#                     f"    bnez x{r_scratch}, 1b",
-#                 ]
-#             )
-
-#             # Set timer WHILE IN S-mode (pass r_stce explicitly)
-#             lines.extend(["    " + line for line in set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce)])
-
-#             # More NOPs for STIP=1 coverage before interrupt fires
-#             lines.extend(
-#                 [
-#                     f"    LI(x{r_scratch}, 2500)",  # 2500 iterations × 2 instructions = 5000 cycles
-#                     f"1:  addi x{r_scratch}, x{r_scratch}, -1",
-#                     f"    bnez x{r_scratch}, 1b",
-#                 ]
-#             )
-
-#             # Wait for interrupt (or not)
-#             lines.append("RVTEST_IDLE_FOR_INTERRUPT")
-
-#             # Clear timer BEFORE returning to M-mode (prevents spurious interrupt)
-#             lines.extend(
-#                 [
-#                     "",
-#                     "# Clear timer before M-mode return",
-#                     f"beqz x{r_stce}, 3f",  # Skip if STCE=0 (legacy needs M-mode)
-#                     "# Sstc: Clear stimecmp from S-mode",
-#                     f"    LI(x{r_temp}, -1)",
-#                     f"    csrw stimecmp, x{r_temp}",
-#                     "#if __riscv_xlen == 32",
-#                     f"    csrw stimecmph, x{r_temp}",
-#                     "#endif",
-#                     "3:",
-#                 ]
-#             )
-
-#             # Return to M-mode
-#             lines.extend(
-#                 [
-#                     "RVTEST_GOTO_MMODE",
-#                     "csrci mstatus, 8",  # Immediately disable MIE
-#                 ]
-#             )
-
-#             # Final cleanup in M-mode
-#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
-#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
-
-#     test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
-#     return lines
-
-# worshsipping this, one above is more og
-# def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
-#     """Generate STIP trigger tests.
-
-#     With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
-#     and mie = 1s (all interrupt enables), mip.STIP=1, change to supervisor mode.
-#     Cross: mideleg x SIE (2x2 = 4 bins)
-#     """
-#     covergroup = "InterruptsS_S_cg"
-#     coverpoint = "cp_trigger_sti"
-
-#     r_scratch = test_data.int_regs.get_registers(1, exclude_regs=[0, 2])[0]
-
-#     lines = [
-#         comment_banner(
-#             "cp_trigger_sti",
-#             "Trigger STIP (supervisor timer interrupt)\n"
-#             "Cross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}\n"
-#             "With mstatus.MIE=0, mie=all 1s, mip.STIP=1",
-#         ),
-#         "",
-#     ]
-
-#     # Cross: mideleg x SIE
-#     for mideleg_val in [0, 1]:
-#         for sie_val in [0, 1]:
-#             mideleg_name = ["nodeleg", "deleg"][mideleg_val]
-#             sie_name = f"sie_{sie_val}"
-#             binname = f"{mideleg_name}_{sie_name}"
-
-#             # === M-MODE SETUP (safe order) ===
-#             lines.extend([
-#                 "",
-#                 "# M-mode setup",
-#                 "CSRW(mie, zero)",  # 1. Disable ALL interrupts first
-#                 "csrci mstatus, 8",  # 2. MIE=0
-#                 f"LI(x{r_scratch}, 0x20)",  # 3. Clear any pending STIP
-#                 f"CSRC(mip, x{r_scratch})",
-#                 "csrci mstatus, 2",  # 3. SIE=0 (clear first)
-#             ])
-
-#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch))
-#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
-
-#             # 4. Set mideleg
-#             if mideleg_val:
-#                 lines.extend([
-#                     f"LI(x{r_scratch}, 0x222)",  # Delegate STI+SEI+SSI
-#                     f"CSRW(mideleg, x{r_scratch})",
-#                 ])
-#             else:
-#                 lines.append("CSRW(mideleg, zero)")
-
-#             # 5. Enable all interrupts in mie (but MIE still 0)
-#             lines.extend([
-#                 f"LI(x{r_scratch}, -1)",
-#                 f"CSRW(mie, x{r_scratch})",
-#             ])
-
-#             # 6. Set SIE in mstatus (last step before STIP)
-#             lines.extend([
-#                 f"LI(x{r_scratch}, 0x02)",  # SIE bit
-#                 f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-#             ])
-
-#             # 7. Set STIP (test plan: "mip.STIP=1")
-#             # lines.extend([
-#             #     test_data.add_testcase(binname, coverpoint, covergroup),
-#             #     f"LI(x{r_scratch}, 0x20)",  # STIP bit
-#             #     f"CSRS(mip, x{r_scratch})",
-#             #     "nop",
-#             # ])
-
-#             # 8. Enter S-mode (test plan: "change to supervisor mode")
-#             lines.extend([
-#                 "RVTEST_GOTO_LOWER_MODE Smode",
-#                 "nop",
-#                 "nop",
-#                 "nop",
-#             ])
-
-#             # 9. Return and cleanup
-#             lines.extend([
-#                 "RVTEST_GOTO_MMODE",
-#                 "csrci mstatus, 8",  # Disable MIE
-#                 f"LI(x{r_scratch}, 0x20)",
-#                 f"CSRC(mip, x{r_scratch})",  # Clear STIP
-#             ])
-
-#     test_data.int_regs.return_registers([r_scratch])
-#     return lines
 
 
 def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
@@ -570,20 +103,17 @@ def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
                 ]
             )
 
-            # 8. Set STIP directly (we're in M-mode, can write mip directly)
+            # 8. Set STIP using timer functions
+            lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+            lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
+
             lines.extend(
                 [
-                    test_data.add_testcase(binname, coverpoint, covergroup),
-                    f"LI(x{r_scratch}, 0x20)",  # STIP bit
-                    f"CSRS(mip, x{r_scratch})",  # Set mip.STIP=1
-                    "nop",
+                    f"    LI(x{r_scratch}, 2500)",  # 2500 iterations × 2 instructions = 5000 cycles
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
                 ]
             )
-
-            # 8. Set STIP using timer functions
-            # lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
-            # lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
-            lines.append("nop")
 
             # 9. Enter S-mode
             lines.extend(
@@ -592,16 +122,6 @@ def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
                     "nop",
                     "nop",
                     "nop",
-                ]
-            )
-
-            # lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
-
-            lines.extend(
-                [
-                    f"    LI(x{r_scratch}, 2500)",  # 2500 iterations × 2 instructions = 5000 cycles
-                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
-                    f"    bnez x{r_scratch}, 1b",
                 ]
             )
 
@@ -614,84 +134,144 @@ def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
                     "csrci mstatus, 2",  # Clear SIE
                     "CSRW(mideleg, zero)",  # Clear delegation
                     "CSRW(mie, zero)",  # Clear all interrupt enables
-                    f"LI(x{r_scratch}, 0x20)",  # Clear STIP
-                    f"CSRC(mip, x{r_scratch})",
                 ]
             )
 
             # Clear timer
             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
-            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
 
     test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
     return lines
 
 
 def _generate_trigger_ssi_mip_tests(test_data: TestData) -> list[str]:
-    """Generate SSIP trigger tests via mip.
+    """Generate SSIP trigger tests.
 
     With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
-    set mip.SSIP and change to supervisor mode.
-    Cross: mideleg x SIE (2x2 = 4 bins)
+    and mie = 1s (all interrupt enables), trigger SSIP and change to supervisor mode.
+    Cross: mideleg x SIE/MIE (2x2 = 4 bins)
     """
     covergroup = "InterruptsS_S_cg"
-    coverpoint = "cp_trigger_ssi_mip"
 
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
 
     lines = [
         comment_banner(
             "cp_trigger_ssi_mip",
-            "Trigger SSIP via mip.SSIP\nCross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}",
+            "Trigger SSIP (supervisor software interrupt)\n"
+            "Cross: mideleg={0/STI+SEI+SSI} x mstatus.SIE/MIE={0/1}\n"
+            "With mstatus.MIE=0 (delegated) or MIE={0/1} (not delegated), mie=all 1s",
         ),
         "",
     ]
 
+    # Cross: mideleg x SIE/MIE
     for mideleg_val in [0, 1]:
-        for sie_val in [0, 1]:
+        for int_enable_val in [0, 1]:
             mideleg_name = ["nodeleg", "deleg"][mideleg_val]
-            sie_name = f"sie_{sie_val}"
-            binname = f"{mideleg_name}_{sie_name}"
 
+            if mideleg_val == 1:
+                # Delegated: cp_trigger_ssi_mip, vary SIE
+                coverpoint = "cp_trigger_ssi_mip"
+                enable_name = f"sie_{int_enable_val}"
+            else:
+                # Not delegated: cp_trigger_ssi_mip2, vary MIE
+                coverpoint = "cp_trigger_ssi_mip2"
+                enable_name = f"mie_{int_enable_val}"
+
+            binname = f"{mideleg_name}_{enable_name}"
+
+            # === M-MODE SETUP (safe order) ===
             lines.extend(
                 [
                     "",
-                    "CSRW(mie, zero)",
-                    "csrci mstatus, 8",
+                    "# M-mode setup",
+                    "RVTEST_GOTO_MMODE",
+                    "CSRW(mie, zero)",  # 1. Disable ALL interrupts first
+                    "csrci mstatus, 8",  # 2. MIE=0
+                    "csrci mstatus, 2",  # 3. SIE=0 (clear first)
                 ]
             )
 
+            # Clear interrupts
+            lines.extend(clr_stimer_mmode(r_scratch))
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+            # Prevent machine timer from firing during test
+            lines.extend(
+                [
+                    f"LA(x{r_temp}, RVMODEL_MTIMECMP_ADDRESS)",
+                    f"LI(x{r_scratch}, -1)",
+                    f"SREG x{r_scratch}, 0(x{r_temp})",
+                ]
+            )
+
+            # 4. Set mideleg
             if mideleg_val:
                 lines.extend(
                     [
-                        f"LI(x{r_scratch}, 0x222)",
+                        f"LI(x{r_scratch}, 0x222)",  # Delegate STI+SEI+SSI
                         f"CSRW(mideleg, x{r_scratch})",
                     ]
                 )
             else:
                 lines.append("CSRW(mideleg, zero)")
 
+            # 5. Enable all interrupts in mie (but MIE still 0)
             lines.extend(
                 [
-                    f"LI(x{r_scratch}, 0x20)",  # SPIE
-                    f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x02)",  # SSIE bit (bit 1)
+                    f"LI(x{r_scratch}, -1)",
                     f"CSRW(mie, x{r_scratch})",
-                    test_data.add_testcase(binname, coverpoint, covergroup),
-                    "# Set mip.SSIP",
-                    f"LI(x{r_scratch}, 0x02)",
-                    f"CSRS(mip, x{r_scratch})",
-                    "RVTEST_GOTO_LOWER_MODE Smode",
-                    "RVTEST_IDLE_FOR_INTERRUPT",
-                    "RVTEST_GOTO_MMODE",
-                    "nop",
-                    "# Clear mip.SSIP",
-                    f"LI(x{r_scratch}, 0x02)",
-                    f"CSRC(mip, x{r_scratch})",
                 ]
             )
 
-    test_data.int_regs.return_registers([r_scratch])
+            # 6. Set SIE (delegated) or MIE (not delegated)
+            if mideleg_val == 1:
+                # Delegated: set SIE
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x02)",  # SIE bit
+                        f"{'CSRS' if int_enable_val else 'CSRC'}(mstatus, x{r_scratch})",
+                    ]
+                )
+            else:
+                # Not delegated: set MIE
+                if int_enable_val:
+                    lines.append("csrsi mstatus, 8")
+
+            # 7. Set SSIP
+            lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+            lines.extend(
+                [
+                    "RVTEST_SET_SSW_INT",
+                    "nop",
+                    "nop",
+                ]
+            )
+
+            # 8. Enter S-mode
+            lines.extend(
+                [
+                    "RVTEST_GOTO_LOWER_MODE Smode",
+                    "    nop",
+                    "    nop",
+                ]
+            )
+
+            # 9. Return and cleanup
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "# Complete state cleanup",
+                    "csrci mstatus, 8",  # Clear MIE
+                    "csrci mstatus, 2",  # Clear SIE
+                    "CSRW(mideleg, zero)",  # Clear delegation
+                    "CSRW(mie, zero)",  # Clear all interrupt enables
+                    "RVTEST_CLR_SSW_INT",
+                ]
+            )
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
     return lines
 
 
@@ -741,15 +321,15 @@ def _generate_trigger_ssi_sip_tests(test_data: TestData) -> list[str]:
 
             lines.extend(
                 [
-                    f"LI(x{r_scratch}, 0x20)",
+                    f"LI(x{r_scratch}, 0x02)",  # SIE bit
                     f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x02)",
+                    f"LI(x{r_scratch}, -1)",  # ✅ FIXED: All interrupt enables
                     f"CSRW(mie, x{r_scratch})",
                     "RVTEST_GOTO_LOWER_MODE Smode",
                     test_data.add_testcase(binname, coverpoint, covergroup),
                     "# Write sip.SSIP from S-mode",
                     f"LI(x{r_scratch}, 0x02)",
-                    f"csrs sip, x{r_scratch})",
+                    f"csrs sip, x{r_scratch}",
                     "RVTEST_IDLE_FOR_INTERRUPT",
                     "# Clear sip.SSIP",
                     f"csrc sip, x{r_scratch}",
@@ -763,75 +343,120 @@ def _generate_trigger_ssi_sip_tests(test_data: TestData) -> list[str]:
 
 
 def _generate_trigger_sei_tests(test_data: TestData) -> list[str]:
-    """Generate SEIP trigger tests via external interrupt controller.
+    """Generate SEIP trigger tests.
 
-    With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
-    use PLIC/EIC to trigger SEIP and change to supervisor mode.
-    Cross: mideleg x SIE (2x2 = 4 bins)
+    With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {STI+SEI+SSI},
+    and mie = 1s, trigger SEIP via PLIC/EIC and change to supervisor mode.
+    Cross: SIE (2 bins - only delegated case since coverpoint has mideleg_ones)
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_trigger_sei"
 
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+    r_scratch = test_data.int_regs.get_registers(1, exclude_regs=[0, 2])[0]
 
     lines = [
         comment_banner(
             "cp_trigger_sei",
-            "Trigger SEIP via external interrupt controller\nCross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}",
+            "Trigger SEIP (supervisor external interrupt)\n"
+            "Cross: mstatus.SIE={0/1}\n"
+            "With mstatus.MIE=0, mideleg=STI+SEI+SSI, mie=all 1s",
         ),
         "",
     ]
 
-    for mideleg_val in [0, 1]:
-        for sie_val in [0, 1]:
-            mideleg_name = ["nodeleg", "deleg"][mideleg_val]
-            sie_name = f"sie_{sie_val}"
-            binname = f"{mideleg_name}_{sie_name}"
+    # Only delegated case (coverpoint has mideleg_ones)
+    for sie_val in [0, 1]:
+        sie_name = f"sie_{sie_val}"
+        binname = f"deleg_{sie_name}"
 
-            lines.extend(
-                [
-                    "",
-                    "CSRW(mie, zero)",
-                    "csrci mstatus, 8",
-                ]
-            )
+        # === M-MODE SETUP ===
+        lines.extend(
+            [
+                "",
+                "# M-mode setup",
+                "CSRW(mie, zero)",  # Disable all interrupts
+                "csrci mstatus, 8",  # MIE=0
+                "csrci mstatus, 2",  # SIE=0
+            ]
+        )
 
-            if mideleg_val:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x222)",
-                        f"CSRW(mideleg, x{r_scratch})",
-                    ]
-                )
-            else:
-                lines.append("CSRW(mideleg, zero)")
+        # Clear SEIP
+        lines.append("RVTEST_CLR_SEXT_INT")
 
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x20)",
-                    f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x200)",  # SEIE bit (bit 9)
-                    f"CSRW(mie, x{r_scratch})",
-                    test_data.add_testcase(binname, coverpoint, covergroup),
-                    "RVTEST_SET_SEXT_INT",  # Platform-specific macro
-                    "RVTEST_GOTO_LOWER_MODE Smode",
-                    "RVTEST_IDLE_FOR_INTERRUPT",
-                    "RVTEST_GOTO_MMODE",
-                    "nop",
-                    "RVTEST_CLR_SEXT_INT",
-                ]
-            )
+        # Set mideleg (delegate STI+SEI+SSI)
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, 0x222)",
+                f"CSRW(mideleg, x{r_scratch})",
+            ]
+        )
+
+        # Enable all interrupts in mie
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, -1)",
+                f"CSRW(mie, x{r_scratch})",
+            ]
+        )
+
+        # Set SIE in mstatus
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, 0x02)",  # SIE bit
+                f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+            ]
+        )
+
+        # Set SEIP in M-mode using macro
+        lines.extend(
+            [
+                test_data.add_testcase(binname, coverpoint, covergroup),
+                "RVTEST_SET_SEXT_INT",
+                "nop",
+            ]
+        )
+
+        # Enter S-mode (SEIP already pending)
+        lines.extend(
+            [
+                "RVTEST_GOTO_LOWER_MODE Smode",
+            ]
+        )
+
+        # NOPs in S-mode for SEIP=1 coverage
+        lines.extend(
+            [
+                f"    LI(x{r_scratch}, 5000)",
+                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                f"    bnez x{r_scratch}, 1b",
+            ]
+        )
+
+        # Return and cleanup
+        lines.extend(
+            [
+                "RVTEST_GOTO_MMODE",
+                "# Complete state cleanup",
+                "csrci mstatus, 8",  # Clear MIE
+                "csrci mstatus, 2",  # Clear SIE
+                "CSRW(mideleg, zero)",  # Clear delegation
+                "CSRW(mie, zero)",  # Clear all interrupt enables
+            ]
+        )
+
+        # Clear SEIP
+        lines.append("RVTEST_CLR_SEXT_INT")
 
     test_data.int_regs.return_registers([r_scratch])
     return lines
 
 
 def _generate_trigger_sei_seip_tests(test_data: TestData) -> list[str]:
-    """Generate SEIP trigger tests via mip.SEIP.
+    """Generate SEIP trigger tests via sip write.
 
-    With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
-    write mip.SEIP and change to supervisor mode.
-    Cross: mideleg x SIE (2x2 = 4 bins)
+    With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {STI+SEI+SSI},
+    and mie = 1s, write sip.SEIP and change to supervisor mode.
+    Cross: SIE (2 bins - only delegated case)
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_trigger_sei_seip"
@@ -841,141 +466,252 @@ def _generate_trigger_sei_seip_tests(test_data: TestData) -> list[str]:
     lines = [
         comment_banner(
             "cp_trigger_sei_seip",
-            "Set SEIP via mip.SEIP\nCross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}",
+            "Trigger SEIP via sip.SEIP write\n"
+            "Cross: mstatus.SIE={0/1}\n"
+            "With mstatus.MIE=0, mideleg=STI+SEI+SSI, mie=all 1s",
         ),
         "",
     ]
 
-    for mideleg_val in [0, 1]:
-        for sie_val in [0, 1]:
-            mideleg_name = ["nodeleg", "deleg"][mideleg_val]
-            sie_name = f"sie_{sie_val}"
-            binname = f"{mideleg_name}_{sie_name}"
+    # Only delegated case
+    for sie_val in [0, 1]:
+        sie_name = f"sie_{sie_val}"
+        binname = f"deleg_{sie_name}"
 
-            lines.extend(
-                [
-                    "",
-                    "CSRW(mie, zero)",
-                    "csrci mstatus, 8",
-                ]
-            )
+        # === M-MODE SETUP ===
+        lines.extend(
+            [
+                "",
+                "CSRW(mie, zero)",
+                "csrci mstatus, 8",  # MIE=0
+                "csrci mstatus, 2",  # SIE=0
+            ]
+        )
 
-            if mideleg_val:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x222)",
-                        f"CSRW(mideleg, x{r_scratch})",
-                    ]
-                )
-            else:
-                lines.append("CSRW(mideleg, zero)")
+        # Set mideleg (delegate STI+SEI+SSI)
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, 0x222)",
+                f"CSRW(mideleg, x{r_scratch})",
+            ]
+        )
 
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x20)",
-                    f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x200)",
-                    f"CSRW(mie, x{r_scratch})",
-                    test_data.add_testcase(binname, coverpoint, covergroup),
-                    "# Set mip.SEIP",
-                    f"LI(x{r_scratch}, 0x200)",
-                    f"CSRS(mip, x{r_scratch})",
-                    "RVTEST_GOTO_LOWER_MODE Smode",
-                    "RVTEST_IDLE_FOR_INTERRUPT",
-                    "RVTEST_GOTO_MMODE",
-                    "nop",
-                    "# Clear mip.SEIP",
-                    f"LI(x{r_scratch}, 0x200)",
-                    f"CSRC(mip, x{r_scratch})",
-                ]
-            )
+        # Set SIE
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, 0x02)",
+                f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+            ]
+        )
+
+        # Enable all interrupts in mie
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, -1)",
+                f"CSRW(mie, x{r_scratch})",
+            ]
+        )
+
+        # Enter S-mode
+        lines.extend(
+            [
+                "RVTEST_GOTO_LOWER_MODE Smode",
+                test_data.add_testcase(binname, coverpoint, covergroup),
+                "# Write sip.SEIP from S-mode",
+                f"LI(x{r_scratch}, 0x200)",  # SEIP bit (bit 9)
+                f"csrs sip, x{r_scratch}",
+                "RVTEST_IDLE_FOR_INTERRUPT",
+                "# Clear sip.SEIP",
+                f"csrc sip, x{r_scratch}",
+            ]
+        )
+
+        # Return and cleanup
+        lines.extend(
+            [
+                "RVTEST_GOTO_MMODE",
+                "csrci mstatus, 8",
+                "csrci mstatus, 2",
+                "CSRW(mideleg, zero)",
+                "CSRW(mie, zero)",
+            ]
+        )
 
     test_data.int_regs.return_registers([r_scratch])
     return lines
 
 
 def _generate_changingtos_sti_tests(test_data: TestData) -> list[str]:
-    """Generate STI interrupt trigger when changing to S-mode.
+    """Generate STIP trigger test when changing to S-mode and enabling SIE.
 
     With mstatus.MIE=0, mstatus.SIE=0, mideleg={STI+SEI+SSI}, mie=1s,
-    set mip.STIP, change to supervisor mode, then enable sstatus.SIE.
+    set STIP, enter S-mode, then write sstatus.SIE=1 to trigger interrupt.
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_trigger_changingtos_sti"
 
-    r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch = test_data.int_regs.get_registers(5, exclude_regs=[0, 2])
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
 
     lines = [
         comment_banner(
             "cp_trigger_changingtos_sti",
-            "Trigger STIP when changing to S-mode\nSet STIP, enter S-mode with SIE=0, then enable SIE",
+            "Trigger STIP when enabling SIE in S-mode\n"
+            "Set STIP in M-mode, enter S-mode with SIE=0, then set sstatus.SIE=1",
         ),
         "",
-        "# Setup: mideleg=all, mie=all, MIE=0, SIE=0",
-        f"LI(x{r_scratch}, 0x222)",
-        f"CSRW(mideleg, x{r_scratch})",
-        f"LI(x{r_scratch}, -1)",
-        f"CSRW(mie, x{r_scratch})",
+        "# M-mode setup",
+        "CSRW(mie, zero)",
         "csrci mstatus, 8",  # MIE=0
-        f"LI(x{r_scratch}, 0x20)",  # SPIE
-        f"CSRC(mstatus, x{r_scratch})",  # SIE will be 0 after sret
-        test_data.add_testcase("sti_changingtos", coverpoint, covergroup),
-        "# Set STIP",
-        f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
-        f"LA(x{r_stimecmp}, RVMODEL_STIMECMP_ADDRESS)",
+        "csrci mstatus, 2",  # SIE=0 (critical: must be 0!)
     ]
 
-    lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+    # Clear timers
+    lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
 
+    # Set mideleg (delegate STI+SEI+SSI)
     lines.extend(
         [
-            "# Enter S-mode with SIE=0",
-            "RVTEST_GOTO_LOWER_MODE Smode",
-            "# Now in S-mode, enable SIE",
-            "csrsi sstatus, 2",  # sstatus.SIE bit 1
-            "RVTEST_IDLE_FOR_INTERRUPT",
-            "RVTEST_GOTO_MMODE",
-            "nop",
+            f"LI(x{r_scratch}, 0x222)",
+            f"CSRW(mideleg, x{r_scratch})",
         ]
     )
 
+    # Enable all interrupts in mie
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, -1)",
+            f"CSRW(mie, x{r_scratch})",
+        ]
+    )
+
+    # Read STCE
+    lines.extend(
+        [
+            f"CSRR x{r_stce}, menvcfg",
+            "#if __riscv_xlen == 64",
+            f"    srli x{r_stce}, x{r_stce}, 63",
+            "#else",
+            f"    srli x{r_stce}, x{r_stce}, 31",
+            "#endif",
+            f"andi x{r_stce}, x{r_stce}, 0x1",
+        ]
+    )
+
+    # Set STIP in M-mode
+    lines.append(test_data.add_testcase("changingtos_sti", coverpoint, covergroup))
+    lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
+
+    # Enter S-mode (SIE=0, so no trap yet despite STIP=1)
+    lines.extend(
+        [
+            "RVTEST_GOTO_LOWER_MODE Smode",
+        ]
+    )
+
+    # In S-mode with STIP=1, SIE=0
+    # Use CSRRS to set sstatus.SIE=1 (interrupt should fire immediately)
+    lines.extend(
+        [
+            f"    LI(x{r_scratch}, 0x02)",  # SIE bit
+            f"    csrrs x0, sstatus, x{r_scratch}",  # CSRRS sets SIE=1
+            "    nop",
+        ]
+    )
+
+    # Cleanup
+    lines.extend(
+        [
+            "RVTEST_GOTO_MMODE",
+            "csrci mstatus, 8",
+            "csrci mstatus, 2",
+            "CSRW(mideleg, zero)",
+            "CSRW(mie, zero)",
+        ]
+    )
+
+    lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
     lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
 
-    test_data.int_regs.return_registers([r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch])
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
     return lines
 
 
 def _generate_changingtos_ssi_tests(test_data: TestData) -> list[str]:
-    """Generate SSI interrupt trigger when changing to S-mode."""
+    """Generate SSIP trigger test when changing to S-mode and enabling SIE.
+
+    With mstatus.MIE=0, mstatus.SIE=0, mideleg={STI+SEI+SSI}, mie=1s,
+    set SSIP, enter S-mode, then write sstatus.SIE=1 to trigger interrupt.
+    """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_trigger_changingtos_ssi"
 
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+    r_scratch = test_data.int_regs.get_registers(1, exclude_regs=[0, 2])[0]
 
     lines = [
         comment_banner(
             "cp_trigger_changingtos_ssi",
-            "Trigger SSIP when changing to S-mode",
+            "Trigger SSIP when enabling SIE in S-mode\n"
+            "Set SSIP in M-mode, enter S-mode with SIE=0, then set sstatus.SIE=1",
         ),
         "",
-        f"LI(x{r_scratch}, 0x222)",
-        f"CSRW(mideleg, x{r_scratch})",
-        f"LI(x{r_scratch}, -1)",
-        f"CSRW(mie, x{r_scratch})",
-        "csrci mstatus, 8",
-        f"LI(x{r_scratch}, 0x20)",
-        f"CSRC(mstatus, x{r_scratch})",
-        test_data.add_testcase("ssi_changingtos", coverpoint, covergroup),
-        f"LI(x{r_scratch}, 0x02)",
-        f"CSRS(mip, x{r_scratch})",
-        "RVTEST_GOTO_LOWER_MODE Smode",
-        "csrsi sstatus, 2",
-        "RVTEST_IDLE_FOR_INTERRUPT",
-        "RVTEST_GOTO_MMODE",
-        "nop",
-        f"LI(x{r_scratch}, 0x02)",
-        f"CSRC(mip, x{r_scratch})",
+        "# M-mode setup",
+        "CSRW(mie, zero)",
+        "csrci mstatus, 8",  # MIE=0
+        "csrci mstatus, 2",  # SIE=0 (critical!)
     ]
+
+    # Clear SSIP
+    lines.append("RVTEST_CLR_SSW_INT")
+
+    # Set mideleg (delegate STI+SEI+SSI)
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, 0x222)",
+            f"CSRW(mideleg, x{r_scratch})",
+        ]
+    )
+
+    # Enable all interrupts in mie
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, -1)",
+            f"CSRW(mie, x{r_scratch})",
+        ]
+    )
+
+    # Set SSIP in M-mode
+    lines.extend(
+        [
+            test_data.add_testcase("changingtos_ssi", coverpoint, covergroup),
+            "RVTEST_SET_SSW_INT",
+            "nop",
+        ]
+    )
+
+    # Enter S-mode (SIE=0, so no trap yet despite SSIP=1)
+    lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+
+    # In S-mode: set sstatus.SIE=1 (interrupt should fire)
+    lines.extend(
+        [
+            f"    LI(x{r_scratch}, 0x02)",  # SIE bit
+            f"    csrrs x0, sstatus, x{r_scratch}",  # Set SIE=1
+            "RVTEST_IDLE_FOR_INTERRUPT",
+        ]
+    )
+
+    # Cleanup
+    lines.extend(
+        [
+            "RVTEST_GOTO_MMODE",
+            "csrci mstatus, 8",
+            "csrci mstatus, 2",
+            "CSRW(mideleg, zero)",
+            "CSRW(mie, zero)",
+            "RVTEST_CLR_SSW_INT",
+        ]
+    )
 
     test_data.int_regs.return_registers([r_scratch])
     return lines
@@ -1018,241 +754,3919 @@ def _generate_changingtos_sei_tests(test_data: TestData) -> list[str]:
 
 
 def _generate_interrupts_s_tests(test_data: TestData) -> list[str]:
-    """Generate interrupt cross-product tests.
+    """Generate interrupt tests with walking 1s in mip and mie.
 
-    Cross of mstatus.MIE = 0, mtvec.MODE = 00, mideleg={0/STI+SEI+SSI},
-    6 walking 1s in mie, 6 walking 1s in mip, change to supervisor mode.
-    (2 x 6 x 6 = 72 bins)
+    Tests: mideleg={0, 0x222} × 6 mip × 6 mie = 72 combinations
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_interrupts_s"
 
-    r_mtime, r_stimecmp, r_temp, r_temp2, r_mie_val, r_scratch = test_data.int_regs.get_registers(
-        6, exclude_regs=[0, 2]
-    )
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
 
     lines = [
         comment_banner(
             "cp_interrupts_s",
-            "Cross product: mideleg x mie x mip\n2 x 6 x 6 = 72 bins",
+            "Test interrupts with walking 1s in mip and mie\nmideleg={0, 0x222} × 6 mip × 6 mie = 72 tests",
         ),
         "",
     ]
 
-    # mideleg: 0 (no delegation) or 1 (delegate all S-interrupts)
+    # ALL 6 interrupts
+    mip_interrupts = [
+        ("ssip", 0x002, "RVTEST_SET_SSW_INT", "RVTEST_CLR_SSW_INT", False),
+        ("msip", 0x008, "RVTEST_SET_MSW_INT", "RVTEST_CLR_MSW_INT", False),
+        ("stip", 0x020, None, None, True),
+        ("mtip", 0x080, None, None, True),
+        ("seip", 0x200, "RVTEST_SET_SEXT_INT", "RVTEST_CLR_SEXT_INT", False),
+        ("meip", 0x800, "RVTEST_SET_MEXT_INT", "RVTEST_CLR_MEXT_INT", False),
+    ]
+
+    # ALL 6 interrupt enables
+    mie_bits = [
+        ("ssie", 0x002),
+        ("msie", 0x008),
+        ("stie", 0x020),
+        ("mtie", 0x080),
+        ("seie", 0x200),
+        ("meie", 0x800),
+    ]
+
+    # Test BOTH mideleg values
     for mideleg_val in [0, 1]:
         mideleg_name = ["nodeleg", "deleg"][mideleg_val]
 
-        lines.extend(
-            [
-                "",
-                f"# mideleg = {mideleg_name}",
-                "csrci mstatus, 8",  # MIE=0
-            ]
-        )
+        for mip_name, mip_bit, mip_set, mip_clr, mip_timer in mip_interrupts:
+            for mie_name, mie_bit in mie_bits:
+                binname = f"{mideleg_name}_{mip_name}_{mie_name}"
 
-        if mideleg_val:
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x222)",
-                    f"CSRW(mideleg, x{r_scratch})",
-                ]
-            )
-        else:
-            lines.append("CSRW(mideleg, zero)")
-
-        # 6 walking 1s in mie: SSIE, STIE, SEIE and combinations
-        for s1 in range(6):
-            # s1: 0=none, 1=SSIE, 2=STIE, 3=SSIE+STIE, 4=SEIE, 5=SSIE+SEIE
-            mie_bits = 0
-            if s1 & 1:
-                mie_bits |= 0x02  # SSIE
-            if s1 & 2:
-                mie_bits |= 0x20  # STIE
-            if s1 & 4:
-                mie_bits |= 0x200  # SEIE
-
-            lines.extend(
-                [
-                    f"LI(x{r_mie_val}, {mie_bits})",
-                    f"CSRW(mie, x{r_mie_val})",
-                ]
-            )
-
-            # 6 walking 1s in mip: SSIP, STIP, SEIP and combinations
-            for s2 in range(6):
-                binname = f"{mideleg_name}_mie_{s1:03b}_mip_{s2:03b}"
-
+                # === M-MODE SETUP ===
                 lines.extend(
                     [
                         "",
-                        "CSRW(mie, zero)",  # Disable while setting interrupts
-                        test_data.add_testcase(binname, coverpoint, covergroup),
-                    ]
-                )
-
-                # Set interrupt pending bits based on s2
-                if s2 & 1:  # SSIP
-                    lines.extend(
-                        [
-                            f"LI(x{r_scratch}, 0x02)",
-                            f"CSRS(mip, x{r_scratch})",
-                        ]
-                    )
-                if s2 & 2:  # STIP
-                    lines.extend(
-                        [
-                            f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
-                            f"LA(x{r_stimecmp}, RVMODEL_STIMECMP_ADDRESS)",
-                            *set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2),
-                        ]
-                    )
-                if s2 & 4:  # SEIP
-                    lines.extend(
-                        [
-                            f"LI(x{r_scratch}, 0x200)",
-                            f"CSRS(mip, x{r_scratch})",
-                        ]
-                    )
-
-                # Settling delay
-                for _ in range(5):
-                    lines.append("    nop")
-
-                # Enable interrupts and enter S-mode
-                lines.extend(
-                    [
-                        f"CSRW(mie, x{r_mie_val})",
-                        "RVTEST_GOTO_LOWER_MODE Smode",
-                        "RVTEST_IDLE_FOR_INTERRUPT",
-                        "RVTEST_GOTO_MMODE",
-                        "nop",
+                        f"# Test: mideleg={mideleg_name}, mip={mip_name}, mie={mie_name}",
+                        "CSRW(mie, zero)",
+                        "csrci mstatus, 8",  # MIE=0
+                        "csrci mstatus, 2",  # SIE=0
                     ]
                 )
 
                 # Clear all interrupts
                 lines.extend(
                     [
-                        f"LI(x{r_scratch}, 0x202)",  # Clear SSIP and SEIP
-                        f"CSRC(mip, x{r_scratch})",
-                        *clr_mtimer_int(r_temp, r_stimecmp),
+                        "RVTEST_CLR_SSW_INT",
+                        "RVTEST_CLR_MSW_INT",
+                        "RVTEST_CLR_SEXT_INT",
+                        "RVTEST_CLR_MEXT_INT",
+                    ]
+                )
+                lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+                lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+                # Set mtvec.MODE = 0 (direct)
+                lines.extend(
+                    [
+                        f"CSRR x{r_scratch}, mtvec",
+                        f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                        f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                        f"CSRW(mtvec, x{r_scratch})",
                     ]
                 )
 
-    test_data.int_regs.return_registers([r_mtime, r_stimecmp, r_temp, r_temp2, r_mie_val, r_scratch])
+                # Set mideleg
+                if mideleg_val:
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x222)",
+                            f"CSRW(mideleg, x{r_scratch})",
+                        ]
+                    )
+                else:
+                    lines.append("CSRW(mideleg, zero)")
+
+                # Set walking 1 in mie
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, {hex(mie_bit)})",
+                        f"CSRW(mie, x{r_scratch})",
+                    ]
+                )
+
+                # Set SIE=1 (will take effect when entering S-mode)
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x02)",
+                        f"CSRS(mstatus, x{r_scratch})",
+                    ]
+                )
+
+                # Ensure MIE is 0
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",  # MPIE bit
+                        f"CSRC(mstatus, x{r_scratch})",  # MPIE=0
+                    ]
+                )
+
+                # Set interrupt pending
+                lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+                if mip_timer:
+                    if mip_name == "stip":
+                        lines.extend(
+                            [
+                                f"CSRR x{r_stce}, menvcfg",
+                                "#if __riscv_xlen == 64",
+                                f"    srli x{r_stce}, x{r_stce}, 63",
+                                "#else",
+                                f"    srli x{r_stce}, x{r_stce}, 31",
+                                "#endif",
+                                f"andi x{r_stce}, x{r_stce}, 0x1",
+                            ]
+                        )
+                        lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
+                    else:  # mtip
+                        lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+                else:
+                    lines.extend([mip_set, "nop"])
+
+                # Wait in M-mode
+                lines.extend(
+                    [
+                        f"    LI(x{r_scratch}, 2500)",
+                        f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                        f"    bnez x{r_scratch}, 1b",
+                    ]
+                )
+
+                # Enter S-mode
+                lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+
+                # Wait in S-mode
+                lines.extend(
+                    [
+                        f"    LI(x{r_scratch}, 2500)",
+                        f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                        f"    bnez x{r_scratch}, 1b",
+                    ]
+                )
+
+                # Cleanup
+                lines.extend(
+                    [
+                        "RVTEST_GOTO_MMODE",
+                        "csrci mstatus, 8",
+                        "csrci mstatus, 2",
+                        "CSRW(mideleg, zero)",
+                        "CSRW(mie, zero)",
+                    ]
+                )
+
+                # Clear interrupt
+                if mip_timer:
+                    if mip_name == "stip":
+                        lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+                    else:
+                        lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+                else:
+                    lines.append(mip_clr)
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
     return lines
 
 
 def _generate_vectored_s_tests(test_data: TestData) -> list[str]:
-    """Generate vectored interrupt mode tests.
+    """Generate vectored interrupt tests for S-mode.
 
-    Cross of stvec.MODE = 00/01, mstatus.MIE=0, mstatus.SIE = 1, mie = 1s,
-    mideleg = {STI+SEI+SSI}, 6 different interrupts walking in mip.
-    (2 x 6 = 12 bins)
+    In M-mode with MIE=0, set interrupt pending but no trap fires.
+    Enter S-mode with SIE=1 - now interrupts can fire (delegated to S, or trap to M).
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_vectored_s"
 
-    r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch, r_csr_tmp = test_data.int_regs.get_registers(
-        6, exclude_regs=[0, 2]
-    )
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
 
     lines = [
         comment_banner(
             "cp_vectored_s",
-            "Vectored interrupt mode tests\nCross: stvec.MODE x interrupt type (2 x 6 = 12 bins)",
+            "Test vectored vs direct interrupt handling\nSet interrupt in M-mode (MIE=0), then enter S-mode (SIE=1)",
         ),
         "",
     ]
 
-    # Test both direct (00) and vectored (01) modes
-    for mode in [0, 1]:
-        mode_name = ["direct", "vectored"][mode]
+    # ALL 6 interrupts (including M-mode ones!)
+    interrupts = [
+        ("ssip", 0x002, "RVTEST_SET_SSW_INT", "RVTEST_CLR_SSW_INT", False),
+        ("msip", 0x008, "RVTEST_SET_MSW_INT", "RVTEST_CLR_MSW_INT", False),
+        ("stip", 0x020, None, None, True),
+        ("mtip", 0x080, None, None, True),
+        ("seip", 0x200, "RVTEST_SET_SEXT_INT", "RVTEST_CLR_SEXT_INT", False),
+        ("meip", 0x800, "RVTEST_SET_MEXT_INT", "RVTEST_CLR_MEXT_INT", False),
+    ]
 
-        lines.extend(
-            [
-                "",
-                f"# stvec.MODE = {mode:02b} ({mode_name})",
-                "# Setup: delegate all S-interrupts, enable all",
-                f"LI(x{r_scratch}, 0x222)",
-                f"CSRW(mideleg, x{r_scratch})",
-                "csrci mstatus, 8",  # MIE=0
-                f"LI(x{r_scratch}, 0x20)",  # SPIE=1 (SIE will be 1 in S-mode)
-                f"CSRS(mstatus, x{r_scratch})",
-                f"LI(x{r_scratch}, -1)",
-                f"CSRW(mie, x{r_scratch})",
-                "# Set stvec.MODE",
-                "csrci stvec, 3",
-                f"csrsi stvec, {mode}",
-            ]
-        )
+    for stvec_mode in [0, 1]:  # direct, vectored
+        stvec_mode_name = ["direct", "vectored"][stvec_mode]
 
-        # 6 interrupt types: SSIP, STIP, SEIP, SSIP+STIP, SSIP+SEIP, STIP+SEIP
-        for s2 in range(6):
-            int_name = f"int_{s2:03b}"
-            binname = f"{mode_name}_{int_name}"
+        for int_name, int_bit, int_set, int_clr, uses_timer in interrupts:
+            binname = f"{stvec_mode_name}_{int_name}"
 
+            # === M-MODE SETUP ===
             lines.extend(
                 [
                     "",
+                    f"# Test: stvec.MODE={stvec_mode_name}, interrupt={int_name}",
                     "CSRW(mie, zero)",
-                    test_data.add_testcase(binname, coverpoint, covergroup),
-                ]
-            )
-
-            # Trigger interrupts based on s2
-            if s2 & 1:  # SSIP
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x02)",
-                        f"CSRS(mip, x{r_scratch})",
-                    ]
-                )
-            if s2 & 2:  # STIP
-                lines.extend(
-                    [
-                        f"LA(x{r_mtime}, RVMODEL_MTIME_ADDRESS)",
-                        f"LA(x{r_stimecmp}, RVMODEL_STIMECMP_ADDRESS)",
-                        *set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2),
-                    ]
-                )
-            if s2 & 4:  # SEIP
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x200)",
-                        f"CSRS(mip, x{r_scratch})",
-                    ]
-                )
-
-            # Settling delay
-            for _ in range(5):
-                lines.append("    nop")
-
-            # Enable all S-interrupts and enter S-mode
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x222)",
-                    f"CSRW(mie, x{r_scratch})",
-                    "RVTEST_GOTO_LOWER_MODE Smode",
-                    "RVTEST_IDLE_FOR_INTERRUPT",
-                    "RVTEST_GOTO_MMODE",
-                    "nop",
+                    "csrci mstatus, 8",  # MIE=0 (blocks interrupts in M-mode)
+                    "csrci mstatus, 2",  # SIE=0 initially
                 ]
             )
 
             # Clear all interrupts
             lines.extend(
                 [
-                    f"LI(x{r_scratch}, 0x202)",
-                    f"CSRC(mip, x{r_scratch})",
-                    *clr_mtimer_int(r_temp, r_stimecmp),
+                    "RVTEST_CLR_SSW_INT",
+                    "RVTEST_CLR_MSW_INT",
+                    "RVTEST_CLR_SEXT_INT",
+                    "RVTEST_CLR_MEXT_INT",
+                ]
+            )
+            lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+            # Set stvec.MODE
+            lines.extend(
+                [
+                    f"CSRR x{r_scratch}, stvec",
+                    f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                    f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                    f"ADDI x{r_scratch}, x{r_scratch}, {stvec_mode}",
+                    f"CSRW(stvec, x{r_scratch})",
                 ]
             )
 
-        # Restore stvec.MODE to direct
-        lines.append("csrci stvec, 1")
+            # Set mideleg (delegate S-interrupts)
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x222)",
+                    f"CSRW(mideleg, x{r_scratch})",
+                ]
+            )
 
-    test_data.int_regs.return_registers([r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch, r_csr_tmp])
+            # Enable ALL interrupts in mie
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, -1)",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
+            # Set SIE=1 (will take effect when entering S-mode)
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x02)",
+                    f"CSRS(mstatus, x{r_scratch})",
+                ]
+            )
+
+            # Ensure MIE = 0
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x80)",  # MPIE bit
+                    f"CSRC(mstatus, x{r_scratch})",  # MPIE=0
+                ]
+            )
+
+            # Set interrupt in M-mode (MIE=0, so no trap yet)
+            lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+            if uses_timer:
+                if int_name == "stip":
+                    lines.extend(
+                        [
+                            f"CSRR x{r_stce}, menvcfg",
+                            "#if __riscv_xlen == 64",
+                            f"    srli x{r_stce}, x{r_stce}, 63",
+                            "#else",
+                            f"    srli x{r_stce}, x{r_stce}, 31",
+                            "#endif",
+                            f"andi x{r_stce}, x{r_stce}, 0x1",
+                        ]
+                    )
+                    lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
+                else:  # mtip
+                    lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+            else:
+                lines.extend([int_set, "nop"])
+
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 2500)",  # Short - trap fires quickly
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
+
+            # Enter S-mode (interrupt pending, SIE=1, trap will fire)
+            lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+
+            # NOPs to allow coverage sampling before trap
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 2500)",  # Short - trap fires quickly
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
+
+            # Cleanup
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "csrci mstatus, 8",
+                    "csrci mstatus, 2",
+                    "CSRW(mideleg, zero)",
+                    "CSRW(mie, zero)",
+                ]
+            )
+
+            # Clear interrupt
+            if uses_timer:
+                if int_name == "stip":
+                    lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+                else:
+                    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+            else:
+                lines.append(int_clr)
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+# ======================================================================
+# NEXT SET OF TESTS
+# ======================================================================
+
+
+def _generate_priority_mip_s_tests(test_data: TestData) -> list[str]:
+    """Generate interrupt priority tests.
+
+    Test all 2^6 = 64 combinations of mip with mie=all 1s.
+    Cross: mideleg={0, 0x222} × 64 mip patterns = 128 tests
+    Highest priority interrupt should fire.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_priority_mip_s"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_priority_mip_s",
+            "Test interrupt priority with all mip combinations\n2^6 mip patterns × 2 mideleg values = 128 tests",
+        ),
+        "",
+    ]
+
+    # Test both mideleg values
+    for mideleg_val in [0, 1]:
+        mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+
+        # Test all 64 combinations of 6 interrupt bits
+        for mip_pattern in range(64):
+            # Extract which interrupts are set in this pattern
+            ssip_set = (mip_pattern >> 0) & 1
+            msip_set = (mip_pattern >> 1) & 1
+            stip_set = (mip_pattern >> 2) & 1
+            mtip_set = (mip_pattern >> 3) & 1
+            seip_set = (mip_pattern >> 4) & 1
+            meip_set = (mip_pattern >> 5) & 1
+
+            binname = f"{mideleg_name}_mip_{mip_pattern:02x}"
+
+            # === M-MODE SETUP ===
+            lines.extend(
+                [
+                    "",
+                    f"# Test: mideleg={mideleg_name}, mip_pattern=0x{mip_pattern:02x}",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",  # MIE=0
+                    "csrci mstatus, 2",  # SIE=0 initially
+                ]
+            )
+
+            # Clear all interrupts
+            lines.extend(
+                [
+                    "RVTEST_CLR_SSW_INT",
+                    "RVTEST_CLR_MSW_INT",
+                    "RVTEST_CLR_SEXT_INT",
+                    "RVTEST_CLR_MEXT_INT",
+                ]
+            )
+            lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+            # Set mtvec.MODE = 0 (direct)
+            lines.extend(
+                [
+                    f"CSRR x{r_scratch}, mtvec",
+                    f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                    f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                    f"CSRW(mtvec, x{r_scratch})",
+                ]
+            )
+
+            # Set mideleg
+            if mideleg_val:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x222)",
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            # Enable ALL interrupts in mie
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, -1)",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
+            # Set SIE=1
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x02)",
+                    f"CSRS(mstatus, x{r_scratch})",
+                ]
+            )
+
+            # Set the interrupt pattern
+            lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+            # Set each interrupt according to the pattern
+            if ssip_set:
+                lines.append("RVTEST_SET_SSW_INT")
+            if msip_set:
+                lines.append("RVTEST_SET_MSW_INT")
+            if stip_set:
+                lines.extend(
+                    [
+                        f"CSRR x{r_stce}, menvcfg",
+                        "#if __riscv_xlen == 64",
+                        f"    srli x{r_stce}, x{r_stce}, 63",
+                        "#else",
+                        f"    srli x{r_stce}, x{r_stce}, 31",
+                        "#endif",
+                        f"andi x{r_stce}, x{r_stce}, 0x1",
+                    ]
+                )
+                lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
+            if mtip_set:
+                lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+            if seip_set:
+                lines.append("RVTEST_SET_SEXT_INT")
+            if meip_set:
+                lines.append("RVTEST_SET_MEXT_INT")
+
+            lines.append("nop")
+
+            # Enter S-mode (highest priority interrupt will fire)
+            lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+
+            # Wait for coverage
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 100)",
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
+
+            # Cleanup
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "csrci mstatus, 8",
+                    "csrci mstatus, 2",
+                    "CSRW(mideleg, zero)",
+                    "CSRW(mie, zero)",
+                ]
+            )
+
+            # Clear all interrupts that were set
+            if ssip_set:
+                lines.append("RVTEST_CLR_SSW_INT")
+            if msip_set:
+                lines.append("RVTEST_CLR_MSW_INT")
+            if stip_set:
+                lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            if mtip_set:
+                lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+            if seip_set:
+                lines.append("RVTEST_CLR_SEXT_INT")
+            if meip_set:
+                lines.append("RVTEST_CLR_MEXT_INT")
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_priority_mie_s_tests(test_data: TestData) -> list[str]:
+    """Generate interrupt priority tests varying mie.
+
+    Set ALL mip bits, vary mie through all combinations.
+    Test both S-mode (8 combinations) and M-mode (7 combinations, excluding 000).
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint_s = "cp_priority_mie_s"
+    coverpoint_m = "cp_priority_mie_s_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_priority_mie_s",
+            "Test interrupt priority with all mie combinations\nAll mip bits set, vary mie",
+        ),
+        "",
+    ]
+
+    # Test both mideleg values
+    for mideleg_val in [0, 1]:
+        mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+
+        # S-mode combinations: 8 patterns (including 000)
+        for mie_pattern_s in range(8):
+            ssie = (mie_pattern_s >> 0) & 1
+            stie = (mie_pattern_s >> 1) & 1
+            seie = (mie_pattern_s >> 2) & 1
+
+            # Build mie value with S-mode bits
+            mie_val = (ssie << 1) | (stie << 5) | (seie << 9)
+
+            binname = f"{mideleg_name}_s_mie_{mie_pattern_s:03b}"
+
+            lines.extend(
+                [
+                    "",
+                    f"# Test: mideleg={mideleg_name}, S-mode mie pattern={mie_pattern_s:03b}",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",  # MIE=0
+                    "csrci mstatus, 2",  # SIE=0
+                ]
+            )
+
+            # Clear all interrupts
+            lines.extend(
+                [
+                    "RVTEST_CLR_SSW_INT",
+                    "RVTEST_CLR_MSW_INT",
+                    "RVTEST_CLR_SEXT_INT",
+                    "RVTEST_CLR_MEXT_INT",
+                ]
+            )
+            lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+            # Set mtvec.MODE = 0
+            lines.extend(
+                [
+                    f"CSRR x{r_scratch}, mtvec",
+                    f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                    f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                    f"CSRW(mtvec, x{r_scratch})",
+                ]
+            )
+
+            # Set mideleg
+            if mideleg_val:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x222)",
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            # Set specific mie pattern
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, {hex(mie_val)})",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
+            # Set SIE=1
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x02)",
+                    f"CSRS(mstatus, x{r_scratch})",
+                ]
+            )
+
+            # Set ALL S-mode interrupts
+            lines.append(test_data.add_testcase(binname, coverpoint_s, covergroup))
+            lines.extend(
+                [
+                    "RVTEST_SET_SSW_INT",
+                    f"CSRR x{r_stce}, menvcfg",
+                    "#if __riscv_xlen == 64",
+                    f"    srli x{r_stce}, x{r_stce}, 63",
+                    "#else",
+                    f"    srli x{r_stce}, x{r_stce}, 31",
+                    "#endif",
+                    f"andi x{r_stce}, x{r_stce}, 0x1",
+                ]
+            )
+            lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
+            lines.extend(
+                [
+                    "RVTEST_SET_SEXT_INT",
+                    "nop",
+                ]
+            )
+
+            # Enter S-mode
+            lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+
+            # Wait for coverage
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 100)",
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
+
+            # Cleanup
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "csrci mstatus, 8",
+                    "csrci mstatus, 2",
+                    "CSRW(mideleg, zero)",
+                    "CSRW(mie, zero)",
+                    "RVTEST_CLR_SSW_INT",
+                ]
+            )
+            lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            lines.append("RVTEST_CLR_SEXT_INT")
+
+        # M-mode combinations: 7 patterns (excluding 000)
+        for mie_pattern_m in range(1, 8):  # Skip 0 (combo_000)
+            msie = (mie_pattern_m >> 0) & 1
+            mtie = (mie_pattern_m >> 1) & 1
+            meie = (mie_pattern_m >> 2) & 1
+
+            # Build mie value with M-mode bits
+            mie_val = (msie << 3) | (mtie << 7) | (meie << 11)
+
+            binname = f"{mideleg_name}_m_mie_{mie_pattern_m:03b}"
+
+            lines.extend(
+                [
+                    "",
+                    f"# Test: mideleg={mideleg_name}, M-mode mie pattern={mie_pattern_m:03b}",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",
+                    "csrci mstatus, 2",
+                ]
+            )
+
+            # Clear all interrupts
+            lines.extend(
+                [
+                    "RVTEST_CLR_SSW_INT",
+                    "RVTEST_CLR_MSW_INT",
+                    "RVTEST_CLR_SEXT_INT",
+                    "RVTEST_CLR_MEXT_INT",
+                ]
+            )
+            lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+            # Set mtvec.MODE = 0
+            lines.extend(
+                [
+                    f"CSRR x{r_scratch}, mtvec",
+                    f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                    f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                    f"CSRW(mtvec, x{r_scratch})",
+                ]
+            )
+
+            # Set mideleg
+            if mideleg_val:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x222)",
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            # Set specific mie pattern
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, {hex(mie_val)})",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
+            # Set SIE=1
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x02)",
+                    f"CSRS(mstatus, x{r_scratch})",
+                ]
+            )
+
+            # Set ALL M-mode interrupts
+            lines.append(test_data.add_testcase(binname, coverpoint_m, covergroup))
+            lines.extend(
+                [
+                    "RVTEST_SET_MSW_INT",
+                ]
+            )
+            lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+            lines.extend(
+                [
+                    "RVTEST_SET_MEXT_INT",
+                    "nop",
+                ]
+            )
+
+            # Enter S-mode (M-interrupt will fire immediately)
+            lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+
+            # Wait
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 100)",
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
+
+            # Cleanup
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "csrci mstatus, 8",
+                    "csrci mstatus, 2",
+                    "CSRW(mideleg, zero)",
+                    "CSRW(mie, zero)",
+                    "RVTEST_CLR_MSW_INT",
+                ]
+            )
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+            lines.append("RVTEST_CLR_MEXT_INT")
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_priority_both_s_tests(test_data: TestData) -> list[str]:
+    """Generate interrupt priority tests with mip == mie.
+
+    For each pattern, set the same bits in both mip and mie.
+    Tests priority when multiple interrupts are both pending and enabled.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint_s = "cp_priority_both_s"
+    coverpoint_m = "cp_priority_both_s_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_priority_both_s",
+            "Test interrupt priority with mip == mie\nSame pattern in both mip and mie for priority testing",
+        ),
+        "",
+    ]
+
+    # Test both mideleg values
+    for mideleg_val in [0, 1]:
+        mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+
+        # S-mode: all 8 patterns (including 000)
+        for pattern in range(8):
+            ssip = (pattern >> 0) & 1
+            stip = (pattern >> 1) & 1
+            seip = (pattern >> 2) & 1
+
+            # Set same pattern in both mip and mie
+            mie_val = (ssip << 1) | (stip << 5) | (seip << 9)
+
+            binname = f"{mideleg_name}_s_both_{pattern:03b}"
+
+            lines.extend(
+                [
+                    "",
+                    f"# Test: mideleg={mideleg_name}, S-mode pattern={pattern:03b} (mip==mie)",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",
+                    "csrci mstatus, 2",
+                ]
+            )
+
+            # Clear all interrupts
+            lines.extend(
+                [
+                    "RVTEST_CLR_SSW_INT",
+                    "RVTEST_CLR_SEXT_INT",
+                ]
+            )
+            lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+
+            # Set mtvec.MODE = 0
+            lines.extend(
+                [
+                    f"CSRR x{r_scratch}, mtvec",
+                    f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                    f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                    f"CSRW(mtvec, x{r_scratch})",
+                ]
+            )
+
+            # Set mideleg
+            if mideleg_val:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x222)",
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            # Set mie pattern
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, {hex(mie_val)})",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
+            # Set SIE=1
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x02)",
+                    f"CSRS(mstatus, x{r_scratch})",
+                ]
+            )
+
+            # Set matching mip pattern
+            lines.append(test_data.add_testcase(binname, coverpoint_s, covergroup))
+
+            if ssip:
+                lines.append("RVTEST_SET_SSW_INT")
+            if stip:
+                lines.extend(
+                    [
+                        f"CSRR x{r_stce}, menvcfg",
+                        "#if __riscv_xlen == 64",
+                        f"    srli x{r_stce}, x{r_stce}, 63",
+                        "#else",
+                        f"    srli x{r_stce}, x{r_stce}, 31",
+                        "#endif",
+                        f"andi x{r_stce}, x{r_stce}, 0x1",
+                    ]
+                )
+                lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
+            if seip:
+                lines.append("RVTEST_SET_SEXT_INT")
+
+            lines.append("nop")
+
+            # Enter S-mode
+            lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+
+            # Wait
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 100)",
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
+
+            # Cleanup
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "csrci mstatus, 8",
+                    "csrci mstatus, 2",
+                    "CSRW(mideleg, zero)",
+                    "CSRW(mie, zero)",
+                ]
+            )
+
+            if ssip:
+                lines.append("RVTEST_CLR_SSW_INT")
+            if stip:
+                lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            if seip:
+                lines.append("RVTEST_CLR_SEXT_INT")
+
+        # M-mode: patterns 1-7 (skip 0, no interrupt = no MRET)
+        for pattern in range(1, 8):
+            msip = (pattern >> 0) & 1
+            mtip = (pattern >> 1) & 1
+            meip = (pattern >> 2) & 1
+
+            # Set same pattern in both mip and mie
+            mie_val = (msip << 3) | (mtip << 7) | (meip << 11)
+
+            binname = f"{mideleg_name}_m_both_{pattern:03b}"
+
+            lines.extend(
+                [
+                    "",
+                    f"# Test: mideleg={mideleg_name}, M-mode pattern={pattern:03b} (mip==mie)",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",
+                    "csrci mstatus, 2",
+                ]
+            )
+
+            # Clear all interrupts
+            lines.extend(
+                [
+                    "RVTEST_CLR_MSW_INT",
+                    "RVTEST_CLR_MEXT_INT",
+                ]
+            )
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+            # Set mtvec.MODE = 0
+            lines.extend(
+                [
+                    f"CSRR x{r_scratch}, mtvec",
+                    f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                    f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                    f"CSRW(mtvec, x{r_scratch})",
+                ]
+            )
+
+            # Set mideleg
+            if mideleg_val:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x222)",
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            # Set mie pattern
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, {hex(mie_val)})",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
+            # Set SIE=1
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x02)",
+                    f"CSRS(mstatus, x{r_scratch})",
+                ]
+            )
+
+            # Set matching mip pattern
+            lines.append(test_data.add_testcase(binname, coverpoint_m, covergroup))
+
+            if msip:
+                lines.append("RVTEST_SET_MSW_INT")
+            if mtip:
+                lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+            if meip:
+                lines.append("RVTEST_SET_MEXT_INT")
+
+            lines.append("nop")
+
+            # Enter S-mode
+            lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+
+            # Wait
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 100)",
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
+
+            # Cleanup
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "csrci mstatus, 8",
+                    "csrci mstatus, 2",
+                    "CSRW(mideleg, zero)",
+                    "CSRW(mie, zero)",
+                ]
+            )
+
+            if msip:
+                lines.append("RVTEST_CLR_MSW_INT")
+            if mtip:
+                lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+            if meip:
+                lines.append("RVTEST_CLR_MEXT_INT")
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_priority_mideleg_m_tests(test_data: TestData) -> list[str]:
+    """Generate mideleg priority tests.
+
+    Test all 8 mideleg patterns (2^3) with all S-interrupts set.
+    mip = SSIP+STIP+SEIP, mie = all 1s, MIE=0, SIE=1.
+    Verifies undelegated interrupts take priority over delegated.
+    """
+    covergroup = "InterruptsS_S_cg"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_priority_mideleg_m",
+            "Test interrupt priority with varying mideleg patterns\n"
+            "All S-interrupts set, vary delegation to test priority",
+        ),
+        "",
+    ]
+
+    # Test all 8 mideleg patterns
+    for mideleg_pattern in range(8):
+        ssie = (mideleg_pattern >> 0) & 1
+        stie = (mideleg_pattern >> 1) & 1
+        seie = (mideleg_pattern >> 2) & 1
+
+        mideleg_val = (ssie << 1) | (stie << 5) | (seie << 9)
+
+        # S-mode coverage: only combo_111 (all delegated)
+        # M-mode coverage: all combos with at least one undelegated
+        coverpoint = "cp_priority_mideleg_s/cp_priority_mideleg_m" if mideleg_pattern == 7 else "cp_priority_mideleg_m"
+
+        binname = f"mideleg_{mideleg_pattern:03b}"
+
+        lines.extend(
+            [
+                "",
+                f"# Test: mideleg pattern={mideleg_pattern:03b}",
+                "CSRW(mie, zero)",
+                "csrci mstatus, 8",  # MIE=0
+                "csrci mstatus, 2",  # SIE=0
+            ]
+        )
+
+        # Clear all interrupts
+        lines.extend(
+            [
+                "RVTEST_CLR_SSW_INT",
+                "RVTEST_CLR_SEXT_INT",
+            ]
+        )
+        lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+
+        # Set mtvec.MODE = 0
+        lines.extend(
+            [
+                f"CSRR x{r_scratch}, mtvec",
+                f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                f"CSRW(mtvec, x{r_scratch})",
+            ]
+        )
+
+        # Set mideleg pattern
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, {hex(mideleg_val)})",
+                f"CSRW(mideleg, x{r_scratch})",
+            ]
+        )
+
+        # Enable ALL interrupts in mie (mie = 1s)
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, -1)",
+                f"CSRW(mie, x{r_scratch})",
+            ]
+        )
+
+        # Set SIE=1
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, 0x02)",
+                f"CSRS(mstatus, x{r_scratch})",
+            ]
+        )
+
+        # Set ALL S-mode interrupts (mip = SSIP+STIP+SEIP)
+        lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+        lines.extend(
+            [
+                "RVTEST_SET_SSW_INT",
+                f"CSRR x{r_stce}, menvcfg",
+                "#if __riscv_xlen == 64",
+                f"    srli x{r_stce}, x{r_stce}, 63",
+                "#else",
+                f"    srli x{r_stce}, x{r_stce}, 31",
+                "#endif",
+                f"andi x{r_stce}, x{r_stce}, 0x1",
+            ]
+        )
+        lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
+        lines.extend(
+            [
+                "RVTEST_SET_SEXT_INT",
+                "nop",
+            ]
+        )
+
+        # Enter S-mode
+        lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+
+        # Wait for highest priority interrupt to fire
+        lines.extend(
+            [
+                f"    LI(x{r_scratch}, 100)",
+                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                f"    bnez x{r_scratch}, 1b",
+            ]
+        )
+
+        # Cleanup
+        lines.extend(
+            [
+                "RVTEST_GOTO_MMODE",
+                "csrci mstatus, 8",
+                "csrci mstatus, 2",
+                "CSRW(mideleg, zero)",
+                "CSRW(mie, zero)",
+                "RVTEST_CLR_SSW_INT",
+            ]
+        )
+        lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+        lines.append("RVTEST_CLR_SEXT_INT")
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_priority_mideleg_s_tests(test_data: TestData) -> list[str]:
+    """Generate priority among delegated interrupts test.
+
+    Set all S-interrupts (mip=all), but mie=mideleg (matching).
+    Only delegated+enabled interrupts fire, testing priority within delegated interrupts.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_priority_mideleg_s"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_priority_mideleg_s",
+            "Test priority among delegated interrupts\nmip=all S-interrupts, mie=mideleg (matching)",
+        ),
+        "",
+    ]
+
+    # Test patterns 1-7 (skip 0 = nothing enabled)
+    for mideleg_pattern in range(1, 8):
+        ssie = (mideleg_pattern >> 0) & 1
+        stie = (mideleg_pattern >> 1) & 1
+        seie = (mideleg_pattern >> 2) & 1
+
+        # mie = mideleg (same pattern)
+        mideleg_val = (ssie << 1) | (stie << 5) | (seie << 9)
+        mie_val = mideleg_val  # MATCHING
+
+        binname = f"delegated_priority_{mideleg_pattern:03b}"
+
+        lines.extend(
+            [
+                "",
+                f"# Test: mideleg=mie pattern={mideleg_pattern:03b}",
+                "CSRW(mie, zero)",
+                "csrci mstatus, 8",  # MIE=0
+                "csrci mstatus, 2",  # SIE=0
+            ]
+        )
+
+        # Clear all interrupts
+        lines.extend(
+            [
+                "RVTEST_CLR_SSW_INT",
+                "RVTEST_CLR_SEXT_INT",
+            ]
+        )
+        lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+
+        # Set mtvec.MODE = 0
+        lines.extend(
+            [
+                f"CSRR x{r_scratch}, mtvec",
+                f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                f"CSRW(mtvec, x{r_scratch})",
+            ]
+        )
+
+        # Set mideleg
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, {hex(mideleg_val)})",
+                f"CSRW(mideleg, x{r_scratch})",
+            ]
+        )
+
+        # Set mie = mideleg (MATCHING)
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, {hex(mie_val)})",
+                f"CSRW(mie, x{r_scratch})",
+            ]
+        )
+
+        # Set SIE=1
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, 0x02)",
+                f"CSRS(mstatus, x{r_scratch})",
+            ]
+        )
+
+        # Set ALL S-mode interrupts (mip = all)
+        lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+        lines.extend(
+            [
+                "RVTEST_SET_SSW_INT",
+                f"CSRR x{r_stce}, menvcfg",
+                "#if __riscv_xlen == 64",
+                f"    srli x{r_stce}, x{r_stce}, 63",
+                "#else",
+                f"    srli x{r_stce}, x{r_stce}, 31",
+                "#endif",
+                f"andi x{r_stce}, x{r_stce}, 0x1",
+            ]
+        )
+        lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
+        lines.extend(
+            [
+                "RVTEST_SET_SEXT_INT",
+                "nop",
+            ]
+        )
+
+        # Enter S-mode (only delegated+enabled interrupts fire)
+        lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+
+        # Wait for highest priority delegated interrupt
+        lines.extend(
+            [
+                f"    LI(x{r_scratch}, 100)",
+                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                f"    bnez x{r_scratch}, 1b",
+            ]
+        )
+
+        # Cleanup
+        lines.extend(
+            [
+                "RVTEST_GOTO_MMODE",
+                "csrci mstatus, 8",
+                "csrci mstatus, 2",
+                "CSRW(mideleg, zero)",
+                "CSRW(mie, zero)",
+                "RVTEST_CLR_SSW_INT",
+            ]
+        )
+        lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+        lines.append("RVTEST_CLR_SEXT_INT")
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_wfi_s_tests(test_data: TestData) -> list[str]:
+    """Generate S-mode WFI tests.
+
+    Test WFI from S-mode with MTIP.
+    Cross: MIE={0,1} × SIE={0,1} × mideleg={0,0x222} × TW={0,1}
+
+    Split:
+    - cp_wfi_s: TW=0, WFI executes in S-mode
+    - cp_wfi_s_tw: TW=1, WFI timeout → illegal instruction → M-mode trap
+    """
+    covergroup = "InterruptsS_S_cg"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_wfi_s",
+            "Test WFI from S-mode with MTIP\nCross: MIE={0,1} × SIE={0,1} × mideleg={0,0x222} × TW={0,1}",
+        ),
+        "",
+    ]
+
+    # Cross: MIE × SIE × mideleg × TW
+    for mie_val in [0, 1]:
+        for sie_val in [0, 1]:
+            for mideleg_val in [0, 1]:
+                for tw_val in [0, 1]:
+                    mideleg_name = ["zeros", "ones"][mideleg_val]
+
+                    # Select coverpoint based on TW
+                    coverpoint = "cp_wfi_s" if tw_val == 0 else "cp_wfi_s_tw"
+
+                    binname = f"mie{mie_val}_sie{sie_val}_{mideleg_name}_tw{tw_val}"
+
+                    lines.extend(
+                        [
+                            "",
+                            f"# Test: MIE={mie_val}, SIE={sie_val}, mideleg={mideleg_name}, TW={tw_val}",
+                            "RVTEST_GOTO_MMODE",
+                            "CSRW(mie, zero)",
+                            "csrci mstatus, 8",  # MIE=0
+                            "csrci mstatus, 2",  # SIE=0
+                        ]
+                    )
+
+                    # Clear timer
+                    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+                    # Set mideleg
+                    if mideleg_val == 1:
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x222)",
+                                f"CSRW(mideleg, x{r_scratch})",
+                            ]
+                        )
+                    else:
+                        lines.append("CSRW(mideleg, zero)")
+
+                    # Set TW bit
+                    if tw_val:
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x200000)",  # TW bit (bit 21)
+                                f"CSRS(mstatus, x{r_scratch})",
+                            ]
+                        )
+                    else:
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x200000)",
+                                f"CSRC(mstatus, x{r_scratch})",
+                            ]
+                        )
+
+                    # Enable MTIE
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x80)",  # MTIE
+                            f"CSRW(mie, x{r_scratch})",
+                        ]
+                    )
+
+                    # Set MIE
+                    if mie_val:
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x80)",  # MPIE bit
+                                f"CSRS(mstatus, x{r_scratch})",
+                            ]
+                        )
+                    else:
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x80)",
+                                f"CSRC(mstatus, x{r_scratch})",
+                            ]
+                        )
+
+                    # Set SIE
+                    if sie_val:
+                        lines.append("csrsi mstatus, 2")
+
+                    # Set timer to fire soon (delayed)
+                    lines.extend(set_mtimer_int_soon(r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch, r_stce))
+
+                    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+                    # Enter S-mode and execute WFI
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_LOWER_MODE Smode",
+                        ]
+                    )
+
+                    lines.extend(
+                        [
+                            "    wfi",  # TW=0: waits, TW=1: timeout → illegal instruction
+                            "    nop",
+                            "    nop",
+                        ]
+                    )
+
+                    # Cleanup
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_MMODE",
+                            "csrci mstatus, 8",
+                            "csrci mstatus, 2",
+                            f"LI(x{r_scratch}, 0x200000)",
+                            f"CSRC(mstatus, x{r_scratch})",  # Clear TW
+                            "CSRW(mideleg, zero)",
+                            "CSRW(mie, zero)",
+                        ]
+                    )
+                    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_wfi_timeout_s_tests(test_data: TestData) -> list[str]:
+    """Generate S-mode and U-mode WFI timeout tests.
+
+    Test WFI timeout with TW=1, MTIMECMP=max.
+    Cross: MIE={0,1} × SIE={0,1} × mideleg={0,0x222} × MTIE={0,1} × mode={S,U}
+    Total: 2×2×2×2×2 = 32 bins
+    """
+    covergroup = "InterruptsS_S_cg"
+
+    r_temp, r_stimecmp, r_scratch = test_data.int_regs.get_registers(3, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_wfi_timeout_s",
+            "Test WFI timeout from S-mode and U-mode\n"
+            "Cross: MIE={0,1} × SIE={0,1} × mideleg={0,0x222} × MTIE={0,1} × mode={S,U}",
+        ),
+        "",
+    ]
+
+    # Cross: MIE × SIE × mideleg × MTIE × mode
+    for mie_val in [0, 1]:
+        for sie_val in [0, 1]:
+            for mideleg_val in [0, 1]:
+                for mtie_val in [0, 1]:
+                    for mode in ["Smode", "Umode"]:
+                        mideleg_name = ["zeros", "ones"][mideleg_val]
+                        mode_short = mode[0].lower()  # 's' or 'u'
+
+                        # Select coverpoint based on mode
+                        coverpoint = "cp_wfi_timeout_s" if mode == "Smode" else "cp_wfi_timeout_u_tw"
+
+                        binname = f"mie{mie_val}_sie{sie_val}_{mideleg_name}_mtie{mtie_val}_{mode_short}"
+
+                        lines.extend(
+                            [
+                                "",
+                                f"# Test: MIE={mie_val}, SIE={sie_val}, mideleg={mideleg_name}, MTIE={mtie_val}, mode={mode}",
+                                "RVTEST_GOTO_MMODE",
+                                "CSRW(mie, zero)",
+                                "csrci mstatus, 8",  # MIE=0
+                                "csrci mstatus, 2",  # SIE=0
+                            ]
+                        )
+
+                        # Clear all interrupts
+                        lines.extend(
+                            [
+                                "RVTEST_CLR_SSW_INT",
+                                "RVTEST_CLR_MSW_INT",
+                            ]
+                        )
+                        lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+                        lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+                        # Set mideleg
+                        if mideleg_val == 1:
+                            lines.extend(
+                                [
+                                    f"LI(x{r_scratch}, 0x222)",
+                                    f"CSRW(mideleg, x{r_scratch})",
+                                ]
+                            )
+                        else:
+                            lines.append("CSRW(mideleg, zero)")
+
+                        # Set TW=1 (timeout enabled)
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x200000)",  # TW bit (bit 21)
+                                f"CSRS(mstatus, x{r_scratch})",
+                            ]
+                        )
+
+                        # Set MTIE
+                        if mtie_val:
+                            lines.extend(
+                                [
+                                    f"LI(x{r_scratch}, 0x80)",  # MTIE
+                                    f"CSRW(mie, x{r_scratch})",
+                                ]
+                            )
+                        else:
+                            lines.append("CSRW(mie, zero)")
+
+                        # Set MTIMECMP to max (no interrupt)
+                        lines.extend(
+                            [
+                                f"LA(x{r_temp}, RVMODEL_MTIMECMP_ADDRESS)",
+                                f"LI(x{r_scratch}, -1)",
+                                f"SREG x{r_scratch}, 0(x{r_temp})",
+                            ]
+                        )
+
+                        # Set MIE
+                        if mie_val:
+                            lines.append("csrsi mstatus, 8")
+
+                        # Set SIE
+                        if sie_val:
+                            lines.append("csrsi mstatus, 2")
+
+                        # Sample in M-mode (before entering target mode)
+                        lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+                        # Enter target mode and execute WFI
+                        lines.extend(
+                            [
+                                f"RVTEST_GOTO_LOWER_MODE {mode}",
+                                "    wfi",  # TW=1 → illegal instruction
+                                "    nop",
+                            ]
+                        )
+
+                        # Cleanup
+                        lines.extend(
+                            [
+                                "RVTEST_GOTO_MMODE",
+                                "csrci mstatus, 8",
+                                "csrci mstatus, 2",
+                                f"LI(x{r_scratch}, 0x200000)",
+                                f"CSRC(mstatus, x{r_scratch})",  # Clear TW
+                                "CSRW(mideleg, zero)",
+                                "CSRW(mie, zero)",
+                            ]
+                        )
+                        lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    test_data.int_regs.return_registers([r_temp, r_stimecmp, r_scratch])
+    return lines
+
+
+def _generate_interrupts_m_tests(test_data: TestData) -> list[str]:
+    """Generate interrupt tests in M-mode.
+
+    Cross: MIE={0,1} × mideleg={0,0x222} × 6 mip walking × 6 mie walking
+    Total: 2 × 2 × 6 × 6 = 144 bins
+
+    Routes to:
+    - cp_interrupts_m: Non-delegated (mideleg=0) OR M-interrupts (always M-mode)
+    - cp_interrupts_m_deleg: Delegated S-interrupts (mideleg=0x222 + SSIP/STIP/SEIP)
+    """
+    covergroup = "InterruptsS_S_cg"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_interrupts_m",
+            "Test interrupts with walking 1s\n2 MIE × 2 mideleg × 6 mip × 6 mie = 144 bins",
+        ),
+        "",
+    ]
+
+    # 6 interrupts (walking 1s)
+    interrupts = [
+        ("ssip", 0x002, 0x002, "RVTEST_SET_SSW_INT", "RVTEST_CLR_SSW_INT", False),
+        ("msip", 0x008, 0x008, "RVTEST_SET_MSW_INT", "RVTEST_CLR_MSW_INT", False),
+        ("stip", 0x020, 0x020, None, None, True),
+        ("mtip", 0x080, 0x080, None, None, True),
+        ("seip", 0x200, 0x200, "RVTEST_SET_SEXT_INT", "RVTEST_CLR_SEXT_INT", False),
+        ("meip", 0x800, 0x800, "RVTEST_SET_MEXT_INT", "RVTEST_CLR_MEXT_INT", False),
+    ]
+
+    # S-interrupts that can be delegated
+    s_interrupts = {"ssip", "stip", "seip"}
+
+    # Loop: MIE × mideleg × mip × mie
+    for mie_val in [0, 1]:
+        for mideleg_val in [0, 1]:  # 0 = none, 1 = 0x222
+            for mip_name, mip_bit, mie_bit, set_fn, clr_fn, is_timer in interrupts:
+                for mie_name in ["ssie", "msie", "stie", "mtie", "seie", "meie"]:
+                    # SKIP: External interrupts not implemented
+                    if mip_name in ["seip", "meip"]:
+                        continue
+
+                    # Determine if delegated
+                    is_delegated = (mideleg_val == 1) and (mip_name in s_interrupts)
+
+                    # Select coverpoint
+                    coverpoint = "cp_interrupts_m_deleg" if is_delegated else "cp_interrupts_m"
+
+                    mideleg_name = ["zeros", "ones"][mideleg_val]
+                    binname = f"mie{mie_val}_{mideleg_name}_{mip_name}_{mie_name}"
+
+                    # === SETUP ===
+                    lines.extend(
+                        [
+                            "",
+                            f"# MIE={mie_val}, mideleg={mideleg_name}, mip={mip_name}, mie={mie_name}",
+                            "RVTEST_GOTO_MMODE",
+                            "CSRW(mie, zero)",
+                            "csrci mstatus, 8",  # MIE=0
+                            "csrci mstatus, 2",  # SIE=0
+                        ]
+                    )
+
+                    # Clear all interrupts
+                    lines.extend(
+                        [
+                            "RVTEST_CLR_SSW_INT",
+                            "RVTEST_CLR_MSW_INT",
+                            # Reset stimecmp to max unconditionally before clearing mip.STIP.
+                            # clr_stimer_int(r_stce=0) always uses legacy csrrc path which does NOT
+                            # reset stimecmp; on STCE=1 systems hardware immediately re-asserts STIP.
+                            f"LI(x{r_temp}, -1)",
+                            f"csrw stimecmp, x{r_temp}",
+                            "#if __riscv_xlen == 32",
+                            f"csrw stimecmph, x{r_temp}",
+                            "#endif",
+                        ]
+                    )
+                    lines.extend(clr_stimer_mmode(r_scratch))
+                    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+                    # Set mtvec.MODE = 0 (direct)
+                    lines.extend(
+                        [
+                            f"CSRR x{r_scratch}, mtvec",
+                            f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                            f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                            f"CSRW(mtvec, x{r_scratch})",
+                        ]
+                    )
+
+                    # Set mideleg
+                    if mideleg_val == 1:
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x222)",  # STI+SEI+SSI
+                                f"CSRW(mideleg, x{r_scratch})",
+                            ]
+                        )
+                    else:
+                        lines.append("CSRW(mideleg, zero)")
+
+                    # Set walking 1 in mie (convert name to bit)
+                    mie_bit_map = {
+                        "ssie": 0x002,
+                        "msie": 0x008,
+                        "stie": 0x020,
+                        "mtie": 0x080,
+                        "seie": 0x200,
+                        "meie": 0x800,
+                    }
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, {hex(mie_bit_map[mie_name])})",
+                            f"CSRW(mie, x{r_scratch})",
+                        ]
+                    )
+
+                    # Set SIE=1 for delegated
+                    if is_delegated:
+                        lines.append("csrsi mstatus, 2")
+
+                    # Set MIE before triggering the interrupt (so trap fires immediately on set)
+                    if mie_val == 1:
+                        lines.append("csrsi mstatus, 8")
+
+                    # === SET INTERRUPT ===
+                    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+                    if is_timer:
+                        if mip_name == "stip":
+                            # Always set mip.STIP directly from M-mode.
+                            # set_stimer_int's legacy path (STCE=0) calls RVTEST_GOTO_LOWER_MODE Smode,
+                            # which would make the wait loop run in S-mode → coverage misses M-mode state.
+                            lines.extend(set_stimer_mmode(r_scratch))
+                        else:  # mtip
+                            if mie_val == 1:
+                                lines.extend(
+                                    set_mtimer_int_soon(r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch, r_stce)
+                                )
+                            else:
+                                lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+                    else:
+                        lines.extend([set_fn, "nop"])
+
+                    # === WAIT FOR INTERRUPT ===
+                    if is_delegated:
+                        # Enter S-mode for delegated interrupts
+                        lines.extend(
+                            [
+                                "RVTEST_GOTO_LOWER_MODE Smode",
+                                f"    LI(x{r_scratch}, 5000)",
+                                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                                f"    bnez x{r_scratch}, 1b",
+                            ]
+                        )
+                    else:
+                        # Stay in M-mode
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 5000)",
+                                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                                f"    bnez x{r_scratch}, 1b",
+                            ]
+                        )
+
+                    # === CLEANUP ===
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_MMODE",
+                            "csrci mstatus, 8",
+                            "csrci mstatus, 2",
+                            "CSRW(mideleg, zero)",
+                            "CSRW(mie, zero)",
+                        ]
+                    )
+
+                    if is_timer:
+                        if mip_name == "stip":
+                            # Reset stimecmp to max unconditionally before clearing mip.STIP.
+                            # On STCE=1 systems, hardware re-asserts STIP immediately if stimecmp
+                            # is not reset before the csrrc mip clear.
+                            lines.extend(
+                                [
+                                    f"LI(x{r_temp}, -1)",
+                                    f"csrw stimecmp, x{r_temp}",
+                                    "#if __riscv_xlen == 32",
+                                    f"csrw stimecmph, x{r_temp}",
+                                    "#endif",
+                                ]
+                            )
+                            lines.extend(clr_stimer_mmode(r_scratch))
+                        else:
+                            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+                    else:
+                        lines.append(clr_fn)
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_vectored_m_tests(test_data: TestData) -> list[str]:
+    """Generate vectored interrupt tests in M-mode.
+
+    Test vectored vs direct with S-interrupts, mideleg=0 (fire in M-mode).
+    3 interrupts: SSIP, STIP, SEIP
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_vectored_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_vectored_m",
+            "Test vectored interrupts in M-mode\nS-interrupts with mideleg=0 fire in M-mode",
+        ),
+        "",
+    ]
+
+    # S-mode interrupts (fire in M-mode when not delegated)
+    interrupts = [
+        ("ssip", 0x002, "RVTEST_SET_SSW_INT", "RVTEST_CLR_SSW_INT", False),
+        ("stip", 0x020, None, None, True),
+        ("seip", 0x200, "RVTEST_SET_SEXT_INT", "RVTEST_CLR_SEXT_INT", False),
+    ]
+
+    for int_name, int_bit, int_set, int_clr, uses_timer in interrupts:
+        binname = f"vectored_{int_name}"
+
+        lines.extend(
+            [
+                "",
+                f"# Test vectored M-mode: {int_name}",
+                "RVTEST_GOTO_MMODE",
+                "CSRW(mie, zero)",
+                "csrci mstatus, 8",  # MIE=0
+            ]
+        )
+
+        # Clear all interrupts
+        lines.extend(
+            [
+                "RVTEST_CLR_SSW_INT",
+                "RVTEST_CLR_SEXT_INT",
+            ]
+        )
+        lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+
+        # Set mtvec.MODE = 1 (vectored)
+        lines.extend(
+            [
+                f"CSRR x{r_scratch}, mtvec",
+                f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                f"ADDI x{r_scratch}, x{r_scratch}, 1",  # MODE=1
+                f"CSRW(mtvec, x{r_scratch})",
+            ]
+        )
+
+        # mideleg=0 (no delegation, fire in M-mode)
+        lines.append("CSRW(mideleg, zero)")
+
+        # Enable all S-mode interrupts
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, 0x222)",  # SSIE, STIE, SEIE
+                f"CSRW(mie, x{r_scratch})",
+            ]
+        )
+
+        # Set MIE=1
+        lines.append("csrsi mstatus, 8")
+
+        # Set interrupt pending
+        lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+        if uses_timer:
+            lines.extend(set_stimer_mmode(r_scratch))
+        else:
+            lines.extend([int_set, "nop"])
+
+        # Wait for interrupt
+        lines.extend(
+            [
+                f"    LI(x{r_scratch}, 2500)",
+                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                f"    bnez x{r_scratch}, 1b",
+            ]
+        )
+
+        # Cleanup
+        lines.extend(
+            [
+                "RVTEST_GOTO_MMODE",
+                "csrci mstatus, 8",
+                "csrci mstatus, 2",
+                "CSRW(mideleg, zero)",
+                "CSRW(mie, zero)",
+            ]
+        )
+
+        # Clear interrupt
+        if uses_timer:
+            lines.extend(clr_stimer_mmode(r_scratch))
+        else:
+            lines.append(int_clr)
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_priority_mip_m_tests(test_data: TestData) -> list[str]:
+    """Generate priority tests varying mip with MIE rising.
+
+    Set MIE=0, configure all 64 mip patterns, mie=all 1s, mideleg=0, then set MIE=1.
+    Tests which interrupt fires based on priority.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_priority_mip_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_priority_mip_m",
+            "Test interrupt priority with MIE rising\nAll 64 mip patterns, mie=all 1s, mideleg=0, MIE 0→1",
+        ),
+        "",
+    ]
+
+    # Test all 64 mip patterns
+    for mip_pattern in range(64):
+        ssip = (mip_pattern >> 0) & 1
+        msip = (mip_pattern >> 1) & 1
+        stip = (mip_pattern >> 2) & 1
+        mtip = (mip_pattern >> 3) & 1
+        seip = (mip_pattern >> 4) & 1
+        meip = (mip_pattern >> 5) & 1
+
+        binname = f"priority_mip_{mip_pattern:02x}"
+
+        lines.extend(
+            [
+                "",
+                f"# Test priority MIE rise: mip=0x{mip_pattern:02x}",
+                "RVTEST_GOTO_MMODE",
+                "CSRW(mie, zero)",
+                "csrci mstatus, 8",  # MIE=0
+            ]
+        )
+
+        # Clear all interrupts
+        lines.extend(
+            [
+                "RVTEST_CLR_SSW_INT",
+                "RVTEST_CLR_MSW_INT",
+                "RVTEST_CLR_SEXT_INT",
+                "RVTEST_CLR_MEXT_INT",
+            ]
+        )
+        lines.extend(clr_stimer_mmode(r_scratch))
+        lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+        # mideleg=0 (no delegation)
+        lines.append("CSRW(mideleg, zero)")
+
+        # Enable ALL interrupts in mie
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, -1)",
+                f"CSRW(mie, x{r_scratch})",
+            ]
+        )
+
+        # Set interrupt pattern (with MIE=0, won't fire yet)
+        lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+        if ssip:
+            lines.append("RVTEST_SET_SSW_INT")
+        if msip:
+            lines.append("RVTEST_SET_MSW_INT")
+        if stip:
+            lines.extend(set_stimer_mmode(r_scratch))
+        if mtip:
+            lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+        if seip:
+            lines.append("RVTEST_SET_SEXT_INT")
+        if meip:
+            lines.append("RVTEST_SET_MEXT_INT")
+
+        lines.append("nop")
+
+        # Set MIE=1 (rise event - interrupt fires)
+        lines.append("csrsi mstatus, 8")
+
+        # Wait for highest priority interrupt to fire
+        lines.extend(
+            [
+                f"    LI(x{r_scratch}, 2500)",
+                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                f"    bnez x{r_scratch}, 1b",
+            ]
+        )
+
+        # Cleanup
+        lines.extend(
+            [
+                "RVTEST_GOTO_MMODE",
+                "csrci mstatus, 8",
+                "CSRW(mideleg, zero)",
+                "CSRW(mie, zero)",
+            ]
+        )
+
+        # Clear interrupts
+        if ssip:
+            lines.append("RVTEST_CLR_SSW_INT")
+        if msip:
+            lines.append("RVTEST_CLR_MSW_INT")
+        if stip:
+            lines.extend(clr_stimer_mmode(r_scratch))
+        if mtip:
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+        if seip:
+            lines.append("RVTEST_CLR_SEXT_INT")
+        if meip:
+            lines.append("RVTEST_CLR_MEXT_INT")
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_priority_mie_m_tests(test_data: TestData) -> list[str]:
+    """Generate priority tests varying mie with MIE rising.
+
+    Set MIE=0, configure all 64 mie patterns, set all mip, mideleg=0, then MIE=1.
+    Tests which interrupt fires based on enable priority.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_priority_mie_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_priority_mie_m",
+            "Test interrupt priority with MIE rising\nAll 64 mie patterns, mip=all 1s, mideleg=0, MIE 0→1",
+        ),
+        "",
+    ]
+
+    # Test all 64 mie patterns
+    for mie_pattern in range(64):
+        ssie = (mie_pattern >> 0) & 1
+        msie = (mie_pattern >> 1) & 1
+        stie = (mie_pattern >> 2) & 1
+        mtie = (mie_pattern >> 3) & 1
+        seie = (mie_pattern >> 4) & 1
+        meie = (mie_pattern >> 5) & 1
+
+        # Build mie value
+        mie_val = (ssie << 1) | (msie << 3) | (stie << 5) | (mtie << 7) | (seie << 9) | (meie << 11)
+
+        binname = f"priority_mie_{mie_pattern:02x}"
+
+        lines.extend(
+            [
+                "",
+                f"# Test priority MIE rise: mie=0x{mie_pattern:02x}",
+                "RVTEST_GOTO_MMODE",
+                "CSRW(mie, zero)",
+                "csrci mstatus, 8",  # MIE=0
+            ]
+        )
+
+        # Clear all interrupts
+        lines.extend(
+            [
+                "RVTEST_CLR_SSW_INT",
+                "RVTEST_CLR_MSW_INT",
+                "RVTEST_CLR_SEXT_INT",
+                "RVTEST_CLR_MEXT_INT",
+            ]
+        )
+        lines.extend(clr_stimer_mmode(r_scratch))
+        lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+        # mideleg=0 (no delegation)
+        lines.append("CSRW(mideleg, zero)")
+
+        # Set specific mie pattern
+        lines.extend(
+            [
+                f"LI(x{r_scratch}, {hex(mie_val)})",
+                f"CSRW(mie, x{r_scratch})",
+            ]
+        )
+
+        # Set ALL interrupts (with MIE=0, won't fire yet)
+        lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+        lines.extend(
+            [
+                "RVTEST_SET_SSW_INT",
+                "RVTEST_SET_MSW_INT",
+            ]
+        )
+        lines.extend(set_stimer_mmode(r_scratch))
+        lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+        lines.extend(
+            [
+                "RVTEST_SET_SEXT_INT",
+                "RVTEST_SET_MEXT_INT",
+                "nop",
+            ]
+        )
+
+        # Set MIE=1 (rise event - interrupt fires)
+        lines.append("csrsi mstatus, 8")
+
+        # Wait for highest priority enabled interrupt
+        lines.extend(
+            [
+                f"    LI(x{r_scratch}, 100)",
+                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                f"    bnez x{r_scratch}, 1b",
+            ]
+        )
+
+        # Cleanup
+        lines.extend(
+            [
+                "RVTEST_GOTO_MMODE",
+                "csrci mstatus, 8",
+                "CSRW(mideleg, zero)",
+                "CSRW(mie, zero)",
+                "RVTEST_CLR_SSW_INT",
+                "RVTEST_CLR_MSW_INT",
+            ]
+        )
+        lines.extend(clr_stimer_mmode(r_scratch))
+        lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+        lines.extend(
+            [
+                "RVTEST_CLR_SEXT_INT",
+                "RVTEST_CLR_MEXT_INT",
+            ]
+        )
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_wfi_m_tests(test_data: TestData) -> list[str]:
+    """Generate WFI tests in M-mode.
+
+    Test WFI with MTIP in M-mode across all MIE, SIE, TW, mideleg combinations.
+    WFI should wake on timer regardless of settings.
+    8 tests: 2 MIE × 2 SIE × 2 TW
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_wfi_m"
+
+    r_mtime, r_mtimecmp, r_temp1, r_temp2, r_temp3, r_temp4 = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_wfi_m",
+            "Test WFI in M-mode with MTIP\n8 tests: MIE × SIE × TW combinations",
+        ),
+        "",
+    ]
+
+    # Test all 8 combinations
+    for mie_val in [0, 1]:
+        for sie_val in [0, 1]:
+            for tw_val in [0, 1]:
+                binname = f"wfi_m_mie{mie_val}_sie{sie_val}_tw{tw_val}"
+
+                lines.extend(
+                    [
+                        "",
+                        f"# Test M-mode WFI: MIE={mie_val}, SIE={sie_val}, TW={tw_val}",
+                        "RVTEST_GOTO_MMODE",
+                        "CSRW(mie, zero)",
+                        "csrci mstatus, 8",  # Clear MIE
+                        "csrci mstatus, 2",  # Clear SIE
+                    ]
+                )
+
+                # Clear timer
+                lines.extend(clr_mtimer_int(r_temp1, r_mtimecmp))
+
+                # Set mideleg = 0x222 (S-interrupts delegated)
+                lines.extend(
+                    [
+                        f"LI(x{r_temp1}, 0x222)",
+                        f"CSRW(mideleg, x{r_temp1})",
+                    ]
+                )
+
+                # Enable MTIE
+                lines.extend(
+                    [
+                        f"LI(x{r_temp1}, 0x80)",  # MTIE bit
+                        f"CSRS(mie, x{r_temp1})",
+                    ]
+                )
+
+                # Set MIE
+                if mie_val:
+                    lines.append("csrsi mstatus, 8")
+
+                # Set SIE
+                if sie_val:
+                    lines.append("csrsi mstatus, 2")
+
+                # Set TW bit
+                if tw_val:
+                    lines.extend(
+                        [
+                            f"LI(x{r_temp1}, 0x200000)",  # TW bit (bit 21)
+                            f"CSRS(mstatus, x{r_temp1})",
+                        ]
+                    )
+
+                # Set machine timer to fire soon
+                lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+                lines.extend(set_mtimer_int_soon(r_mtime, r_mtimecmp, r_temp1, r_temp2, r_temp3, r_temp4))
+
+                # Execute WFI in M-mode
+                lines.extend(
+                    [
+                        "    nop",
+                        "    wfi",  # Wait for timer interrupt
+                        "    nop",
+                        "    nop",
+                    ]
+                )
+
+                # Cleanup
+                lines.extend(
+                    [
+                        "RVTEST_GOTO_MMODE",
+                        "csrci mstatus, 8",  # Clear MIE
+                        "csrci mstatus, 2",  # Clear SIE
+                        f"LI(x{r_temp1}, 0x200000)",
+                        f"CSRC(mstatus, x{r_temp1})",  # Clear TW
+                        "CSRW(mideleg, zero)",
+                        "CSRW(mie, zero)",
+                    ]
+                )
+                lines.extend(clr_mtimer_int(r_temp1, r_mtimecmp))
+
+    test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp1, r_temp2, r_temp3, r_temp4])
+    return lines
+
+
+def _generate_trigger_mti_m_tests(test_data: TestData) -> list[str]:
+    """Generate MTIP trigger test when MIE rises via CSRRS.
+
+    Set MTIP pending with MIE=0, then use CSRRS to set MIE=1.
+    Interrupt fires when MIE rises.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_mti_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_mti_m",
+            "Test MTIP trigger when MIE rises via CSRRS instruction",
+        ),
+        "",
+    ]
+
+    binname = "trigger_mti_csrrs"
+
+    lines.extend(
+        [
+            "",
+            "# Test: MTIP fires when MIE rises (CSRRS)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",  # MIE=0
+        ]
+    )
+
+    # Clear timer
+    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    # Set mideleg=0
+    lines.append("CSRW(mideleg, zero)")
+
+    # Enable all interrupts in mie
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, -1)",
+            f"CSRW(mie, x{r_scratch})",
+        ]
+    )
+
+    # Set MTIP using the timer function
+    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+    lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+
+    # Wait for timer to be pending
+    lines.extend(
+        [
+            "nop",
+            "nop",
+            "nop",
+            "nop",
+        ]
+    )
+
+    # Use CSRRS to set MIE=1 (interrupt fires)
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, 0x8)",  # MIE bit (bit 3)
+            f"CSRRS x0, mstatus, x{r_scratch}",  # Set MIE=1 via CSRRS
+            "nop",
+            "nop",
+        ]
+    )
+
+    # Cleanup
+    lines.extend(
+        [
+            "RVTEST_GOTO_MMODE",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "CSRW(mie, zero)",
+        ]
+    )
+    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_trigger_ssi_sip_m_tests(test_data: TestData) -> list[str]:
+    """Generate SSIP trigger test via SIP CSR write in M-mode.
+
+    Use CSRRS to write sip.SSIP, test with MIE={0,1} and mideleg.SSI={0,1}.
+    4 tests total.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_ssi_sip_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_ssi_sip_m",
+            "Test SSIP trigger via SIP write (CSRRS) in M-mode\n4 tests: MIE={0,1} × mideleg.SSI={0,1}",
+        ),
+        "",
+    ]
+
+    # Test both MIE and mideleg.SSI values
+    for mie_val in [0, 1]:
+        for mideleg_ssi in [0, 1]:
+            binname = f"trigger_ssi_sip_mie{mie_val}_ssi{mideleg_ssi}"
+
+            lines.extend(
+                [
+                    "",
+                    f"# Test: SSIP via SIP write, MIE={mie_val}, mideleg.SSI={mideleg_ssi}",
+                    "RVTEST_GOTO_MMODE",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",  # MIE=0
+                ]
+            )
+
+            # Clear SSIP
+            lines.append("RVTEST_CLR_SSW_INT")
+
+            lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+            # Set mideleg.SSI
+            if mideleg_ssi:
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x2)",  # SSI bit
+                        f"CSRW(mideleg, x{r_scratch})",
+                    ]
+                )
+            else:
+                lines.append("CSRW(mideleg, zero)")
+
+            # Enable all interrupts in mie
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, -1)",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
+            # Set MIE if needed (AFTER setting up everything)
+            # This prevents early firing
+            lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+            # Set MIE
+            if mie_val:
+                lines.extend(
+                    [
+                        "csrsi mstatus, 8",
+                        "nop",
+                        "nop",
+                    ]
+                )
+
+            # Use CSRRS to set sip.SSIP (with MIE still 0)
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x2)",  # SSIP bit (bit 1)
+                    f"CSRRS x0, sip, x{r_scratch}",  # Set SSIP via SIP write
+                    "nop",
+                    "nop",
+                ]
+            )
+
+            # Wait for highest priority enabled interrupt
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 2500)",
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
+
+            # Cleanup
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "csrci mstatus, 8",
+                    "RVTEST_CLR_SSW_INT",
+                    "CSRW(mideleg, zero)",
+                    "CSRW(mie, zero)",
+                ]
+            )
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_trigger_msi_m_tests(test_data: TestData) -> list[str]:
+    """Generate MSIP trigger test when MIE rises via CSRRS.
+
+    Set MSIP pending with MIE=0, then use CSRRS to set MIE=1.
+    Interrupt fires when MIE rises.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_msi_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_msi_m",
+            "Test MSIP trigger when MIE rises via CSRRS instruction",
+        ),
+        "",
+    ]
+
+    binname = "trigger_msi_csrrs"
+
+    lines.extend(
+        [
+            "",
+            "# Test: MSIP fires when MIE rises (CSRRS)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",  # MIE=0
+        ]
+    )
+
+    # Clear all interrupts
+    lines.extend(
+        [
+            "RVTEST_CLR_SSW_INT",
+            "RVTEST_CLR_MSW_INT",
+        ]
+    )
+    lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    # Set mideleg=0
+    lines.append("CSRW(mideleg, zero)")
+
+    # Enable all interrupts in mie
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, -1)",
+            f"CSRW(mie, x{r_scratch})",
+        ]
+    )
+
+    # Set MSIP
+    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+    lines.extend(
+        [
+            "RVTEST_SET_MSW_INT",
+        ]
+    )
+
+    lines.extend(
+        [
+            f"    LI(x{r_scratch}, 2500)",
+            f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+            f"    bnez x{r_scratch}, 1b",
+        ]
+    )
+
+    # Use CSRRS to set MIE=1 (interrupt fires)
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, 0x8)",  # MIE bit (bit 3)
+            f"CSRRS x0, mstatus, x{r_scratch}",  # Set MIE=1 via CSRRS
+            "nop",
+            "nop",
+        ]
+    )
+
+    # Cleanup
+    lines.extend(
+        [
+            "RVTEST_GOTO_MMODE",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "CSRW(mie, zero)",
+            "RVTEST_CLR_MSW_INT",
+        ]
+    )
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_trigger_mei_m_tests(test_data: TestData) -> list[str]:
+    """Generate MEIP trigger test when MIE rises via CSRRS.
+
+    Set MEIP pending with MIE=0, then use CSRRS to set MIE=1.
+    Interrupt fires when MIE rises.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_mei_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_mei_m",
+            "Test MEIP trigger when MIE rises via CSRRS instruction",
+        ),
+        "",
+    ]
+
+    binname = "trigger_mei_csrrs"
+
+    lines.extend(
+        [
+            "",
+            "# Test: MEIP fires when MIE rises (CSRRS)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",  # MIE=0
+        ]
+    )
+
+    # Clear all interrupts
+    lines.extend(
+        [
+            "RVTEST_CLR_SSW_INT",
+            "RVTEST_CLR_MSW_INT",
+            "RVTEST_CLR_SEXT_INT",
+            "RVTEST_CLR_MEXT_INT",
+        ]
+    )
+    lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    # Set mideleg=0
+    lines.append("CSRW(mideleg, zero)")
+
+    # Enable all interrupts in mie
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, -1)",
+            f"CSRW(mie, x{r_scratch})",
+        ]
+    )
+
+    # Set MEIP
+    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+    lines.extend(
+        [
+            "RVTEST_SET_MEXT_INT",
+        ]
+    )
+
+    lines.extend(
+        [
+            f"    LI(x{r_scratch}, 2500)",
+            f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+            f"    bnez x{r_scratch}, 1b",
+        ]
+    )
+
+    # Use CSRRS to set MIE=1 (interrupt fires)
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, 0x8)",  # MIE bit (bit 3)
+            f"CSRRS x0, mstatus, x{r_scratch}",  # Set MIE=1 via CSRRS
+        ]
+    )
+
+    # Cleanup
+    lines.extend(
+        [
+            "RVTEST_GOTO_MMODE",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "CSRW(mie, zero)",
+            "RVTEST_CLR_MEXT_INT",
+        ]
+    )
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_trigger_sti_m_tests(test_data: TestData) -> list[str]:
+    """Generate STIP trigger test when MIE rises via CSRRS.
+
+    Set STIP pending with MIE=0, then use CSRRS to set MIE=1.
+    Interrupt fires when MIE rises.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_sti_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_sti_m",
+            "Test STIP trigger when MIE rises via CSRRS instruction",
+        ),
+        "",
+    ]
+
+    binname = "trigger_sti_csrrs"
+
+    lines.extend(
+        [
+            "",
+            "# Test: STIP fires when MIE rises (CSRRS)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",  # MIE=0
+        ]
+    )
+
+    # Clear all interrupts
+    lines.extend(
+        [
+            "RVTEST_CLR_SSW_INT",
+            "RVTEST_CLR_MSW_INT",
+            "RVTEST_CLR_SEXT_INT",
+            "RVTEST_CLR_MEXT_INT",
+        ]
+    )
+    lines.extend(clr_stimer_mmode(r_scratch))
+    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    # Set mideleg=0 (STIP fires in M-mode)
+    lines.append("CSRW(mideleg, zero)")
+
+    # Enable all interrupts in mie
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, -1)",
+            f"CSRW(mie, x{r_scratch})",
+        ]
+    )
+
+    # Set STIP using M-mode direct write
+    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+    lines.extend(set_stimer_mmode(r_scratch))
+
+    lines.extend(
+        [
+            f"    LI(x{r_scratch}, 2500)",
+            f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+            f"    bnez x{r_scratch}, 1b",
+        ]
+    )
+
+    # Use CSRRS to set MIE=1 (interrupt fires)
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, 0x8)",  # MIE bit (bit 3)
+            f"CSRRS x0, mstatus, x{r_scratch}",  # Set MIE=1 via CSRRS
+            "nop",
+            "nop",
+        ]
+    )
+
+    # Cleanup
+    lines.extend(
+        [
+            "RVTEST_GOTO_MMODE",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "CSRW(mie, zero)",
+        ]
+    )
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_trigger_ssi_m_tests(test_data: TestData) -> list[str]:
+    """Generate SSIP trigger test when MIE rises via CSRRS.
+
+    Set SSIP pending with MIE=0, mideleg=0, then use CSRRS to set MIE=1.
+    Interrupt fires when MIE rises.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_ssi_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_ssi_m",
+            "Test SSIP trigger when MIE rises via CSRRS instruction",
+        ),
+        "",
+    ]
+
+    binname = "trigger_ssi_csrrs"
+
+    lines.extend(
+        [
+            "",
+            "# Test: SSIP fires when MIE rises (CSRRS)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",  # MIE=0
+        ]
+    )
+
+    # Clear all interrupts
+    lines.extend(
+        [
+            "RVTEST_CLR_SSW_INT",
+            "RVTEST_CLR_MSW_INT",
+            "RVTEST_CLR_SEXT_INT",
+            "RVTEST_CLR_MEXT_INT",
+        ]
+    )
+    lines.extend(clr_stimer_mmode(r_scratch))
+    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    # Set mideleg=0 (SSIP fires in M-mode)
+    lines.append("CSRW(mideleg, zero)")
+
+    # Enable all interrupts in mie
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, -1)",
+            f"CSRW(mie, x{r_scratch})",
+        ]
+    )
+
+    # Set SSIP
+    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+    lines.extend(
+        [
+            "RVTEST_SET_SSW_INT",
+        ]
+    )
+
+    lines.extend(
+        [
+            f"    LI(x{r_scratch}, 2500)",
+            f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+            f"    bnez x{r_scratch}, 1b",
+        ]
+    )
+
+    # Use CSRRS to set MIE=1 (interrupt fires)
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, 0x8)",  # MIE bit (bit 3)
+            f"CSRRS x0, mstatus, x{r_scratch}",  # Set MIE=1 via CSRRS
+            "nop",
+            "nop",
+        ]
+    )
+
+    # Cleanup
+    lines.extend(
+        [
+            "RVTEST_GOTO_MMODE",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "CSRW(mie, zero)",
+            "RVTEST_CLR_SSW_INT",
+        ]
+    )
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_trigger_sei_m_tests(test_data: TestData) -> list[str]:
+    """Generate SEIP trigger test when MIE rises via CSRRS.
+
+    Set SEIP pending with MIE=0, mideleg=0, then use CSRRS to set MIE=1.
+    Interrupt fires when MIE rises.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_trigger_sei_m"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_trigger_sei_m",
+            "Test SEIP trigger when MIE rises via CSRRS instruction",
+        ),
+        "",
+    ]
+
+    binname = "trigger_sei_csrrs"
+
+    lines.extend(
+        [
+            "",
+            "# Test: SEIP fires when MIE rises (CSRRS)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",  # MIE=0
+        ]
+    )
+
+    # Clear all interrupts
+    lines.extend(
+        [
+            "RVTEST_CLR_SSW_INT",
+            "RVTEST_CLR_MSW_INT",
+            "RVTEST_CLR_SEXT_INT",
+            "RVTEST_CLR_MEXT_INT",
+        ]
+    )
+    lines.extend(clr_stimer_mmode(r_scratch))
+    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    # Set mideleg=0 (SEIP fires in M-mode)
+    lines.append("CSRW(mideleg, zero)")
+
+    # Enable all interrupts in mie
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, -1)",
+            f"CSRW(mie, x{r_scratch})",
+        ]
+    )
+
+    # Set SEIP
+    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+    lines.extend(
+        [
+            "RVTEST_SET_SEXT_INT",
+        ]
+    )
+
+    lines.extend(
+        [
+            f"    LI(x{r_scratch}, 2500)",
+            f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+            f"    bnez x{r_scratch}, 1b",
+        ]
+    )
+
+    # Use CSRRS to set MIE=1 (interrupt fires)
+    lines.extend(
+        [
+            f"LI(x{r_scratch}, 0x8)",  # MIE bit (bit 3)
+            f"CSRRS x0, mstatus, x{r_scratch}",  # Set MIE=1 via CSRRS
+            "nop",
+            "nop",
+        ]
+    )
+
+    # Cleanup
+    lines.extend(
+        [
+            "RVTEST_GOTO_MMODE",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "CSRW(mie, zero)",
+            "RVTEST_CLR_SEXT_INT",
+        ]
+    )
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_sei_interaction_tests(test_data: TestData) -> list[str]:
+    """Generate SEIP/PLIC interaction tests.
+
+    Tests interaction between software mip.SEIP writes and PLIC hardware SEIP.
+    Note: SEIP not implemented on platform - all tests expected 0%.
+    """
+    covergroup = "InterruptsS_S_cg"
+
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "SEIP Interaction Tests",
+            "Test SEIP interaction between CSR writes and PLIC\nExpected 0% - SEIP not implemented on platform",
+        ),
+        "",
+    ]
+
+    # === cp_sei1: csrrw to set mip.SEIP ===
+    lines.extend(
+        [
+            "",
+            "# cp_sei1: Use csrrw to set mip.SEIP (PLIC inactive)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",  # MIE=0
+            "CSRW(mideleg, zero)",  # mideleg=0
+            "RVTEST_CLR_SEXT_INT",  # Clear PLIC
+            f"LI(x{r_scratch}, 0x200)",  # SEIP bit
+            test_data.add_testcase("csrrw_set", "cp_sei1", covergroup),
+            f"CSRRW(zero, mip, x{r_scratch})",  # Write SEIP=1
+            "nop",
+            "nop",
+            "RVTEST_CLR_SEXT_INT",
+            "",
+        ]
+    )
+
+    # === cp_sei2: csrrs to set mip.SEIP ===
+    lines.extend(
+        [
+            "# cp_sei2: Use csrrs to set mip.SEIP (PLIC inactive)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "RVTEST_CLR_SEXT_INT",
+            f"LI(x{r_scratch}, 0x200)",
+            test_data.add_testcase("csrrs_set", "cp_sei2", covergroup),
+            f"CSRRS(zero, mip, x{r_scratch})",  # Set SEIP=1
+            "nop",
+            "nop",
+            "RVTEST_CLR_SEXT_INT",
+            "",
+        ]
+    )
+
+    # === cp_sei3: PLIC sets mip.SEIP ===
+    lines.extend(
+        [
+            "# cp_sei3: PLIC sets mip.SEIP",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "CSRW(mip, zero)",  # Clear software SEIP
+            test_data.add_testcase("plic_set", "cp_sei3", covergroup),
+            "RVTEST_SET_SEXT_INT",  # PLIC sets SEIP
+            "nop",
+            "nop",
+            "RVTEST_CLR_SEXT_INT",
+            "",
+        ]
+    )
+
+    # === cp_sei4: csrrc clears mip.SEIP (PLIC inactive, software wrote 1) ===
+    lines.extend(
+        [
+            "# cp_sei4: Use csrrc to clear mip.SEIP (software wrote 1, PLIC inactive)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "RVTEST_CLR_SEXT_INT",
+            f"LI(x{r_scratch}, 0x200)",
+            f"CSRRS(zero, mip, x{r_scratch})",  # First set SEIP=1 via software
+            "nop",
+            test_data.add_testcase("csrrc_clr_sw", "cp_sei4", covergroup),
+            f"CSRRC(zero, mip, x{r_scratch})",  # Clear SEIP
+            "nop",
+            "nop",
+            "",
+        ]
+    )
+
+    # === cp_sei5: csrrc fails to clear (PLIC active, software wrote 1) ===
+    lines.extend(
+        [
+            "# cp_sei5: Try csrrc to clear mip.SEIP (software wrote 1, PLIC active)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "RVTEST_CLR_SEXT_INT",
+            f"LI(x{r_scratch}, 0x200)",
+            f"CSRRS(zero, mip, x{r_scratch})",  # Software sets SEIP=1
+            "RVTEST_SET_SEXT_INT",  # PLIC also sets SEIP
+            "nop",
+            test_data.add_testcase("csrrc_fail_plic", "cp_sei5", covergroup),
+            f"CSRRC(zero, mip, x{r_scratch})",  # Try to clear - should fail
+            "nop",
+            "nop",
+            "RVTEST_CLR_SEXT_INT",
+            "",
+        ]
+    )
+
+    # === cp_sei6: Turn off PLIC (no software write) ===
+    lines.extend(
+        [
+            "# cp_sei6: Turn off PLIC.SEIP (software never wrote 1)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            "CSRW(mip, zero)",  # No software write
+            "RVTEST_SET_SEXT_INT",  # PLIC sets SEIP
+            "nop",
+            test_data.add_testcase("plic_off_nosw", "cp_sei6", covergroup),
+            "RVTEST_CLR_SEXT_INT",  # Turn off PLIC
+            "nop",
+            "nop",
+            "",
+        ]
+    )
+
+    # === cp_sei7: Turn off PLIC (software wrote 1) ===
+    lines.extend(
+        [
+            "# cp_sei7: Turn off PLIC.SEIP (software wrote 1)",
+            "RVTEST_GOTO_MMODE",
+            "CSRW(mie, zero)",
+            "csrci mstatus, 8",
+            "CSRW(mideleg, zero)",
+            f"LI(x{r_scratch}, 0x200)",
+            f"CSRRS(zero, mip, x{r_scratch})",  # Software sets SEIP=1
+            "RVTEST_SET_SEXT_INT",  # PLIC also sets SEIP
+            "nop",
+            test_data.add_testcase("plic_off_sw", "cp_sei7", covergroup),
+            "RVTEST_CLR_SEXT_INT",  # Turn off PLIC
+            "nop",
+            "nop",
+            "CSRW(mip, zero)",  # Final cleanup
+            "",
+        ]
+    )
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_global_ie_tests(test_data: TestData) -> list[str]:
+    """Generate global interrupt enable tests.
+
+    Test MIE and SIE interaction with M-mode interrupts.
+    Cross: MIE={0,1} × SIE={0,1} × M-interrupts (MSIP, MTIP, MEIP)
+    2 × 2 × 3 = 12 bins (4 achievable with only MTIP)
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_global_ie"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_global_ie",
+            "Test global interrupt enables in M-mode\nCross: MIE={0,1} × SIE={0,1} × M-interrupts",
+        ),
+        "",
+    ]
+
+    # M-mode interrupts
+    m_interrupts = [
+        ("msip", 0x008, 0x008, "RVTEST_SET_MSW_INT", "RVTEST_CLR_MSW_INT", False),
+        ("mtip", 0x080, 0x080, None, None, True),
+        ("meip", 0x800, 0x800, "RVTEST_SET_MEXT_INT", "RVTEST_CLR_MEXT_INT", False),
+    ]
+
+    # Cross: MIE × SIE × M-interrupts
+    for mie_val in [0, 1]:
+        for sie_val in [0, 1]:
+            for int_name, mip_bit, mie_bit, int_set, int_clr, is_timer in m_interrupts:
+                binname = f"mie{mie_val}_sie{sie_val}_{int_name}"
+
+                lines.extend(
+                    [
+                        "",
+                        f"# Test: MIE={mie_val}, SIE={sie_val}, {int_name}",
+                        "RVTEST_GOTO_MMODE",
+                        "CSRW(mie, zero)",
+                        "csrci mstatus, 8",  # MIE=0
+                        "csrci mstatus, 2",  # SIE=0
+                    ]
+                )
+
+                # Clear all interrupts
+                lines.extend(
+                    [
+                        "RVTEST_CLR_SSW_INT",
+                        "RVTEST_CLR_MSW_INT",
+                        "RVTEST_CLR_SEXT_INT",
+                        "RVTEST_CLR_MEXT_INT",
+                    ]
+                )
+                lines.extend(clr_stimer_mmode(r_scratch))
+                lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+                # Set mideleg=0 (no delegation)
+                lines.append("CSRW(mideleg, zero)")
+
+                # Enable matching interrupt in mie
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, {hex(mie_bit)})",
+                        f"CSRW(mie, x{r_scratch})",
+                    ]
+                )
+
+                # Set MIE
+                if mie_val:
+                    lines.append("csrsi mstatus, 8")
+
+                # Set SIE
+                if sie_val:
+                    lines.append("csrsi mstatus, 2")
+
+                # Set interrupt pending
+                lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+                if is_timer:
+                    lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+                else:
+                    lines.extend([int_set, "nop"])
+
+                # Wait for interrupt (if MIE=1, fires; if MIE=0, doesn't)
+                lines.extend(
+                    [
+                        f"    LI(x{r_scratch}, 2500)",
+                        f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                        f"    bnez x{r_scratch}, 1b",
+                    ]
+                )
+
+                # Cleanup
+                lines.extend(
+                    [
+                        "RVTEST_GOTO_MMODE",
+                        "csrci mstatus, 8",
+                        "csrci mstatus, 2",
+                        "CSRW(mideleg, zero)",
+                        "CSRW(mie, zero)",
+                    ]
+                )
+
+                # Clear interrupt
+                if is_timer:
+                    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+                else:
+                    lines.append(int_clr)
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_user_mti_tests(test_data: TestData) -> list[str]:
+    """Generate U-mode MTIP tests.
+
+    Test MTIP from U-mode with mideleg=0 (not delegated).
+    Cross: MIE={0,1} × SIE={0,1} × mtvec.MODE={0,1} × MTIP={0,1}
+    2 × 2 × 2 × 2 = 16 bins
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_user_mti"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_user_mti",
+            "Test MTIP from U-mode (not delegated)\nCross: MIE={0,1} × SIE={0,1} × mtvec.MODE={0,1} × MTIP={0,1}",
+        ),
+        "",
+    ]
+
+    # Cross: MIE × SIE × mtvec.MODE × MTIP
+    for mie_val in [0, 1]:
+        for sie_val in [0, 1]:
+            for mtvec_mode in [0, 1]:
+                for set_timer in [False, True]:
+                    timer_name = "mtip1" if set_timer else "mtip0"
+                    binname = f"mie{mie_val}_sie{sie_val}_vec{mtvec_mode}_{timer_name}"
+
+                    lines.extend(
+                        [
+                            "",
+                            f"# Test: MIE={mie_val}, SIE={sie_val}, mtvec.MODE={mtvec_mode}, timer={set_timer}",
+                            "RVTEST_GOTO_MMODE",
+                            "CSRW(mie, zero)",
+                            "csrci mstatus, 8",  # MIE=0
+                            "csrci mstatus, 2",  # SIE=0
+                        ]
+                    )
+
+                    # Clear timer
+                    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+                    # Set mideleg.MTI=0 (not delegated)
+                    lines.append("CSRW(mideleg, zero)")
+
+                    # Set both mtvec and stvec MODE
+                    lines.extend(
+                        [
+                            f"CSRR x{r_scratch}, mtvec",
+                            f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                            f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                            f"ADDI x{r_scratch}, x{r_scratch}, {mtvec_mode}",
+                            f"CSRW(mtvec, x{r_scratch})",
+                            f"CSRR x{r_scratch}, stvec",
+                            f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                            f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                            f"ADDI x{r_scratch}, x{r_scratch}, {mtvec_mode}",
+                            f"CSRW(stvec, x{r_scratch})",
+                        ]
+                    )
+
+                    # Enable MTIE
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x80)",  # MTIE
+                            f"CSRW(mie, x{r_scratch})",
+                        ]
+                    )
+
+                    # Set MIE
+                    if mie_val:
+                        lines.append("csrsi mstatus, 8")
+
+                    # Set SIE
+                    if sie_val:
+                        lines.append("csrsi mstatus, 2")
+
+                    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+                    # Set MTIP if needed
+                    if set_timer:
+                        lines.extend(set_mtimer_int(r_mtime, r_stimecmp, r_temp, r_temp2))
+                        lines.extend(
+                            [
+                                f"    LI(x{r_scratch}, 2500)",
+                                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                                f"    bnez x{r_scratch}, 1b",
+                            ]
+                        )
+
+                    # Enter U-mode
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_LOWER_MODE Umode",
+                            "    nop",
+                            "    nop",
+                            "    nop",
+                            "    nop",
+                        ]
+                    )
+
+                    lines.extend(
+                        [
+                            f"    LI(x{r_scratch}, 2500)",
+                            f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                            f"    bnez x{r_scratch}, 1b",
+                        ]
+                    )
+
+                    # Cleanup
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_MMODE",
+                            "csrci mstatus, 8",
+                            "csrci mstatus, 2",
+                            "CSRW(mideleg, zero)",
+                            "CSRW(mie, zero)",
+                        ]
+                    )
+                    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_user_msi_tests(test_data: TestData) -> list[str]:
+    """Generate U-mode MSIP tests.
+
+    Test MSIP from U-mode with mideleg=0 (not delegated).
+    Cross: MIE={0,1} × SIE={0,1} × stvec.MODE={0,1} × MSIP={0,1}
+    2 × 2 × 2 × 2 = 16 bins
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_user_msi"
+
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_user_msi",
+            "Test MSIP from U-mode (not delegated)\nCross: MIE={0,1} × SIE={0,1} × stvec.MODE={0,1} × MSIP={0,1}",
+        ),
+        "",
+    ]
+
+    # Cross: MIE × SIE × stvec.MODE × MSIP
+    for mie_val in [0, 1]:
+        for sie_val in [0, 1]:
+            for stvec_mode in [0, 1]:
+                for set_msip in [False, True]:
+                    msip_name = "msip1" if set_msip else "msip0"
+                    binname = f"mie{mie_val}_sie{sie_val}_vec{stvec_mode}_{msip_name}"
+
+                    lines.extend(
+                        [
+                            "",
+                            f"# Test: MIE={mie_val}, SIE={sie_val}, stvec.MODE={stvec_mode}, MSIP={set_msip}",
+                            "RVTEST_GOTO_MMODE",
+                            "CSRW(mie, zero)",
+                            "csrci mstatus, 8",  # MIE=0
+                            "csrci mstatus, 2",  # SIE=0
+                        ]
+                    )
+
+                    # Clear MSIP
+                    lines.append("RVTEST_CLR_MSW_INT")
+
+                    # Set mideleg.MSI=0 (not delegated)
+                    lines.append("CSRW(mideleg, zero)")
+
+                    # Set both mtvec and stvec MODE
+                    lines.extend(
+                        [
+                            f"CSRR x{r_scratch}, mtvec",
+                            f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                            f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                            f"ADDI x{r_scratch}, x{r_scratch}, {stvec_mode}",
+                            f"CSRW(mtvec, x{r_scratch})",
+                            f"CSRR x{r_scratch}, stvec",
+                            f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                            f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                            f"ADDI x{r_scratch}, x{r_scratch}, {stvec_mode}",
+                            f"CSRW(stvec, x{r_scratch})",
+                        ]
+                    )
+
+                    # Enable MSIE
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x8)",  # MSIE
+                            f"CSRW(mie, x{r_scratch})",
+                        ]
+                    )
+
+                    # Set SIE first
+                    if sie_val:
+                        lines.append("csrsi mstatus, 2")
+
+                    # NOW set MIE
+                    if mie_val:
+                        lines.append("csrsi mstatus, 8")
+
+                    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+                    # Set MSIP BEFORE setting MIE (critical order!)
+                    if set_msip:
+                        lines.extend(
+                            [
+                                "RVTEST_SET_MSW_INT",
+                                "nop",
+                                "nop",
+                            ]
+                        )
+                        lines.extend(
+                            [
+                                f"    LI(x{r_scratch}, 2500)",
+                                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                                f"    bnez x{r_scratch}, 1b",
+                            ]
+                        )
+
+                    # Enter U-mode
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_LOWER_MODE Umode",
+                            "    nop",
+                            "    nop",
+                        ]
+                    )
+
+                    # For MIE=1 + MSIP=1: Set MSIP in U-mode (wait - can't do this!)
+                    # Software interrupt is immediate, not delayed like timer
+                    # This case is IMPOSSIBLE to hit correctly
+
+                    # Cleanup
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_MMODE",
+                            "csrci mstatus, 8",
+                            "csrci mstatus, 2",
+                            "CSRW(mideleg, zero)",
+                            "CSRW(mie, zero)",
+                            "RVTEST_CLR_MSW_INT",
+                        ]
+                    )
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_user_mei_tests(test_data: TestData) -> list[str]:
+    """Generate U-mode MEIP tests.
+
+    Test MEIP from U-mode with mideleg=0 (not delegated).
+    Cross: MIE={0,1} × SIE={0,1} × stvec.MODE={0,1} × MEIP={0,1}
+    2 × 2 × 2 × 2 = 16 bins
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_user_mei"
+
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_user_mei",
+            "Test MEIP from U-mode (not delegated)\nCross: MIE={0,1} × SIE={0,1} × stvec.MODE={0,1} × MEIP={0,1}",
+        ),
+        "",
+    ]
+
+    # Cross: MIE × SIE × stvec.MODE × MEIP
+    for mie_val in [0, 1]:
+        for sie_val in [0, 1]:
+            for stvec_mode in [0, 1]:
+                for set_meip in [False, True]:
+                    meip_name = "meip1" if set_meip else "meip0"
+                    binname = f"mie{mie_val}_sie{sie_val}_vec{stvec_mode}_{meip_name}"
+
+                    lines.extend(
+                        [
+                            "",
+                            f"# Test: MIE={mie_val}, SIE={sie_val}, stvec.MODE={stvec_mode}, MEIP={set_meip}",
+                            "RVTEST_GOTO_MMODE",
+                            "CSRW(mie, zero)",
+                            "csrci mstatus, 8",  # MIE=0
+                            "csrci mstatus, 2",  # SIE=0
+                        ]
+                    )
+
+                    # Clear MEIP
+                    lines.append("RVTEST_CLR_MEXT_INT")
+
+                    # Set mideleg.MEI=0 (not delegated)
+                    lines.append("CSRW(mideleg, zero)")
+
+                    # Set both mtvec and stvec MODE
+                    lines.extend(
+                        [
+                            f"CSRR x{r_scratch}, mtvec",
+                            f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                            f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                            f"ADDI x{r_scratch}, x{r_scratch}, {stvec_mode}",
+                            f"CSRW(mtvec, x{r_scratch})",
+                            f"CSRR x{r_scratch}, stvec",
+                            f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                            f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                            f"ADDI x{r_scratch}, x{r_scratch}, {stvec_mode}",
+                            f"CSRW(stvec, x{r_scratch})",
+                        ]
+                    )
+
+                    # Enable MEIE
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x800)",  # MEIE
+                            f"CSRW(mie, x{r_scratch})",
+                        ]
+                    )
+
+                    # Set SIE
+                    if sie_val:
+                        lines.append("csrsi mstatus, 2")
+
+                    # Set MIE
+                    if mie_val:
+                        lines.append("csrsi mstatus, 8")
+
+                    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+                    # Set MEIP
+                    if set_meip:
+                        lines.extend(
+                            [
+                                "RVTEST_SET_MEXT_INT",
+                            ]
+                        )
+                        lines.extend(
+                            [
+                                f"    LI(x{r_scratch}, 2500)",
+                                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                                f"    bnez x{r_scratch}, 1b",
+                            ]
+                        )
+
+                    # Enter U-mode (always)
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_LOWER_MODE Umode",
+                            "    nop",
+                            "    nop",
+                        ]
+                    )
+
+                    # Cleanup
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_MMODE",
+                            "csrci mstatus, 8",
+                            "csrci mstatus, 2",
+                            "CSRW(mideleg, zero)",
+                            "CSRW(mie, zero)",
+                            "RVTEST_CLR_MEXT_INT",
+                        ]
+                    )
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_user_sei_tests(test_data: TestData) -> list[str]:
+    """Generate U-mode SEIP tests.
+
+    cp_user_sei: MIE=0, enters U-mode
+    cp_user_sei_m: MIE=1, stays in M-mode
+    """
+    covergroup = "InterruptsS_S_cg"
+
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_user_sei",
+            "Test SEIP from U-mode with delegation",
+        ),
+        "",
+    ]
+
+    # Cross: MIE × SIE × stvec.MODE × mideleg.SEI
+    for mie_val in [0, 1]:
+        for sie_val in [0, 1]:
+            for stvec_mode in [0, 1]:
+                for mideleg_sei in [0, 1]:
+                    deleg_name = "deleg" if mideleg_sei else "nodeleg"
+
+                    # Select coverpoint based on MIE
+                    coverpoint = "cp_user_sei" if mie_val == 0 else "cp_user_sei_m"
+
+                    binname = f"mie{mie_val}_sie{sie_val}_vec{stvec_mode}_{deleg_name}"
+
+                    lines.extend(
+                        [
+                            "",
+                            f"# Test: MIE={mie_val}, SIE={sie_val}, stvec.MODE={stvec_mode}, mideleg.SEI={mideleg_sei}",
+                            "RVTEST_GOTO_MMODE",
+                            "CSRW(mie, zero)",
+                            "csrci mstatus, 8",
+                            "csrci mstatus, 2",
+                        ]
+                    )
+
+                    # Clear SEIP
+                    lines.append("RVTEST_CLR_SEXT_INT")
+
+                    # Set mideleg
+                    if mideleg_sei:
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x200)",
+                                f"CSRW(mideleg, x{r_scratch})",
+                            ]
+                        )
+                    else:
+                        lines.append("CSRW(mideleg, zero)")
+
+                    # Set both mtvec and stvec MODE
+                    lines.extend(
+                        [
+                            f"CSRR x{r_scratch}, mtvec",
+                            f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                            f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                            f"ADDI x{r_scratch}, x{r_scratch}, {stvec_mode}",
+                            f"CSRW(mtvec, x{r_scratch})",
+                            f"CSRR x{r_scratch}, stvec",
+                            f"SRLI x{r_scratch}, x{r_scratch}, 2",
+                            f"SLLI x{r_scratch}, x{r_scratch}, 2",
+                            f"ADDI x{r_scratch}, x{r_scratch}, {stvec_mode}",
+                            f"CSRW(stvec, x{r_scratch})",
+                        ]
+                    )
+
+                    # Enable SEIE
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x200)",
+                            f"CSRW(mie, x{r_scratch})",
+                        ]
+                    )
+
+                    # Set SIE
+                    if sie_val:
+                        lines.append("csrsi mstatus, 2")
+
+                    # Set MIE
+                    if mie_val:
+                        lines.append("csrsi mstatus, 8")
+
+                    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+                    # Try to set SEIP (not implemented)
+                    lines.extend(
+                        [
+                            "RVTEST_SET_SEXT_INT",
+                        ]
+                    )
+                    lines.extend(
+                        [
+                            f"    LI(x{r_scratch}, 2500)",
+                            f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                            f"    bnez x{r_scratch}, 1b",
+                        ]
+                    )
+
+                    # Enter U-mode (for both MIE=0 and MIE=1)
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_LOWER_MODE Umode",
+                            "    nop",
+                            "    nop",
+                        ]
+                    )
+                    lines.extend(
+                        [
+                            f"    LI(x{r_scratch}, 2500)",
+                            f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                            f"    bnez x{r_scratch}, 1b",
+                        ]
+                    )
+
+                    # Cleanup
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_MMODE",
+                            "csrci mstatus, 8",
+                            "csrci mstatus, 2",
+                            "CSRW(mideleg, zero)",
+                            "CSRW(mie, zero)",
+                            "RVTEST_CLR_SEXT_INT",
+                        ]
+                    )
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_wfi_u_tests(test_data: TestData) -> list[str]:
+    """Generate U-mode WFI tests.
+
+    Test WFI from U-mode with MTIP.
+    Cross: MIE={0,1} × SIE={0,1} × mideleg={0,0x222} × TW={0,1}
+    Split: TW=0 (WFI works) and TW=1 (illegal instruction)
+    """
+    covergroup = "InterruptsS_S_cg"
+
+    r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_wfi_u",
+            "Test WFI from U-mode\nCross: MIE={0,1} × SIE={0,1} × mideleg={0,0x222} × TW={0,1}",
+        ),
+        "",
+    ]
+
+    # Cross: MIE × SIE × mideleg × TW
+    for mie_val in [0, 1]:
+        for sie_val in [0, 1]:
+            for mideleg_val in [0, 1]:
+                for tw_val in [0, 1]:
+                    mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+                    tw_name = f"tw{tw_val}"
+                    binname = f"mie{mie_val}_sie{sie_val}_{mideleg_name}_{tw_name}"
+
+                    coverpoint = "cp_wfi_u" if tw_val == 0 else "cp_wfi_u_tw"
+
+                    lines.extend(
+                        [
+                            "",
+                            f"# Test: MIE={mie_val}, SIE={sie_val}, mideleg={mideleg_name}, TW={tw_val}",
+                            "RVTEST_GOTO_MMODE",
+                            "CSRW(mie, zero)",
+                            "csrci mstatus, 8",  # MIE=0
+                            "csrci mstatus, 2",  # SIE=0
+                        ]
+                    )
+
+                    # Clear timer
+                    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+                    # Set mideleg
+                    if mideleg_val:
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x222)",
+                                f"CSRW(mideleg, x{r_scratch})",
+                            ]
+                        )
+                    else:
+                        lines.append("CSRW(mideleg, zero)")
+
+                    # Set TW bit
+                    if tw_val:
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x200000)",  # TW bit (bit 21)
+                                f"CSRS(mstatus, x{r_scratch})",
+                            ]
+                        )
+                    else:
+                        lines.extend(
+                            [
+                                f"LI(x{r_scratch}, 0x200000)",
+                                f"CSRC(mstatus, x{r_scratch})",
+                            ]
+                        )
+
+                    # Enable MTIE
+                    lines.extend(
+                        [
+                            f"LI(x{r_scratch}, 0x80)",  # MTIE
+                            f"CSRW(mie, x{r_scratch})",
+                        ]
+                    )
+
+                    # Set MIE
+                    if mie_val:
+                        lines.append("csrsi mstatus, 8")
+
+                    # Set SIE
+                    if sie_val:
+                        lines.append("csrsi mstatus, 2")
+
+                    # Set timer to fire soon (delayed)
+                    lines.extend(set_mtimer_int_soon(r_mtime, r_stimecmp, r_temp, r_temp2, r_scratch, r_stce))
+
+                    lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+                    # Enter U-mode and execute WFI
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_LOWER_MODE Umode",
+                            "    wfi",  # TW=0: waits, TW=1: illegal instruction
+                            "    nop",
+                            "    nop",
+                        ]
+                    )
+
+                    # Cleanup
+                    lines.extend(
+                        [
+                            "RVTEST_GOTO_MMODE",
+                            "csrci mstatus, 8",
+                            "csrci mstatus, 2",
+                            f"LI(x{r_scratch}, 0x200000)",
+                            f"CSRC(mstatus, x{r_scratch})",
+                            "CSRW(mideleg, zero)",
+                            "CSRW(mie, zero)",
+                        ]
+                    )
+                    lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+    return lines
+
+
+def _generate_wfi_timeout_u_tests(test_data: TestData) -> list[str]:
+    """Generate U-mode WFI timeout tests.
+
+    Test WFI timeout from U-mode with TW=1.
+    Cross: MIE={0,1} × SIE={0,1}
+    - mideleg = ones
+    - TW = 1
+    - MTIE = 1 (fixed - required for timeout mechanism)
+    - MTIMECMP = max (no interrupt fires)
+    - WFI times out → illegal instruction → M-mode trap
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_wfi_timeout_u"
+
+    r_temp, r_stimecmp, r_scratch = test_data.int_regs.get_registers(3, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_wfi_timeout_u",
+            "Test WFI timeout from U-mode\nCross: MIE={0,1} × SIE={0,1}",
+        ),
+        "",
+    ]
+
+    # Cross: MIE × SIE (MTIE=1 fixed)
+    for mie_val in [0, 1]:
+        for sie_val in [0, 1]:
+            binname = f"mie{mie_val}_sie{sie_val}"
+
+            lines.extend(
+                [
+                    "",
+                    f"# Test: MIE={mie_val}, SIE={sie_val}",
+                    "RVTEST_GOTO_MMODE",
+                    "CSRW(mie, zero)",
+                    "csrci mstatus, 8",  # MIE=0
+                    "csrci mstatus, 2",  # SIE=0
+                ]
+            )
+
+            # Clear all interrupts
+            lines.extend(
+                [
+                    "RVTEST_CLR_SSW_INT",
+                    "RVTEST_CLR_MSW_INT",
+                ]
+            )
+            lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+            # Set mideleg = ones
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x222)",
+                    f"CSRW(mideleg, x{r_scratch})",
+                ]
+            )
+
+            # Set TW=1 (timeout enabled)
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x200000)",  # TW bit (bit 21)
+                    f"CSRS(mstatus, x{r_scratch})",
+                ]
+            )
+
+            # Enable MTIE=1 (required for timeout to work)
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x80)",  # MTIE
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
+            # Set MTIMECMP to max (no interrupt fires)
+            lines.extend(
+                [
+                    f"LA(x{r_temp}, RVMODEL_MTIMECMP_ADDRESS)",
+                    f"LI(x{r_scratch}, -1)",
+                    f"SREG x{r_scratch}, 0(x{r_temp})",
+                ]
+            )
+
+            # Set MIE
+            if mie_val:
+                lines.append("csrsi mstatus, 8")
+
+            # Set SIE
+            if sie_val:
+                lines.append("csrsi mstatus, 2")
+
+            lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+
+            # Enter U-mode and execute WFI
+            lines.extend(
+                [
+                    "RVTEST_GOTO_LOWER_MODE Umode",
+                    "    wfi",  # Times out → illegal instruction → trap to M-mode
+                    "    nop",
+                ]
+            )
+
+            # Cleanup
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "csrci mstatus, 8",
+                    "csrci mstatus, 2",
+                    f"LI(x{r_scratch}, 0x200000)",
+                    f"CSRC(mstatus, x{r_scratch})",  # Clear TW
+                    "CSRW(mideleg, zero)",
+                    "CSRW(mie, zero)",
+                ]
+            )
+            lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+    test_data.int_regs.return_registers([r_temp, r_stimecmp, r_scratch])
     return lines
 
 
@@ -1260,8 +4674,9 @@ def _generate_vectored_s_tests(test_data: TestData) -> list[str]:
 def make_interruptss_s(test_data: TestData) -> list[str]:
     """Generate supervisor-mode interrupt tests.
 
-    Test supervisor-mode interrupts with delegation from M-mode.
-    All tests execute in S-mode after proper mideleg setup.
+    Covers STIP, SSIP, and SEIP across S-mode, M-mode, and U-mode scenarios,
+    including trigger conditions, delegation, priority, vectoring, and WFI.
+    Individual test groups are enabled incrementally as they are validated.
     """
     r_temp = test_data.int_regs.get_register(exclude_regs=[0, 2])
 
@@ -1280,16 +4695,53 @@ def make_interruptss_s(test_data: TestData) -> list[str]:
 
     test_data.int_regs.return_registers([r_temp])
 
-    # Generate all test functions
+    # -----------------------------------------------------------------------
+    # S-mode interrupt tests (STIP, SSIP, SEIP with mideleg)
+    # -----------------------------------------------------------------------
     lines.extend(_generate_trigger_sti_tests(test_data))
-    # lines.extend(_generate_trigger_ssi_mip_tests(test_data))
-    # lines.extend(_generate_trigger_ssi_sip_tests(test_data))
-    # lines.extend(_generate_trigger_sei_tests(test_data))
-    # lines.extend(_generate_trigger_sei_seip_tests(test_data))
-    # lines.extend(_generate_changingtos_sti_tests(test_data))
-    # lines.extend(_generate_changingtos_ssi_tests(test_data))
-    # lines.extend(_generate_changingtos_sei_tests(test_data))
-    # lines.extend(_generate_interrupts_s_tests(test_data))
-    # lines.extend(_generate_vectored_s_tests(test_data))
+    lines.extend(_generate_trigger_ssi_mip_tests(test_data))
+    lines.extend(_generate_trigger_ssi_sip_tests(test_data))
+    lines.extend(_generate_trigger_sei_tests(test_data))
+    lines.extend(_generate_trigger_sei_seip_tests(test_data))
+    lines.extend(_generate_changingtos_sti_tests(test_data))
+    lines.extend(_generate_changingtos_ssi_tests(test_data))
+    lines.extend(_generate_changingtos_sei_tests(test_data))
+    lines.extend(_generate_interrupts_s_tests(test_data))
+    lines.extend(_generate_vectored_s_tests(test_data))
+    lines.extend(_generate_priority_mip_s_tests(test_data))
+    lines.extend(_generate_priority_mie_s_tests(test_data))
+    lines.extend(_generate_priority_both_s_tests(test_data))
+    lines.extend(_generate_priority_mideleg_m_tests(test_data))
+    lines.extend(_generate_priority_mideleg_s_tests(test_data))
+    lines.extend(_generate_wfi_s_tests(test_data))
+    lines.extend(_generate_wfi_timeout_s_tests(test_data))
+
+    # -----------------------------------------------------------------------
+    # M-mode interrupt tests (non-delegated and delegated S-interrupts)
+    # -----------------------------------------------------------------------
+    lines.extend(_generate_interrupts_m_tests(test_data))
+    lines.extend(_generate_vectored_m_tests(test_data))
+    lines.extend(_generate_priority_mip_m_tests(test_data))
+    lines.extend(_generate_priority_mie_m_tests(test_data))
+    lines.extend(_generate_wfi_m_tests(test_data))
+    lines.extend(_generate_trigger_mti_m_tests(test_data))
+    lines.extend(_generate_trigger_ssi_sip_m_tests(test_data))
+    lines.extend(_generate_trigger_msi_m_tests(test_data))
+    lines.extend(_generate_trigger_mei_m_tests(test_data))
+    lines.extend(_generate_trigger_sti_m_tests(test_data))
+    lines.extend(_generate_trigger_ssi_m_tests(test_data))
+    lines.extend(_generate_trigger_sei_m_tests(test_data))
+    lines.extend(_generate_sei_interaction_tests(test_data))
+    lines.extend(_generate_global_ie_tests(test_data))
+
+    # -----------------------------------------------------------------------
+    # U-mode interrupt tests
+    # -----------------------------------------------------------------------
+    lines.extend(_generate_user_mti_tests(test_data))
+    lines.extend(_generate_user_msi_tests(test_data))
+    lines.extend(_generate_user_mei_tests(test_data))
+    lines.extend(_generate_user_sei_tests(test_data))
+    lines.extend(_generate_wfi_u_tests(test_data))
+    lines.extend(_generate_wfi_timeout_u_tests(test_data))
 
     return lines

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
@@ -2375,10 +2375,6 @@ def _generate_interrupts_m_tests(test_data: TestData) -> list[str]:
         for mideleg_val in [0, 1]:  # 0 = none, 1 = 0x222
             for mip_name, mip_bit, mie_bit, set_fn, clr_fn, is_timer in interrupts:
                 for mie_name in ["ssie", "msie", "stie", "mtie", "seie", "meie"]:
-                    # SKIP: External interrupts not implemented
-                    if mip_name in ["seip", "meip"]:
-                        continue
-
                     # Determine if delegated
                     is_delegated = (mideleg_val == 1) and (mip_name in s_interrupts)
 

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsS.py
@@ -9,7 +9,6 @@ from testgen.asm.interrupts import (
     clr_mtimer_int,
     clr_stimer_int,
     set_mtimer_int,
-    set_stimer_int,
 )
 from testgen.data.state import TestData
 from testgen.priv.registry import add_priv_test_generator
@@ -237,6 +236,256 @@ from testgen.priv.registry import add_priv_test_generator
 #     return lines
 
 
+# def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
+#     """Generate STIP trigger tests.
+
+#     With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
+#     and mie = 1s (all interrupt enables), trigger STIP and change to supervisor mode.
+#     Cross: mideleg x SIE (2x2 = 4 bins)
+#     """
+#     covergroup = "InterruptsS_S_cg"
+#     coverpoint = "cp_trigger_sti"
+
+#     r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce = test_data.int_regs.get_registers(6, exclude_regs=[0, 2])
+
+#     lines = [
+#         comment_banner(
+#             "cp_trigger_sti",
+#             "Trigger STIP (supervisor timer interrupt)\n"
+#             "Cross: mideleg={0/STI+SEI+SSI}ma x mstatus.SIE={0/1}\n"
+#             "With mstatus.MIE=0, mie=all 1s",
+#         ),
+#         "",
+#     ]
+
+#     # Cross: mideleg x SIE
+#     for mideleg_val in [0, 1]:  # 0=no delegation, 1=delegate all S-interrupts
+#         for sie_val in [0, 1]:
+#             mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+#             sie_name = f"sie_{sie_val}"
+#             binname = f"{mideleg_name}_{sie_name}"
+
+#             # === M-MODE SETUP ===
+#             lines.extend(
+#                 [
+#                     "",
+#                     "# M-mode setup",
+#                     "csrci mstatus, 8",  # MIE=0
+#                 ]
+#             )
+
+#             # Clear all timers first
+#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+#             # Set mideleg
+#             if mideleg_val:
+#                 lines.extend(
+#                     [
+#                         f"LI(x{r_scratch}, 0x222)",  # Delegate STI+SEI+SSI
+#                         f"CSRW(mideleg, x{r_scratch})",
+#                     ]
+#                 )
+#             else:
+#                 lines.append("CSRW(mideleg, zero)")
+
+#             # Set SPIE (controls SIE after sret)
+#             # lines.extend([
+#             #     f"LI(x{r_scratch}, 0x20)",  # SPIE bit
+#             #     f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+#             # ])
+#             lines.extend(
+#                 [
+#                     f"LI(x{r_scratch}, 0x02)",  # SIE bit 1, not SPIE!
+#                     f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+#                 ]
+#             )
+
+#             # Enable all interrupts in mie
+#             lines.extend(
+#                 [
+#                     f"LI(x{r_scratch}, -1)",  # All interrupts
+#                     f"CSRW(mie, x{r_scratch})",
+#                 ]
+#             )
+
+#             # Read menvcfg.STCE (needed for timer operations in S-mode)
+#             lines.extend(
+#                 [
+#                     "# Read menvcfg.STCE",
+#                     f"CSRR x{r_stce}, menvcfg",
+#                     "#if __riscv_xlen == 64",
+#                     f"    srli x{r_stce}, x{r_stce}, 63",
+#                     "#else",
+#                     f"    srli x{r_stce}, x{r_stce}, 31",
+#                     "#endif",
+#                     f"andi x{r_stce}, x{r_stce}, 0x1",
+#                 ]
+#             )
+
+#             # === ENTER S-MODE ===
+#             lines.extend(
+#                 [
+#                     test_data.add_testcase(binname, coverpoint, covergroup),
+#                     "RVTEST_GOTO_LOWER_MODE Smode",
+#                 ]
+#             )
+
+#             # TODO: adding this for now to get sie in s-mode:
+#             # NOW set SIE in S-mode based on sie_val
+#             # if sie_val:
+#             #     lines.append("    csrsi sstatus, 2")  # Set SIE (bit 1 of sstatus)
+#             # else:
+#             #     lines.append("    csrci sstatus, 2")  # Clear SIE (bit 1 of sstatus)
+
+#             # NOPs in S-mode for STIP=0 coverage
+#             lines.extend(
+#                 [
+#                     f"    LI(x{r_scratch}, 20)",  # 2500 iterations × 2 instructions = 5000 cycles
+#                     f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+#                     f"    bnez x{r_scratch}, 1b",
+#                 ]
+#             )
+
+#             # Set timer WHILE IN S-mode (pass r_stce explicitly)
+#             lines.extend(["    " + line for line in set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce)])
+
+#             # More NOPs for STIP=1 coverage before interrupt fires
+#             lines.extend(
+#                 [
+#                     f"    LI(x{r_scratch}, 2500)",  # 2500 iterations × 2 instructions = 5000 cycles
+#                     f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+#                     f"    bnez x{r_scratch}, 1b",
+#                 ]
+#             )
+
+#             # Wait for interrupt (or not)
+#             lines.append("RVTEST_IDLE_FOR_INTERRUPT")
+
+#             # Clear timer BEFORE returning to M-mode (prevents spurious interrupt)
+#             lines.extend(
+#                 [
+#                     "",
+#                     "# Clear timer before M-mode return",
+#                     f"beqz x{r_stce}, 3f",  # Skip if STCE=0 (legacy needs M-mode)
+#                     "# Sstc: Clear stimecmp from S-mode",
+#                     f"    LI(x{r_temp}, -1)",
+#                     f"    csrw stimecmp, x{r_temp}",
+#                     "#if __riscv_xlen == 32",
+#                     f"    csrw stimecmph, x{r_temp}",
+#                     "#endif",
+#                     "3:",
+#                 ]
+#             )
+
+#             # Return to M-mode
+#             lines.extend(
+#                 [
+#                     "RVTEST_GOTO_MMODE",
+#                     "csrci mstatus, 8",  # Immediately disable MIE
+#                 ]
+#             )
+
+#             # Final cleanup in M-mode
+#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
+#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+#     test_data.int_regs.return_registers([r_mtime, r_temp, r_temp2, r_stimecmp, r_scratch, r_stce])
+#     return lines
+
+# worshsipping this, one above is more og
+# def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
+#     """Generate STIP trigger tests.
+
+#     With mstatus.MIE = 0, mstatus.SIE = {0/1}, mideleg = {0s/STI+SEI+SSI},
+#     and mie = 1s (all interrupt enables), mip.STIP=1, change to supervisor mode.
+#     Cross: mideleg x SIE (2x2 = 4 bins)
+#     """
+#     covergroup = "InterruptsS_S_cg"
+#     coverpoint = "cp_trigger_sti"
+
+#     r_scratch = test_data.int_regs.get_registers(1, exclude_regs=[0, 2])[0]
+
+#     lines = [
+#         comment_banner(
+#             "cp_trigger_sti",
+#             "Trigger STIP (supervisor timer interrupt)\n"
+#             "Cross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}\n"
+#             "With mstatus.MIE=0, mie=all 1s, mip.STIP=1",
+#         ),
+#         "",
+#     ]
+
+#     # Cross: mideleg x SIE
+#     for mideleg_val in [0, 1]:
+#         for sie_val in [0, 1]:
+#             mideleg_name = ["nodeleg", "deleg"][mideleg_val]
+#             sie_name = f"sie_{sie_val}"
+#             binname = f"{mideleg_name}_{sie_name}"
+
+#             # === M-MODE SETUP (safe order) ===
+#             lines.extend([
+#                 "",
+#                 "# M-mode setup",
+#                 "CSRW(mie, zero)",  # 1. Disable ALL interrupts first
+#                 "csrci mstatus, 8",  # 2. MIE=0
+#                 f"LI(x{r_scratch}, 0x20)",  # 3. Clear any pending STIP
+#                 f"CSRC(mip, x{r_scratch})",
+#                 "csrci mstatus, 2",  # 3. SIE=0 (clear first)
+#             ])
+
+#             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch))
+#             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
+
+#             # 4. Set mideleg
+#             if mideleg_val:
+#                 lines.extend([
+#                     f"LI(x{r_scratch}, 0x222)",  # Delegate STI+SEI+SSI
+#                     f"CSRW(mideleg, x{r_scratch})",
+#                 ])
+#             else:
+#                 lines.append("CSRW(mideleg, zero)")
+
+#             # 5. Enable all interrupts in mie (but MIE still 0)
+#             lines.extend([
+#                 f"LI(x{r_scratch}, -1)",
+#                 f"CSRW(mie, x{r_scratch})",
+#             ])
+
+#             # 6. Set SIE in mstatus (last step before STIP)
+#             lines.extend([
+#                 f"LI(x{r_scratch}, 0x02)",  # SIE bit
+#                 f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+#             ])
+
+#             # 7. Set STIP (test plan: "mip.STIP=1")
+#             # lines.extend([
+#             #     test_data.add_testcase(binname, coverpoint, covergroup),
+#             #     f"LI(x{r_scratch}, 0x20)",  # STIP bit
+#             #     f"CSRS(mip, x{r_scratch})",
+#             #     "nop",
+#             # ])
+
+#             # 8. Enter S-mode (test plan: "change to supervisor mode")
+#             lines.extend([
+#                 "RVTEST_GOTO_LOWER_MODE Smode",
+#                 "nop",
+#                 "nop",
+#                 "nop",
+#             ])
+
+#             # 9. Return and cleanup
+#             lines.extend([
+#                 "RVTEST_GOTO_MMODE",
+#                 "csrci mstatus, 8",  # Disable MIE
+#                 f"LI(x{r_scratch}, 0x20)",
+#                 f"CSRC(mip, x{r_scratch})",  # Clear STIP
+#             ])
+
+#     test_data.int_regs.return_registers([r_scratch])
+#     return lines
+
+
 def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
     """Generate STIP trigger tests.
 
@@ -253,33 +502,35 @@ def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
         comment_banner(
             "cp_trigger_sti",
             "Trigger STIP (supervisor timer interrupt)\n"
-            "Cross: mideleg={0/STI+SEI+SSI}ma x mstatus.SIE={0/1}\n"
+            "Cross: mideleg={0/STI+SEI+SSI} x mstatus.SIE={0/1}\n"
             "With mstatus.MIE=0, mie=all 1s",
         ),
         "",
     ]
 
     # Cross: mideleg x SIE
-    for mideleg_val in [0, 1]:  # 0=no delegation, 1=delegate all S-interrupts
+    for mideleg_val in [0, 1]:
         for sie_val in [0, 1]:
             mideleg_name = ["nodeleg", "deleg"][mideleg_val]
             sie_name = f"sie_{sie_val}"
             binname = f"{mideleg_name}_{sie_name}"
 
-            # === M-MODE SETUP ===
+            # === M-MODE SETUP (safe order) ===
             lines.extend(
                 [
                     "",
                     "# M-mode setup",
-                    "csrci mstatus, 8",  # MIE=0
+                    "CSRW(mie, zero)",  # 1. Disable ALL interrupts first
+                    "csrci mstatus, 8",  # 2. MIE=0
+                    "csrci mstatus, 2",  # 3. SIE=0 (clear first)
                 ]
             )
 
-            # Clear all timers first
+            # Clear timers
             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
 
-            # Set mideleg
+            # 4. Set mideleg
             if mideleg_val:
                 lines.extend(
                     [
@@ -290,30 +541,17 @@ def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
             else:
                 lines.append("CSRW(mideleg, zero)")
 
-            # Set SPIE (controls SIE after sret)
-            # lines.extend([
-            #     f"LI(x{r_scratch}, 0x20)",  # SPIE bit
-            #     f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-            # ])
+            # 5. Enable all interrupts in mie (but MIE still 0)
             lines.extend(
                 [
-                    f"LI(x{r_scratch}, 0x02)",  # SIE bit 1, not SPIE!
-                    f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
-                ]
-            )
-
-            # Enable all interrupts in mie
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, -1)",  # All interrupts
+                    f"LI(x{r_scratch}, -1)",
                     f"CSRW(mie, x{r_scratch})",
                 ]
             )
 
-            # Read menvcfg.STCE (needed for timer operations in S-mode)
+            # 6. Read STCE (needed for timer functions)
             lines.extend(
                 [
-                    "# Read menvcfg.STCE",
                     f"CSRR x{r_stce}, menvcfg",
                     "#if __riscv_xlen == 64",
                     f"    srli x{r_stce}, x{r_stce}, 63",
@@ -324,34 +562,41 @@ def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
                 ]
             )
 
-            # === ENTER S-MODE ===
+            # 7. Set SIE in mstatus (last step before STIP)
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x02)",  # SIE bit
+                    f"{'CSRS' if sie_val else 'CSRC'}(mstatus, x{r_scratch})",
+                ]
+            )
+
+            # 8. Set STIP directly (we're in M-mode, can write mip directly)
             lines.extend(
                 [
                     test_data.add_testcase(binname, coverpoint, covergroup),
-                    "RVTEST_GOTO_LOWER_MODE Smode",
+                    f"LI(x{r_scratch}, 0x20)",  # STIP bit
+                    f"CSRS(mip, x{r_scratch})",  # Set mip.STIP=1
+                    "nop",
                 ]
             )
 
-            # TODO: adding this for now to get sie in s-mode:
-            # NOW set SIE in S-mode based on sie_val
-            # if sie_val:
-            #     lines.append("    csrsi sstatus, 2")  # Set SIE (bit 1 of sstatus)
-            # else:
-            #     lines.append("    csrci sstatus, 2")  # Clear SIE (bit 1 of sstatus)
+            # 8. Set STIP using timer functions
+            # lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
+            # lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
+            lines.append("nop")
 
-            # NOPs in S-mode for STIP=0 coverage
+            # 9. Enter S-mode
             lines.extend(
                 [
-                    f"    LI(x{r_scratch}, 20)",  # 2500 iterations × 2 instructions = 5000 cycles
-                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
-                    f"    bnez x{r_scratch}, 1b",
+                    "RVTEST_GOTO_LOWER_MODE Smode",
+                    "nop",
+                    "nop",
+                    "nop",
                 ]
             )
 
-            # Set timer WHILE IN S-mode (pass r_stce explicitly)
-            lines.extend(["    " + line for line in set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce)])
+            # lines.extend(set_stimer_int(r_mtime, r_temp, r_temp2, r_scratch, r_stce))
 
-            # More NOPs for STIP=1 coverage before interrupt fires
             lines.extend(
                 [
                     f"    LI(x{r_scratch}, 2500)",  # 2500 iterations × 2 instructions = 5000 cycles
@@ -360,34 +605,21 @@ def _generate_trigger_sti_tests(test_data: TestData) -> list[str]:
                 ]
             )
 
-            # Wait for interrupt (or not)
-            lines.append("RVTEST_IDLE_FOR_INTERRUPT")
-
-            # Clear timer BEFORE returning to M-mode (prevents spurious interrupt)
-            lines.extend(
-                [
-                    "",
-                    "# Clear timer before M-mode return",
-                    f"beqz x{r_stce}, 3f",  # Skip if STCE=0 (legacy needs M-mode)
-                    "# Sstc: Clear stimecmp from S-mode",
-                    f"    LI(x{r_temp}, -1)",
-                    f"    csrw stimecmp, x{r_temp}",
-                    "#if __riscv_xlen == 32",
-                    f"    csrw stimecmph, x{r_temp}",
-                    "#endif",
-                    "3:",
-                ]
-            )
-
-            # Return to M-mode
+            # 10. Return and cleanup
             lines.extend(
                 [
                     "RVTEST_GOTO_MMODE",
-                    "csrci mstatus, 8",  # Immediately disable MIE
+                    "# Complete state cleanup",
+                    "csrci mstatus, 8",  # Clear MIE
+                    "csrci mstatus, 2",  # Clear SIE
+                    "CSRW(mideleg, zero)",  # Clear delegation
+                    "CSRW(mie, zero)",  # Clear all interrupt enables
+                    f"LI(x{r_scratch}, 0x20)",  # Clear STIP
+                    f"CSRC(mip, x{r_scratch})",
                 ]
             )
 
-            # Final cleanup in M-mode
+            # Clear timer
             lines.extend(clr_stimer_int(r_temp, r_stimecmp, r_scratch, 0))
             lines.extend(clr_mtimer_int(r_temp, r_stimecmp))
 

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
@@ -24,7 +24,7 @@ def _generate_trigger_mti_tests(test_data: TestData) -> list[str]:
 
     # Exclude: x2 (sp), x5 (t0-used by macros),
     # x7 (t2-consumed by interrupt macros), x30 (t5-consumed by interrupt macros)
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2 = test_data.int_regs.get_registers(5, exclude_regs=[0])
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2 = test_data.int_regs.get_registers(5, exclude_regs=[0, 2, 7, 30])
 
     lines = [
         comment_banner(
@@ -71,7 +71,9 @@ def _generate_trigger_msi_tests(test_data: TestData) -> list[str]:
     coverpoint = "cp_trigger_msi"
     ######################################
 
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_cleanup = test_data.int_regs.get_registers(6, exclude_regs=[0])
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_cleanup = test_data.int_regs.get_registers(
+        6, exclude_regs=[0, 2, 7, 30]
+    )
 
     lines = [
         comment_banner(
@@ -118,7 +120,7 @@ def _generate_trigger_mei_tests(test_data: TestData) -> list[str]:
     coverpoint = "cp_trigger_mei"
     ######################################
 
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2 = test_data.int_regs.get_registers(5, exclude_regs=[0])
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2 = test_data.int_regs.get_registers(5, exclude_regs=[0, 2, 7, 30])
 
     lines = [
         comment_banner(
@@ -167,7 +169,7 @@ def _generate_interrupt_cross_tests(test_data: TestData) -> list[str]:
     ######################################
 
     r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_val, r_mie_save, r_csr_tmp = test_data.int_regs.get_registers(
-        8, exclude_regs=[0]
+        8, exclude_regs=[0, 2, 7, 30]
     )
 
     lines = [
@@ -208,6 +210,7 @@ def _generate_interrupt_cross_tests(test_data: TestData) -> list[str]:
                 lines.extend(
                     [
                         "CSRW(mie, zero)",  # disable interrupts
+                        "CSRW(mie, zero)",  # disable interrupts
                         "# Testcase: " + binname,
                         test_data.add_testcase(binname, coverpoint, covergroup),
                     ]
@@ -222,6 +225,7 @@ def _generate_interrupt_cross_tests(test_data: TestData) -> list[str]:
                     lines.append("RVTEST_SET_MSW_INT")
 
                 # More settling
+                lines.extend([f"CSRW(mie, x{r_mie_val})", "RVTEST_IDLE_FOR_INTERRUPT"])
                 lines.extend([f"CSRW(mie, x{r_mie_val})", "RVTEST_IDLE_FOR_INTERRUPT"])
 
                 # Clear to prevent leakage
@@ -246,7 +250,7 @@ def _generate_vectored_tests(test_data: TestData) -> list[str]:
     ######################################
 
     r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_all, r_mie_save, r_csr_tmp = test_data.int_regs.get_registers(
-        8, exclude_regs=[0]
+        8, exclude_regs=[0, 2, 7, 30]
     )
 
     lines = [
@@ -321,7 +325,7 @@ def _generate_priority_tests(test_data: TestData) -> list[str]:
     ######################################
 
     r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_mask, r_scratch, r_csr_tmp = test_data.int_regs.get_registers(
-        8, exclude_regs=[0]
+        8, exclude_regs=[0, 2, 7, 30]
     )
 
     lines = [
@@ -347,6 +351,7 @@ def _generate_priority_tests(test_data: TestData) -> list[str]:
         for mip_bits in range(8):
             lines.extend(
                 [
+                    "CSRW(mie, zero)",  # disable interrupts
                     "CSRW(mie, zero)",  # disable interrupts
                     f"# Testcase: mie: {mie_bits:03b}, mip: {mip_bits:03b}",
                     test_data.add_testcase(f"mie_{mie_bits:03b}_mip_{mip_bits:03b}", coverpoint, covergroup),
@@ -382,9 +387,8 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
     covergroup = "InterruptsSm_cg"
     coverpoint = "cp_wfi"
 
-    r_mtime, r_mtimecmp, r_t0, r_t1, r_t2, r_t3, r_scratch, r_csr_tmp = test_data.int_regs.get_registers(
-        8, exclude_regs=[0]
-    )
+    # FIX 1: 7 registers (remove unused r_csr_tmp), simple exclude
+    r_mtime, r_mtimecmp, r_t0, r_t1, r_t2, r_t3, r_scratch = test_data.int_regs.get_registers(7, exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -401,20 +405,20 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
             lines.extend(
                 [
                     f"# Testcase: WFI with mie = {mie_val}, tw = {tw_val}",
-                    "CSRW(mie, zero)",
-                    "# Clear TW (bit 21, 0x200000) and MIE (bit 3, 0x8)",
+                    "CSRW(mie, zero)",  # FIX 2: Macro with parentheses
+                    # FIX 3: Clear specific bits, not whole mstatus
                     f"LI(x{r_scratch}, 0x200008)",
                     f"CSRC(mstatus, x{r_scratch})",
                     "# Set MIE if needed",
                     f"LI(x{r_scratch}, 0x8)",
                     f"{'CSRS' if mie_val else 'CSRC'}(mstatus, x{r_scratch})",
+                    "# Set TW if needed",
                 ]
             )
 
             if tw_val:
                 lines.extend(
                     [
-                        "# Set TW",
                         f"LI(x{r_scratch}, 0x200000)",
                         f"CSRS(mstatus, x{r_scratch})",
                     ]
@@ -424,17 +428,19 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
                 [
                     "# Enable MTIE",
                     f"LI(x{r_scratch}, 0x80)",
-                    f"CSRW(mie, x{r_scratch})",
+                    f"CSRW(mie, x{r_scratch})",  # FIX 5: Parentheses for macro
                     # Set timer
                     *set_mtimer_int_soon(r_mtime, r_mtimecmp, r_t0, r_t1, r_t2, r_t3),
                     test_data.add_testcase(binname, coverpoint, covergroup),
                     "wfi",
                     "nop",
+                    # FIX 6: Clear timer AFTER wfi
                     *clr_mtimer_int(r_t0, r_mtimecmp),
                     "",
                 ]
             )
 
+    test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_t0, r_t1, r_t2, r_t3, r_scratch])
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_t0, r_t1, r_t2, r_t3, r_scratch])
     return lines
 
@@ -443,7 +449,9 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
 def make_interruptssm(test_data: TestData) -> list[str]:
     """Generate tests for InterruptsSm machine-mode interrupts."""
 
->>>>>>> 9e4cabd7a (udpated interrupt tests)
+    # consumer t2 and t5 for interrupt subroutines, but mark as consumed for whole test since they're used throughout
+    test_data.int_regs.consume_registers([7, 30])
+
     lines: list[str] = []
 
     lines.extend(_generate_trigger_mti_tests(test_data))
@@ -453,5 +461,8 @@ def make_interruptssm(test_data: TestData) -> list[str]:
     lines.extend(_generate_vectored_tests(test_data))
     lines.extend(_generate_priority_tests(test_data))
     lines.extend(_generate_wfi_tests(test_data))
+
+    # Return the consumed registers before test ends
+    test_data.int_regs.return_registers([7, 30])
 
     return lines

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
@@ -405,18 +405,19 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
                 [
                     f"# Testcase: WFI with mie = {mie_val}, tw = {tw_val}",
                     "CSRW(mie, zero)",
+                    "# Clear TW (bit 21, 0x200000) and MIE (bit 3, 0x8)",
                     f"LI(x{r_scratch}, 0x200008)",
                     f"CSRC(mstatus, x{r_scratch})",
                     "# Set MIE if needed",
                     f"LI(x{r_scratch}, 0x8)",
                     f"{'CSRS' if mie_val else 'CSRC'}(mstatus, x{r_scratch})",
-                    "# Set TW if needed",
                 ]
             )
 
             if tw_val:
                 lines.extend(
                     [
+                        "# Set TW",
                         f"LI(x{r_scratch}, 0x200000)",
                         f"CSRS(mstatus, x{r_scratch})",
                     ]

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
@@ -447,9 +447,6 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
 def make_interruptssm(test_data: TestData) -> list[str]:
     """Generate tests for InterruptsSm machine-mode interrupts."""
 
-    # consumer t2 and t5 for interrupt subroutines, but mark as consumed for whole test since they're used throughout
-    test_data.int_regs.consume_registers([7, 30])
-
     lines: list[str] = []
 
     lines.extend(_generate_trigger_mti_tests(test_data))
@@ -459,8 +456,5 @@ def make_interruptssm(test_data: TestData) -> list[str]:
     lines.extend(_generate_vectored_tests(test_data))
     lines.extend(_generate_priority_tests(test_data))
     lines.extend(_generate_wfi_tests(test_data))
-
-    # Return the consumed registers before test ends
-    test_data.int_regs.return_registers([7, 30])
 
     return lines

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
@@ -387,7 +387,6 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
     covergroup = "InterruptsSm_cg"
     coverpoint = "cp_wfi"
 
-    # FIX 1: 7 registers (remove unused r_csr_tmp), simple exclude
     r_mtime, r_mtimecmp, r_t0, r_t1, r_t2, r_t3, r_scratch = test_data.int_regs.get_registers(7, exclude_regs=[0])
 
     lines = [
@@ -405,8 +404,7 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
             lines.extend(
                 [
                     f"# Testcase: WFI with mie = {mie_val}, tw = {tw_val}",
-                    "CSRW(mie, zero)",  # FIX 2: Macro with parentheses
-                    # FIX 3: Clear specific bits, not whole mstatus
+                    "CSRW(mie, zero)",
                     f"LI(x{r_scratch}, 0x200008)",
                     f"CSRC(mstatus, x{r_scratch})",
                     "# Set MIE if needed",
@@ -428,13 +426,12 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
                 [
                     "# Enable MTIE",
                     f"LI(x{r_scratch}, 0x80)",
-                    f"CSRW(mie, x{r_scratch})",  # FIX 5: Parentheses for macro
+                    f"CSRW(mie, x{r_scratch})",
                     # Set timer
                     *set_mtimer_int_soon(r_mtime, r_mtimecmp, r_t0, r_t1, r_t2, r_t3),
                     test_data.add_testcase(binname, coverpoint, covergroup),
                     "wfi",
                     "nop",
-                    # FIX 6: Clear timer AFTER wfi
                     *clr_mtimer_int(r_t0, r_mtimecmp),
                     "",
                 ]

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
@@ -441,6 +441,14 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
 def make_interruptssm(test_data: TestData) -> list[str]:
     """Generate tests for InterruptsSm machine-mode interrupts."""
 
+<<<<<<< HEAD
+=======
+    # Consume t2 and t5 - reserved by trap handler in arch_test.h for interrupt clearing subroutines
+    # The trap handler uses these registers when calling RVMODEL_CLR_*_INT macros
+    # See: tests/env/arch_test.h, trap handler interrupt dispatch logic
+    test_data.int_regs.consume_registers([7, 30])
+
+>>>>>>> 9e4cabd7a (udpated interrupt tests)
     lines: list[str] = []
 
     lines.extend(_generate_trigger_mti_tests(test_data))

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
@@ -24,7 +24,7 @@ def _generate_trigger_mti_tests(test_data: TestData) -> list[str]:
 
     # Exclude: x2 (sp), x5 (t0-used by macros),
     # x7 (t2-consumed by interrupt macros), x30 (t5-consumed by interrupt macros)
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2 = test_data.int_regs.get_registers(5, exclude_regs=[2, 7, 30])
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2 = test_data.int_regs.get_registers(5, exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -71,7 +71,7 @@ def _generate_trigger_msi_tests(test_data: TestData) -> list[str]:
     coverpoint = "cp_trigger_msi"
     ######################################
 
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_cleanup = test_data.int_regs.get_registers(6, exclude_regs=[2, 7, 30])
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_cleanup = test_data.int_regs.get_registers(6, exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -118,7 +118,7 @@ def _generate_trigger_mei_tests(test_data: TestData) -> list[str]:
     coverpoint = "cp_trigger_mei"
     ######################################
 
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2 = test_data.int_regs.get_registers(5, exclude_regs=[2, 7, 30])
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2 = test_data.int_regs.get_registers(5, exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -166,8 +166,8 @@ def _generate_interrupt_cross_tests(test_data: TestData) -> list[str]:
     coverpoint = "cp_interrupts"
     ######################################
 
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_val, r_mie_save = test_data.int_regs.get_registers(
-        7, exclude_regs=[2, 7, 30]
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_val, r_mie_save, r_csr_tmp = test_data.int_regs.get_registers(
+        8, exclude_regs=[0]
     )
 
     lines = [
@@ -245,8 +245,8 @@ def _generate_vectored_tests(test_data: TestData) -> list[str]:
     coverpoint = "cp_vectored"
     ######################################
 
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_all, r_mie_save = test_data.int_regs.get_registers(
-        7, exclude_regs=[2, 7, 30]
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_all, r_mie_save, r_csr_tmp = test_data.int_regs.get_registers(
+        8, exclude_regs=[0]
     )
 
     lines = [
@@ -320,8 +320,8 @@ def _generate_priority_tests(test_data: TestData) -> list[str]:
     coverpoint = "cp_priority"
     ######################################
 
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_mask, r_scratch = test_data.int_regs.get_registers(
-        7, exclude_regs=[2, 7, 30]
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_mask, r_scratch, r_csr_tmp = test_data.int_regs.get_registers(
+        8, exclude_regs=[0]
     )
 
     lines = [
@@ -382,7 +382,9 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
     covergroup = "InterruptsSm_cg"
     coverpoint = "cp_wfi"
 
-    r_mtime, r_mtimecmp, r_t0, r_t1, r_t2, r_t3, r_scratch = test_data.int_regs.get_registers(7)
+    r_mtime, r_mtimecmp, r_t0, r_t1, r_t2, r_t3, r_scratch, r_csr_tmp = test_data.int_regs.get_registers(
+        8, exclude_regs=[0]
+    )
 
     lines = [
         comment_banner(
@@ -440,13 +442,6 @@ def _generate_wfi_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator("InterruptsSm", required_extensions=["Sm", "I", "Zicsr"])
 def make_interruptssm(test_data: TestData) -> list[str]:
     """Generate tests for InterruptsSm machine-mode interrupts."""
-
-<<<<<<< HEAD
-=======
-    # Consume t2 and t5 - reserved by trap handler in arch_test.h for interrupt clearing subroutines
-    # The trap handler uses these registers when calling RVMODEL_CLR_*_INT macros
-    # See: tests/env/arch_test.h, trap handler interrupt dispatch logic
-    test_data.int_regs.consume_registers([7, 30])
 
 >>>>>>> 9e4cabd7a (udpated interrupt tests)
     lines: list[str] = []

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsSm.py
@@ -168,8 +168,8 @@ def _generate_interrupt_cross_tests(test_data: TestData) -> list[str]:
     coverpoint = "cp_interrupts"
     ######################################
 
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_val, r_mie_save, r_csr_tmp = test_data.int_regs.get_registers(
-        8, exclude_regs=[0, 2, 7, 30]
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_val, r_mie_save = test_data.int_regs.get_registers(
+        7, exclude_regs=[0, 2, 7, 30]
     )
 
     lines = [
@@ -249,8 +249,8 @@ def _generate_vectored_tests(test_data: TestData) -> list[str]:
     coverpoint = "cp_vectored"
     ######################################
 
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_all, r_mie_save, r_csr_tmp = test_data.int_regs.get_registers(
-        8, exclude_regs=[0, 2, 7, 30]
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_all, r_mie_save = test_data.int_regs.get_registers(
+        7, exclude_regs=[0, 2, 7, 30]
     )
 
     lines = [
@@ -324,8 +324,8 @@ def _generate_priority_tests(test_data: TestData) -> list[str]:
     coverpoint = "cp_priority"
     ######################################
 
-    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_mask, r_scratch, r_csr_tmp = test_data.int_regs.get_registers(
-        8, exclude_regs=[0, 2, 7, 30]
+    r1, r_mtime, r_mtimecmp, r_temp, r_temp2, r_mie_mask, r_scratch = test_data.int_regs.get_registers(
+        7, exclude_regs=[0, 2, 7, 30]
     )
 
     lines = [

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsSstc.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsSstc.py
@@ -1,0 +1,546 @@
+##################################
+# priv/extensions/interruptsSstc.py
+#
+# InterruptsSstc privileged extension test generator.
+# sanarayanan@hmc.edu April 2026
+# SPDX-License-Identifier: Apache-2.0
+##################################
+
+from testgen.asm.helpers import comment_banner
+from testgen.asm.interrupts import (
+    mmode_sti_cleanup,
+    mmode_sti_setup,
+    set_menvcfg_stce,
+    set_mpie,
+    set_stimecmp_max,
+    set_stimecmp_soon,
+    set_stimecmp_zero,
+)
+from testgen.data.state import TestData
+from testgen.priv.registry import add_priv_test_generator
+
+# ---------------------------------------------------------------------------
+# Machine-mode STI tests
+# ---------------------------------------------------------------------------
+
+
+def _generate_machine_sti_tests(test_data: TestData) -> list[str]:
+    """cp_machine_sti: iterate mideleg x mie_stie; sample at ``csrw stimecmp, zero`` in M-mode.
+
+    STCE=1 and MIE=1 are fixed (required by menvcfg_stce_one and mstatus_mie_one).
+    The interrupt fires at the countdown loop after the sample.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_machine_sti"
+    r_scratch, r_stce = test_data.int_regs.get_registers(2, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner("cp_machine_sti", "M-mode STI: mideleg x mie_stie (STCE=1, MIE=1 fixed)"),
+        "",
+    ]
+
+    for mideleg_sti in [0, 1]:
+        for mie_stie in [0, 1]:
+            binname = f"{'d' if mideleg_sti else 'nd'}_stie{mie_stie}"
+            lines += [
+                "",
+                f"# cp_machine_sti: mideleg={mideleg_sti} stie={mie_stie}",
+                # --- setup: STCE=1, mideleg, mie.STIE, stimecmp=-1, MIE/SIE=0 ---
+                *mmode_sti_setup(r_scratch, r_stce, mideleg_sti, mie_stie),
+                # enable MIE=1; interrupt won't fire yet because stimecmp=-1
+                "csrsi mstatus, 8",
+                test_data.add_testcase(binname, coverpoint, covergroup),
+                *set_stimecmp_zero(),
+                # --- wait for interrupt to be handled ---
+                f"LI(x{r_scratch}, 2500)",
+                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                f"    bnez x{r_scratch}, 1b",
+                # --- cleanup: restore stimecmp=-1, STCE=0, mideleg=0, mie=0 ---
+                *mmode_sti_cleanup(r_scratch, r_stce),
+            ]
+
+    test_data.int_regs.return_registers([r_scratch, r_stce])
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Machine-mode TM / STCE read tests
+# ---------------------------------------------------------------------------
+
+
+def _generate_machine_tm_tests(test_data: TestData) -> list[str]:
+    """cp_machine_tm: M-mode csrr stimecmp with mcounteren.TM={0,1}."""
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_machine_tm"
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner("cp_machine_tm", "M-mode stimecmp read: mcounteren.TM={0,1}"),
+        "",
+    ]
+    for tm_val in [0, 1]:
+        lines += [
+            "",
+            f"# cp_machine_tm: TM={tm_val}",
+            "RVTEST_GOTO_MMODE",
+            # set or clear mcounteren.TM to control stimecmp visibility
+        ]
+        if tm_val:
+            lines += [f"LI(x{r_scratch}, 0x2)", f"CSRS(mcounteren, x{r_scratch})"]
+        else:
+            lines += [f"LI(x{r_scratch}, 0x2)", f"CSRC(mcounteren, x{r_scratch})"]
+
+        lines.append(test_data.add_testcase(f"tm{tm_val}", coverpoint, covergroup))
+        lines += [f"CSRR x{r_scratch}, stimecmp", "nop"]
+        # restore: clear mcounteren.TM
+        lines += [f"LI(x{r_scratch}, 0x2)", f"CSRC(mcounteren, x{r_scratch})"]
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_machine_stce_tests(test_data: TestData) -> list[str]:
+    """cp_machine_stce: M-mode csrr stimecmp with menvcfg.STCE={0,1}."""
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_machine_stce"
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner("cp_machine_stce", "M-mode stimecmp read: menvcfg.STCE={0,1}"),
+        "",
+    ]
+    for stce_val in [0, 1]:
+        lines += [
+            "",
+            f"# cp_machine_stce: STCE={stce_val}",
+            "RVTEST_GOTO_MMODE",
+            # set menvcfg.STCE to the loop value
+            *set_menvcfg_stce(r_scratch, bool(stce_val)),
+        ]
+        lines.append(test_data.add_testcase(f"stce{stce_val}", coverpoint, covergroup))
+        lines += [f"CSRR x{r_scratch}, stimecmp", "nop"]
+        # restore STCE=1 for subsequent tests
+        lines += set_menvcfg_stce(r_scratch, True)
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Supervisor-mode STI tests
+# ---------------------------------------------------------------------------
+
+
+def _generate_supervisor_sti_tests(test_data: TestData) -> list[str]:
+    """cp_supervisor_sti_deleg / cp_supervisor_sti_nodeleg: all 32 bins.
+
+    deleg=1 (cp_supervisor_sti_deleg, priv_mode_s):
+      Enter S-mode via mret. For STCE=1: sample at csrw stimecmp,0 in S-mode,
+      interrupt fires after. For STCE=0: stimecmp=0 written in M-mode (no STI
+      since STCE=0 disables Sstc), sample at nop in S-mode.
+      MIE in S-mode is controlled via MPIE; SIE via csrsi/csrci in S-mode.
+
+    deleg=0 (cp_supervisor_sti_nodeleg, priv_mode_m):
+      Stay in M-mode. Enable MIE=1 before testcase so prev.MIE=1 at sample.
+      For STCE=1: sample at csrw stimecmp,0. For STCE=0: sample at nop
+      (stimecmp already 0 from setup, no interrupt since STCE=0).
+    """
+    covergroup = "InterruptsS_S_cg"
+    r_scratch, r_stce = test_data.int_regs.get_registers(2, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_supervisor_sti_deleg / cp_supervisor_sti_nodeleg",
+            "S-mode STI: menvcfg_stce x mstatus_mie x mstatus_sie\n"
+            "         x mideleg_sti x mie_stie x stimecmp_zero  (32 bins each)",
+        ),
+        "",
+    ]
+
+    for stce in [0, 1]:
+        for mie in [0, 1]:
+            for sie in [0, 1]:
+                for deleg in [0, 1]:
+                    for stie in [0, 1]:
+                        deleg_name = ["no_deleg", "deleg"][deleg]
+                        binname = f"stce{stce}_mie{mie}_sie{sie}_{deleg_name}_stie{stie}"
+
+                        # --- common M-mode setup: disable all interrupts, clear state ---
+                        lines += [
+                            "",
+                            f"# cp_supervisor_sti: STCE={stce} MIE={mie} SIE={sie} deleg={deleg} STIE={stie}",
+                            "RVTEST_GOTO_MMODE",
+                            "CSRW(mie, zero)",
+                            "csrci mstatus, 8",  # MIE=0
+                            "csrci mstatus, 2",  # SIE=0
+                            f"LI(x{r_scratch}, 0x20)",
+                            f"CSRC(mip, x{r_scratch})",  # clear any pending STIP
+                        ]
+
+                        # configure STCE and stimecmp
+                        if stce:
+                            lines += set_stimecmp_max(r_scratch)  # stimecmp=-1 (no pending STI yet)
+                            lines += set_menvcfg_stce(r_stce, True)  # STCE=1: enable Sstc
+                        else:
+                            lines += set_menvcfg_stce(r_stce, False)  # STCE=0: disable Sstc
+                            lines.append("CSRW(stimecmp, zero)")  # stimecmp=0; no STI fires (STCE=0)
+
+                        # configure delegation and interrupt enable
+                        if deleg:
+                            lines += [f"LI(x{r_scratch}, 0x20)", f"CSRW(mideleg, x{r_scratch})"]  # STI → S-mode
+                        else:
+                            lines.append("CSRW(mideleg, zero)")  # STI → M-mode
+
+                        if stie:
+                            lines += [f"LI(x{r_scratch}, 0x20)", f"CSRW(mie, x{r_scratch})"]  # STIE=1
+                        else:
+                            lines.append("CSRW(mie, zero)")  # STIE=0
+
+                        if deleg:
+                            # --- enter S-mode; MIE controlled via MPIE, SIE set inside S-mode ---
+                            lines += set_mpie(r_scratch, bool(mie))  # MPIE → MIE after mret
+                            lines.append("RVTEST_GOTO_LOWER_MODE Smode")
+                            if sie:
+                                lines.append("    csrsi sstatus, 2")  # SIE=1
+                            else:
+                                lines.append("    csrci sstatus, 2")  # SIE=0
+                            lines.append(
+                                f"    {test_data.add_testcase(binname, 'cp_supervisor_sti_deleg', covergroup)}"
+                            )
+                            if stce:
+                                lines += ["    " + l for l in set_stimecmp_zero()]
+                            else:
+                                lines.append("    nop")
+                            lines += [
+                                f"    LI(x{r_scratch}, 2500)",
+                                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                                f"    bnez x{r_scratch}, 1b",
+                            ]
+                        else:
+                            # --- stay in M-mode; enable MIE=1 before testcase so prev.MIE=1 at sample ---
+                            lines.append("csrsi mstatus, 8")  # MIE=1 (prev.MIE=1 at next insn)
+                            lines.append("nop")  # stable prev state
+                            lines.append(test_data.add_testcase(binname, "cp_supervisor_sti_nodeleg", covergroup))
+                            if stce:
+                                lines += set_stimecmp_zero()
+                            else:
+                                lines.append("nop")
+                            lines += [
+                                f"LI(x{r_scratch}, 2500)",
+                                f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                                f"    bnez x{r_scratch}, 1b",
+                            ]
+
+                        # --- cleanup: restore stimecmp=-1, STCE=0, mideleg=0, mie=0 ---
+                        lines += mmode_sti_cleanup(r_scratch, r_stce)
+
+    test_data.int_regs.return_registers([r_scratch, r_stce])
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Supervisor-mode TM / STCE read tests
+# ---------------------------------------------------------------------------
+
+
+def _generate_supervisor_tm_tests(test_data: TestData) -> list[str]:
+    """cp_supervisor_tm: S-mode csrr stimecmp with mcounteren.TM={0,1}.
+
+    TM=0: csrr stimecmp from S-mode traps; coverage is still sampled at the csrr.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_supervisor_tm"
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner("cp_supervisor_tm", "S-mode stimecmp read: mcounteren.TM={0,1}"),
+        "",
+    ]
+    for tm_val in [0, 1]:
+        lines += [
+            "",
+            f"# cp_supervisor_tm: TM={tm_val}",
+            "RVTEST_GOTO_MMODE",
+            # STCE=1 so stimecmp is accessible from S-mode
+            *set_menvcfg_stce(r_scratch, True),
+            # set or clear mcounteren.TM
+        ]
+        if tm_val:
+            lines += [f"LI(x{r_scratch}, 0x2)", f"CSRS(mcounteren, x{r_scratch})"]
+        else:
+            lines += [f"LI(x{r_scratch}, 0x2)", f"CSRC(mcounteren, x{r_scratch})"]
+
+        lines += [
+            "RVTEST_GOTO_LOWER_MODE Smode",
+            f"    {test_data.add_testcase(f'tm{tm_val}', coverpoint, covergroup)}",
+            f"    CSRR x{r_scratch}, stimecmp",
+            "    nop",
+            # --- return to M-mode and restore ---
+            "RVTEST_GOTO_MMODE",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mcounteren, x{r_scratch})",
+            *set_menvcfg_stce(r_scratch, False),
+        ]
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_supervisor_stce_tests(test_data: TestData) -> list[str]:
+    """cp_supervisor_stce: S-mode csrr stimecmp with menvcfg.STCE={0,1}.
+
+    STCE=0: csrr stimecmp from S-mode traps; coverage sampled at the csrr.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_supervisor_stce"
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner("cp_supervisor_stce", "S-mode stimecmp read: menvcfg.STCE={0,1}"),
+        "",
+    ]
+    for stce_val in [0, 1]:
+        lines += [
+            "",
+            f"# cp_supervisor_stce: STCE={stce_val}",
+            "RVTEST_GOTO_MMODE",
+            # set STCE to test value before entering S-mode
+            *set_menvcfg_stce(r_scratch, bool(stce_val)),
+            "RVTEST_GOTO_LOWER_MODE Smode",
+            f"    {test_data.add_testcase(f'stce{stce_val}', coverpoint, covergroup)}",
+            f"    CSRR x{r_scratch}, stimecmp",
+            "    nop",
+            # --- return to M-mode and restore STCE=0 ---
+            "RVTEST_GOTO_MMODE",
+            *set_menvcfg_stce(r_scratch, False),
+        ]
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# User-mode STI tests
+# ---------------------------------------------------------------------------
+
+
+def _generate_user_sti_tests(test_data: TestData) -> list[str]:
+    """cp_user_sti: U-mode STI cross (32 bins).
+
+    All 32 bins (menvcfg_stce x mstatus_mie x mstatus_sie x mideleg_sti x mie_stie)
+    are sampled at a nop in U-mode.
+
+    stce=1: stimecmp=TIME+500 so the interrupt fires AFTER the sample nop; the
+            interrupt then goes to S-mode (mideleg=1) or M-mode (mideleg=0).
+    stce=0: stimecmp=TIME+500 is set but STCE=0 disables Sstc, so no interrupt fires;
+            we only sample the CSR configuration.  mip.STIP is NOT set for stce=0
+            because doing so with mideleg=0+STIE=1 would cause M-mode to preempt
+            U-mode unconditionally before the sample instruction executes.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_user_sti"
+    r_scratch, r_stce, r_hi = test_data.int_regs.get_registers(3, exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "cp_user_sti",
+            "U-mode STI: menvcfg_stce x mstatus_mie x mstatus_sie\n"
+            "         x mideleg_sti x mie_stie  (32 bins)\n"
+            "stce=1: stimecmp=TIME+500, interrupt fires after sample.\n"
+            "stce=0: CSR state sampled only; no interrupt (avoids mideleg=0+STIE=1 preemption).",
+        ),
+        "",
+    ]
+
+    for stce in [0, 1]:
+        for mie in [0, 1]:
+            for sie in [0, 1]:
+                for deleg in [0, 1]:
+                    for stie in [0, 1]:
+                        deleg_name = ["no_deleg", "deleg"][deleg]
+                        binname = f"stce{stce}_mie{mie}_sie{sie}_{deleg_name}_stie{stie}"
+
+                        # --- common M-mode setup: disable all interrupts, clear state ---
+                        lines += [
+                            "",
+                            f"# cp_user_sti: STCE={stce} MIE={mie} SIE={sie} deleg={deleg} STIE={stie}",
+                            "RVTEST_GOTO_MMODE",
+                            "CSRW(mie, zero)",
+                            "csrci mstatus, 8",  # MIE=0
+                            "csrci mstatus, 2",  # SIE=0
+                            f"LI(x{r_scratch}, 0x20)",
+                            f"CSRC(mip, x{r_scratch})",  # clear any pending STIP
+                            *set_stimecmp_max(r_scratch),  # stimecmp=-1
+                            *set_menvcfg_stce(r_stce, bool(stce)),  # set STCE
+                        ]
+
+                        # configure delegation and interrupt enable
+                        if deleg:
+                            lines += [f"LI(x{r_scratch}, 0x20)", f"CSRW(mideleg, x{r_scratch})"]  # STI → S-mode
+                        else:
+                            lines.append("CSRW(mideleg, zero)")  # STI → M-mode
+
+                        if stie:
+                            lines += [f"LI(x{r_scratch}, 0x20)", f"CSRW(mie, x{r_scratch})"]  # STIE=1
+                        else:
+                            lines.append("CSRW(mie, zero)")  # STIE=0
+
+                        # schedule interrupt: stce=1 fires after sample; stce=0 no interrupt
+                        if stce:
+                            lines += set_stimecmp_soon(r_scratch, r_stce, r_hi)  # stimecmp=TIME+500
+
+                        # set SIE in mstatus before entering U-mode
+                        if sie:
+                            lines.append("csrsi mstatus, 2")
+                        else:
+                            lines.append("csrci mstatus, 2")
+
+                        # MPIE controls MIE after mret into U-mode
+                        lines += set_mpie(r_scratch, bool(mie))
+                        lines.append("RVTEST_GOTO_LOWER_MODE Umode")
+                        lines.append(f"    {test_data.add_testcase(binname, coverpoint, covergroup)}")
+                        lines += [
+                            f"    LI(x{r_scratch}, 2500)",
+                            f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                            f"    bnez x{r_scratch}, 1b",
+                        ]
+
+                        # --- cleanup: restore stimecmp=-1, STCE=0, mideleg=0, mie=0 ---
+                        lines += mmode_sti_cleanup(r_scratch, r_stce)
+
+    test_data.int_regs.return_registers([r_scratch, r_stce, r_hi])
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# User-mode TM / STCE read tests
+# ---------------------------------------------------------------------------
+
+
+def _generate_user_tm_tests(test_data: TestData) -> list[str]:
+    """cp_user_tm: U-mode csrr stimecmp with mcounteren.TM={0,1}.
+
+    scounteren.TM is fixed to 1 so mcounteren.TM is the only variable.
+    TM=0 causes a trap; coverage is sampled at the csrr before the trap.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_user_tm"
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner("cp_user_tm", "U-mode stimecmp read: mcounteren.TM={0,1}"),
+        "",
+    ]
+    for tm_val in [0, 1]:
+        lines += [
+            "",
+            f"# cp_user_tm: TM={tm_val}",
+            "RVTEST_GOTO_MMODE",
+            # STCE=1 so stimecmp is accessible (when TM=1)
+            *set_menvcfg_stce(r_scratch, True),
+            # scounteren.TM=1 always; only mcounteren.TM varies
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRS(scounteren, x{r_scratch})",
+        ]
+        if tm_val:
+            lines += [f"LI(x{r_scratch}, 0x2)", f"CSRS(mcounteren, x{r_scratch})"]
+        else:
+            lines += [f"LI(x{r_scratch}, 0x2)", f"CSRC(mcounteren, x{r_scratch})"]
+
+        lines += [
+            "RVTEST_GOTO_LOWER_MODE Umode",
+            f"    {test_data.add_testcase(f'tm{tm_val}', coverpoint, covergroup)}",
+            f"    CSRR x{r_scratch}, stimecmp",
+            "    nop",
+            # --- return to M-mode and restore ---
+            "RVTEST_GOTO_MMODE",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mcounteren, x{r_scratch})",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(scounteren, x{r_scratch})",
+            *set_menvcfg_stce(r_scratch, False),
+        ]
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+def _generate_user_stce_tests(test_data: TestData) -> list[str]:
+    """cp_user_stce: U-mode csrr stimecmp with menvcfg.STCE={0,1}.
+
+    mcounteren.TM and scounteren.TM are fixed to 1.
+    STCE=0: csrr stimecmp from U-mode traps; coverage sampled at the csrr.
+    """
+    covergroup = "InterruptsS_S_cg"
+    coverpoint = "cp_user_stce"
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner("cp_user_stce", "U-mode stimecmp read: menvcfg.STCE={0,1}"),
+        "",
+    ]
+    for stce_val in [0, 1]:
+        lines += [
+            "",
+            f"# cp_user_stce: STCE={stce_val}",
+            "RVTEST_GOTO_MMODE",
+            # set STCE to test value before entering U-mode
+            *set_menvcfg_stce(r_scratch, bool(stce_val)),
+            # TM=1 in both counteren so stimecmp access depends only on STCE
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRS(mcounteren, x{r_scratch})",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRS(scounteren, x{r_scratch})",
+            "RVTEST_GOTO_LOWER_MODE Umode",
+            f"    {test_data.add_testcase(f'stce{stce_val}', coverpoint, covergroup)}",
+            f"    CSRR x{r_scratch}, stimecmp",
+            "    nop",
+            # --- return to M-mode and restore ---
+            "RVTEST_GOTO_MMODE",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(mcounteren, x{r_scratch})",
+            f"LI(x{r_scratch}, 0x2)",
+            f"CSRC(scounteren, x{r_scratch})",
+            *set_menvcfg_stce(r_scratch, False),
+        ]
+
+    test_data.int_regs.return_registers([r_scratch])
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Top-level generator
+# ---------------------------------------------------------------------------
+
+
+@add_priv_test_generator("InterruptsSstc", required_extensions=["Sm", "S", "Sstc", "I", "Zicsr"])
+def make_interruptss_s(test_data: TestData) -> list[str]:
+    """Generate all Sstc interrupt tests (machine, supervisor, user modes)."""
+    r_temp = test_data.int_regs.get_register(exclude_regs=[0, 2])
+
+    lines = [
+        comment_banner(
+            "InterruptsSstc",
+            "Supervisor timer (Sstc) interrupt tests\n"
+            "Covers M-mode, S-mode, and U-mode scenarios for stimecmp-based STI.",
+        ),
+        "",
+        # global init: no delegation, clear TW so WFI doesn't trap in lower modes
+        "CSRW(mideleg, zero)",
+        f"LI(x{r_temp}, 0x200000)",
+        f"CSRC(mstatus, x{r_temp})",  # clear TW bit
+        "",
+    ]
+
+    lines += _generate_machine_sti_tests(test_data)
+    lines += _generate_machine_tm_tests(test_data)
+    lines += _generate_machine_stce_tests(test_data)
+    lines += _generate_supervisor_sti_tests(test_data)
+    lines += _generate_supervisor_tm_tests(test_data)
+    lines += _generate_supervisor_stce_tests(test_data)
+    lines += _generate_user_sti_tests(test_data)
+    lines += _generate_user_tm_tests(test_data)
+    lines += _generate_user_stce_tests(test_data)
+
+    test_data.int_regs.return_registers([r_temp])
+    return lines

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsSstc.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsSstc.py
@@ -32,7 +32,7 @@ def _generate_machine_sti_tests(test_data: TestData) -> list[str]:
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_machine_sti"
-    r_scratch, r_stce = test_data.int_regs.get_registers(2, exclude_regs=[0, 2])
+    r_scratch, r_stce = test_data.int_regs.get_registers(2, exclude_regs=[0])
 
     lines = [
         comment_banner("cp_machine_sti", "M-mode STI: mideleg x mie_stie (STCE=1, MIE=1 fixed)"),
@@ -72,7 +72,7 @@ def _generate_machine_tm_tests(test_data: TestData) -> list[str]:
     """cp_machine_tm: M-mode csrr stimecmp with mcounteren.TM={0,1}."""
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_machine_tm"
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0])
 
     lines = [
         comment_banner("cp_machine_tm", "M-mode stimecmp read: mcounteren.TM={0,1}"),
@@ -103,7 +103,7 @@ def _generate_machine_stce_tests(test_data: TestData) -> list[str]:
     """cp_machine_stce: M-mode csrr stimecmp with menvcfg.STCE={0,1}."""
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_machine_stce"
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0])
 
     lines = [
         comment_banner("cp_machine_stce", "M-mode stimecmp read: menvcfg.STCE={0,1}"),
@@ -146,7 +146,7 @@ def _generate_supervisor_sti_tests(test_data: TestData) -> list[str]:
       (stimecmp already 0 from setup, no interrupt since STCE=0).
     """
     covergroup = "InterruptsS_S_cg"
-    r_scratch, r_stce = test_data.int_regs.get_registers(2, exclude_regs=[0, 2])
+    r_scratch, r_stce = test_data.int_regs.get_registers(2, exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -250,7 +250,7 @@ def _generate_supervisor_tm_tests(test_data: TestData) -> list[str]:
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_supervisor_tm"
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0])
 
     lines = [
         comment_banner("cp_supervisor_tm", "S-mode stimecmp read: mcounteren.TM={0,1}"),
@@ -293,7 +293,7 @@ def _generate_supervisor_stce_tests(test_data: TestData) -> list[str]:
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_supervisor_stce"
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0])
 
     lines = [
         comment_banner("cp_supervisor_stce", "S-mode stimecmp read: menvcfg.STCE={0,1}"),
@@ -339,7 +339,7 @@ def _generate_user_sti_tests(test_data: TestData) -> list[str]:
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_user_sti"
-    r_scratch, r_stce, r_hi = test_data.int_regs.get_registers(3, exclude_regs=[0, 2])
+    r_scratch, r_stce, r_hi = test_data.int_regs.get_registers(3, exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -425,7 +425,7 @@ def _generate_user_tm_tests(test_data: TestData) -> list[str]:
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_user_tm"
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0])
 
     lines = [
         comment_banner("cp_user_tm", "U-mode stimecmp read: mcounteren.TM={0,1}"),
@@ -473,7 +473,7 @@ def _generate_user_stce_tests(test_data: TestData) -> list[str]:
     """
     covergroup = "InterruptsS_S_cg"
     coverpoint = "cp_user_stce"
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2])
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0])
 
     lines = [
         comment_banner("cp_user_stce", "U-mode stimecmp read: menvcfg.STCE={0,1}"),
@@ -516,7 +516,7 @@ def _generate_user_stce_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator("InterruptsSstc", required_extensions=["Sm", "S", "Sstc", "I", "Zicsr"])
 def make_interruptss_s(test_data: TestData) -> list[str]:
     """Generate all Sstc interrupt tests (machine, supervisor, user modes)."""
-    r_temp = test_data.int_regs.get_register(exclude_regs=[0, 2])
+    r_temp = test_data.int_regs.get_register(exclude_regs=[0])
 
     lines = [
         comment_banner(

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
@@ -19,11 +19,9 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
     """Generate undelegated MTI interrupt tests from U-mode."""
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_user_mti"
-    
-    r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch = test_data.int_regs.get_registers(
-        5, exclude_regs=[0, 2, 7, 30]
-    )
-    
+
+    r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch = test_data.int_regs.get_registers(5, exclude_regs=[0, 2, 7, 30])
+
     lines = [
         comment_banner(
             "cp_user_mti",
@@ -33,63 +31,75 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
         ),
         "",
     ]
-    
+
     # Cross: mtvec.MODE x mstatus.MIE (2x2 = 4 bins)
     for mtvec_mode in [0, 1]:
         for mstatus_mie in [0, 1]:
             mode_name = ["direct", "vectored"][mtvec_mode]
             mie_name = f"mie_{mstatus_mie}"
             binname = f"{mode_name}_{mie_name}"
-            
-            lines.extend([
-                "",
-                "# Setup mstatus and mtvec",
-                "csrci mstatus, 8",
-                "csrci mtvec, 3",
-            ])
-            
+
+            lines.extend(
+                [
+                    "",
+                    "# Setup mstatus and mtvec",
+                    "csrci mstatus, 8",
+                    "csrci mtvec, 3",
+                ]
+            )
+
             # Set mtvec.MODE if needed
             if mtvec_mode:
                 lines.append("csrsi mtvec, 1")
-            
+
             # Set mstatus.MPIE (not MIE) because mret copies MPIE→MIE when transitioning to U-mode.
             # Setting MIE directly would be overwritten by mret's automatic MPIE restoration.
             if mstatus_mie:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",  # MPIE bit mask
-                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",  # Set MPIE
-                ])
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",  # MPIE bit mask
+                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",  # Set MPIE
+                    ]
+                )
             else:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",  # MPIE bit mask
-                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",  # Clear MPIE
-                ])
-            
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",  # MPIE bit mask
+                        f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",  # Clear MPIE
+                    ]
+                )
+
             # Enable MTIE
-            lines.extend([
-                f"LI(x{r_scratch}, 0x80)",
-                f"CSRW(mie, x{r_scratch})",
-            ])
-            
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
             # Go to U-mode
             lines.append("RVTEST_GOTO_LOWER_MODE Umode")
-            
+
             # Trigger interrupt
             lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
-            
+
             lines.extend(indent(set_mtimer_int(r_mtime, r_mtimecmp, r_temp, r_temp2)))
-            
-            lines.extend([
-                "RVTEST_IDLE_FOR_INTERRUPT",
-            ])
-            
+
+            lines.extend(
+                [
+                    "RVTEST_IDLE_FOR_INTERRUPT",
+                ]
+            )
+
             # Return to M-mode and cleanup
-            lines.extend([
-                "RVTEST_GOTO_MMODE",
-                "nop",
-            ])
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "nop",
+                ]
+            )
             lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
-    
+
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch])
     return lines
 
@@ -98,9 +108,9 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
     """Generate undelegated MSI interrupt tests from U-mode."""
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_user_msi"
-    
+
     r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2, 7, 30])
-    
+
     lines = [
         comment_banner(
             "cp_user_msi",
@@ -110,54 +120,66 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
         ),
         "",
     ]
-    
+
     for mtvec_mode in [0, 1]:
         for mstatus_mie in [0, 1]:
             mode_name = ["direct", "vectored"][mtvec_mode]
             mie_name = f"mie_{mstatus_mie}"
             binname = f"{mode_name}_{mie_name}"
-            
-            lines.extend([
-                "",
-                "csrci mstatus, 8",
-                "csrci mtvec, 3",
-            ])
-            
+
+            lines.extend(
+                [
+                    "",
+                    "csrci mstatus, 8",
+                    "csrci mtvec, 3",
+                ]
+            )
+
             if mtvec_mode:
                 lines.append("csrsi mtvec, 1")
-            
+
             if mstatus_mie:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
-                ])
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",
+                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                    ]
+                )
             else:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
-                ])
-            
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",
+                        f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+                    ]
+                )
+
             # Enable MSIE
-            lines.extend([
-                f"LI(x{r_scratch}, 0x08)",
-                f"CSRW(mie, x{r_scratch})",
-            ])
-            
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x08)",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
             lines.append("RVTEST_GOTO_LOWER_MODE Umode")
-            
+
             # Trigger - label right before
-            lines.extend([
-                test_data.add_testcase(binname, coverpoint, covergroup),
-                "    RVTEST_SET_MSW_INT",
-                "    RVTEST_IDLE_FOR_INTERRUPT",
-            ])
-            
-            lines.extend([
-                "RVTEST_GOTO_MMODE",
-                "nop",
-                "RVTEST_CLR_MSW_INT",
-            ])
-    
+            lines.extend(
+                [
+                    test_data.add_testcase(binname, coverpoint, covergroup),
+                    "    RVTEST_SET_MSW_INT",
+                    "    RVTEST_IDLE_FOR_INTERRUPT",
+                ]
+            )
+
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "nop",
+                    "RVTEST_CLR_MSW_INT",
+                ]
+            )
+
     test_data.int_regs.return_registers([r_scratch])
     return lines
 
@@ -166,9 +188,9 @@ def _generate_user_mei_tests(test_data: TestData) -> list[str]:
     """Generate undelegated MEI interrupt tests from U-mode."""
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_user_mei"
-    
+
     r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2, 7, 30])
-    
+
     lines = [
         comment_banner(
             "cp_user_mei",
@@ -178,53 +200,65 @@ def _generate_user_mei_tests(test_data: TestData) -> list[str]:
         ),
         "",
     ]
-    
+
     for mtvec_mode in [0, 1]:
         for mstatus_mie in [0, 1]:
             mode_name = ["direct", "vectored"][mtvec_mode]
             mie_name = f"mie_{mstatus_mie}"
             binname = f"{mode_name}_{mie_name}"
-            
-            lines.extend([
-                "",
-                "csrci mstatus, 8",
-                "csrci mtvec, 3",
-            ])
-            
+
+            lines.extend(
+                [
+                    "",
+                    "csrci mstatus, 8",
+                    "csrci mtvec, 3",
+                ]
+            )
+
             if mtvec_mode:
                 lines.append("csrsi mtvec, 1")
-            
+
             if mstatus_mie:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
-                ])
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",
+                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                    ]
+                )
             else:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
-                ])
-            
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",
+                        f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+                    ]
+                )
+
             # Enable MEIE
-            lines.extend([
-                f"LI(x{r_scratch}, 0x800)",
-                f"CSRW(mie, x{r_scratch})",
-            ])
-            
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x800)",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
             lines.append("RVTEST_GOTO_LOWER_MODE Umode")
-            
-            lines.extend([
-                test_data.add_testcase(binname, coverpoint, covergroup),
-                "    RVTEST_SET_MEXT_INT",
-                "    RVTEST_IDLE_FOR_INTERRUPT",
-            ])
-            
-            lines.extend([
-                "RVTEST_GOTO_MMODE",
-                "nop",
-                "RVTEST_CLR_MEXT_INT",
-            ])
-    
+
+            lines.extend(
+                [
+                    test_data.add_testcase(binname, coverpoint, covergroup),
+                    "    RVTEST_SET_MEXT_INT",
+                    "    RVTEST_IDLE_FOR_INTERRUPT",
+                ]
+            )
+
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                    "nop",
+                    "RVTEST_CLR_MEXT_INT",
+                ]
+            )
+
     test_data.int_regs.return_registers([r_scratch])
     return lines
 
@@ -233,11 +267,11 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
     """Generate WFI tests from U-mode."""
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_wfi"
-    
+
     r_mtime, r_mtimecmp, r_temp, r_temp2, r_t1, r_t2, r_scratch = test_data.int_regs.get_registers(
         7, exclude_regs=[0, 2, 7, 30]
     )
-    
+
     lines = [
         comment_banner(
             "cp_wfi",
@@ -247,60 +281,74 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
         ),
         "",
     ]
-    
+
     # Cross: MIE x TW (2x2 = 4 bins)
     for mie_val in [0, 1]:
         for tw_val in [0, 1]:
             binname = f"mie_{mie_val}_tw_{tw_val}"
-            
-            lines.extend([
-                "",
-                f"LI(x{r_scratch}, 0x200008)",
-                f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
-            ])
-            
+
+            lines.extend(
+                [
+                    "",
+                    f"LI(x{r_scratch}, 0x200008)",
+                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+                ]
+            )
+
             # Set MIE if needed
             if mie_val:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
-                ])
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",
+                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                    ]
+                )
             else:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
-                ])
-            
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",
+                        f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+                    ]
+                )
+
             # Set TW if needed
             if tw_val:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x200000)",
-                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
-                ])
-            
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x200000)",
+                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                    ]
+                )
+
             # Enable MTIE
-            lines.extend([
-                f"LI(x{r_scratch}, 0x80)",
-                f"CSRW(mie, x{r_scratch})",
-            ])
-            
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRW(mie, x{r_scratch})",
+                ]
+            )
+
             lines.append("RVTEST_GOTO_LOWER_MODE Umode")
-            
+
             # Set timer to fire soon
             lines.extend(indent(set_mtimer_int_soon(r_mtime, r_mtimecmp, r_temp, r_t1, r_t2, r_temp2)))
-            
+
             # WFI - label right before
-            lines.extend([
-                test_data.add_testcase(binname, coverpoint, covergroup),
-                "    wfi",
-                "    nop",
-            ])
-            
-            lines.extend([
-                "RVTEST_GOTO_MMODE",
-            ])
+            lines.extend(
+                [
+                    test_data.add_testcase(binname, coverpoint, covergroup),
+                    "    wfi",
+                    "    nop",
+                ]
+            )
+
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                ]
+            )
             lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
-    
+
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp, r_temp2, r_t1, r_t2, r_scratch])
     return lines
 
@@ -309,11 +357,9 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
     """Generate WFI timeout tests (illegal instruction) from U-mode."""
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_wfi_timeout"
-    
-    r_temp, r_mtimecmp, r_scratch = test_data.int_regs.get_registers(
-        3, exclude_regs=[0, 2, 7, 30]
-    )
-    
+
+    r_temp, r_mtimecmp, r_scratch = test_data.int_regs.get_registers(3, exclude_regs=[0, 2, 7, 30])
+
     lines = [
         comment_banner(
             "cp_wfi_timeout",
@@ -327,59 +373,73 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
         f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
         "",
     ]
-    
+
     # Cross: MIE x MTIE (2x2 = 4 bins), TW=1 fixed
     for mie_val in [0, 1]:
         for mtie_val in [0, 1]:
             binname = f"mie_{mie_val}_mtie_{mtie_val}"
-            
-            lines.extend([
-                "",
-                "csrci mstatus, 8",
-                f"LI(x{r_scratch}, 0x80)",
-                f"CSRRC(x{r_scratch}, mie, x{r_scratch})",
-            ])
-            
+
+            lines.extend(
+                [
+                    "",
+                    "csrci mstatus, 8",
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRRC(x{r_scratch}, mie, x{r_scratch})",
+                ]
+            )
+
             # Set MIE if needed
             if mie_val:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
-                ])
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",
+                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                    ]
+                )
             else:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
-                ])
-            
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",
+                        f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+                    ]
+                )
+
             # Set MTIE if needed
             if mtie_val:
-                lines.extend([
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRRS(x{r_scratch}, mie, x{r_scratch})",
-                ])
-            
+                lines.extend(
+                    [
+                        f"LI(x{r_scratch}, 0x80)",
+                        f"CSRRS(x{r_scratch}, mie, x{r_scratch})",
+                    ]
+                )
+
             # Clear timer (ensure no interrupt)
             lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
-            
-            lines.extend([
-                "nop",
-                "RVTEST_GOTO_LOWER_MODE Umode",
-                "",
-            ])
-            
+
+            lines.extend(
+                [
+                    "nop",
+                    "RVTEST_GOTO_LOWER_MODE Umode",
+                    "",
+                ]
+            )
+
             # WFI
-            lines.extend([
-                test_data.add_testcase(binname, coverpoint, covergroup),
-                "    wfi",
-                "    nop",
-            ])
-            
-            lines.extend([
-                "RVTEST_GOTO_MMODE",
-            ])
+            lines.extend(
+                [
+                    test_data.add_testcase(binname, coverpoint, covergroup),
+                    "    wfi",
+                    "    nop",
+                ]
+            )
+
+            lines.extend(
+                [
+                    "RVTEST_GOTO_MMODE",
+                ]
+            )
             lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
-    
+
     test_data.int_regs.return_registers([r_temp, r_mtimecmp, r_scratch])
     return lines
 
@@ -387,33 +447,35 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
 @add_priv_test_generator("InterruptsU", required_extensions=["Sm", "I", "Zicsr"])
 def make_interruptsu(test_data: TestData) -> list[str]:
     """Generate tests for InterruptsU user-mode interrupt behavior."""
-    
+
     # Consume t2 and t5 for interrupt subroutines throughout the test
     test_data.int_regs.consume_registers([7, 30])
-    
+
     lines: list[str] = []
-    
+
     r_temp, r_mtimecmp = test_data.int_regs.get_registers(2, exclude_regs=[0, 2, 7, 30])
-    
-    # Initial setup - clear any pending timer!
-    lines.extend([
-        "",
-        "CSRW(mideleg, zero)",
-    ])
+
+    # Initial setup - clear any pending timer
+    lines.extend(
+        [
+            "",
+            "CSRW(mideleg, zero)",
+        ]
+    )
     lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
     lines.append("")
-    
+
     # Return the temporary registers
     test_data.int_regs.return_registers([r_temp, r_mtimecmp])
-    
+
     # Generate all test sections
     lines.extend(_generate_user_mti_tests(test_data))
     lines.extend(_generate_user_msi_tests(test_data))
     lines.extend(_generate_user_mei_tests(test_data))
     lines.extend(_generate_user_wfi_tests(test_data))
     lines.extend(_generate_user_wfi_timeout_tests(test_data))
-    
+
     # Return the consumed registers before test ends
     test_data.int_regs.return_registers([7, 30])
-    
+
     return lines

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
@@ -333,7 +333,6 @@ def make_interruptsu(test_data: TestData) -> list[str]:
     # Initial setup - clear any pending timer
     lines.extend(
         [
-            "",
             "CSRW(mideleg, zero)",
         ]
     )

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
@@ -10,7 +10,7 @@
 """InterruptsU privileged extension test generator for user-mode interrupts."""
 
 from testgen.asm.helpers import comment_banner
-from testgen.asm.interrupts import clr_mtimer_int, indent, set_mtimer_int, set_mtimer_int_soon
+from testgen.asm.interrupts import clr_mtimer_int, set_mtimer_int, set_mtimer_int_soon
 from testgen.data.state import TestData
 from testgen.priv.registry import add_priv_test_generator
 
@@ -20,7 +20,7 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_user_mti"
 
-    r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch = test_data.int_regs.get_registers(5, exclude_regs=[0])
+    r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch = test_data.int_regs.get_registers(5, exclude_regs=[0, 2])
 
     lines = [
         comment_banner(
@@ -39,43 +39,36 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
             mie_name = f"mie_{mstatus_mie}"
             binname = f"{mode_name}_{mie_name}"
 
-            lines.extend(
-                [
-                    "",
-                    "# Setup mstatus and mtvec",
-                    "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
-                    "csrci mtvec, 3",  # Clear mtvec.MODE (bits 1:0)
-                ]
-            )
-
-            # Set mtvec.MODE if needed
             if mtvec_mode:
-                lines.append("csrsi mtvec, 1")  # Set mtvec.MODE to vectored (01)
+                lines.append("csrsi mtvec, 1")
 
-            # Set mstatus.MPIE (not MIE) because mret copies MPIE→MIE when transitioning to U-mode.
-            # Setting MIE directly would be overwritten by mret's automatic MPIE restoration.
             lines.extend(
                 [
-                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
+                    f"LI(x{r_scratch}, 0x80)",
                     f"{'CSRS' if mstatus_mie else 'CSRC'}(mstatus, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x80)",  # Enable MTIE
+                    f"LI(x{r_scratch}, 0x80)",
                     f"CSRW(mie, x{r_scratch})",
-                    "RVTEST_GOTO_LOWER_MODE Umode",  # Go to U-mode
+                    "RVTEST_GOTO_LOWER_MODE Umode",
                     test_data.add_testcase(binname, coverpoint, covergroup),
+                    *set_mtimer_int(r_mtime, r_mtimecmp, r_temp, r_temp2),
                 ]
             )
 
-            lines.extend(indent(set_mtimer_int(r_mtime, r_mtimecmp, r_temp, r_temp2)))
+            # lines.extend(*set_mtimer_int(r_mtime, r_mtimecmp, r_temp, r_temp2))
+
+            for _ in range(5000):
+                lines.append("    nop")
 
             lines.extend(
                 [
                     "RVTEST_IDLE_FOR_INTERRUPT",
-                    "RVTEST_GOTO_MMODE",  # Return to M-mode and cleanup
+                    "RVTEST_GOTO_MMODE",
                     "nop",
+                    *clr_mtimer_int(r_temp, r_mtimecmp),
                 ]
             )
 
-            lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
+            # lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
 
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch])
     return lines
@@ -124,6 +117,14 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
                     "RVTEST_GOTO_LOWER_MODE Umode",
                     test_data.add_testcase(binname, coverpoint, covergroup),
                     "RVTEST_SET_MSW_INT",
+                ]
+            )
+
+            for _ in range(5000):
+                lines.append("    nop")
+
+            lines.extend(
+                [
                     "RVTEST_IDLE_FOR_INTERRUPT",
                     "RVTEST_GOTO_MMODE",
                     "nop",
@@ -239,20 +240,19 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
             # Enable MTIE
             lines.extend([f"LI(x{r_scratch}, 0x80)", f"CSRW(mie, x{r_scratch})", "RVTEST_GOTO_LOWER_MODE Umode"])
 
-            # Set timer to fire soon
-            lines.extend(indent(set_mtimer_int_soon(r_mtime, r_mtimecmp, r_temp, r_t1, r_t2, r_temp2)))
-
             # WFI - label right before
             lines.extend(
                 [
+                    *set_mtimer_int_soon(r_mtime, r_mtimecmp, r_temp, r_t1, r_t2, r_temp2),  # Set timer to fire soon
                     test_data.add_testcase(binname, coverpoint, covergroup),
                     "    wfi",
                     "    nop",
                     "    RVTEST_GOTO_MMODE",
+                    *clr_mtimer_int(r_temp, r_mtimecmp),
                 ]
             )
 
-            lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
+            # lines.extend(*clr_mtimer_int(r_temp, r_mtimecmp))
 
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp, r_temp2, r_t1, r_t2, r_scratch])
     return lines

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
@@ -39,6 +39,14 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
             mie_name = f"mie_{mstatus_mie}"
             binname = f"{mode_name}_{mie_name}"
 
+            lines.extend(
+                [
+                    "",
+                    "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
+                    "csrci mtvec, 3",  # Clear mtvec.MODE (bits 1:0)
+                ]
+            )
+
             if mtvec_mode:
                 lines.append("csrsi mtvec, 1")
 
@@ -54,8 +62,13 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
                 ]
             )
 
-            for _ in range(5000):
-                lines.append("    nop")
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 2500)",  # 2500 iterations × 2 instructions = 5000 cycles
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
 
             lines.extend(
                 [
@@ -116,8 +129,13 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
                 ]
             )
 
-            for _ in range(5000):
-                lines.append("    nop")
+            lines.extend(
+                [
+                    f"    LI(x{r_scratch}, 2500)",  # 2500 iterations × 2 instructions = 5000 cycles
+                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
+                    f"    bnez x{r_scratch}, 1b",
+                ]
+            )
 
             lines.extend(
                 [
@@ -325,11 +343,7 @@ def make_interruptsu(test_data: TestData) -> list[str]:
     r_temp, r_mtimecmp = test_data.int_regs.get_registers(2, exclude_regs=[0])
 
     # Initial setup - clear any pending timer
-    lines.extend(
-        [
-            "CSRW(mideleg, zero)",
-        ]
-    )
+    lines.append("CSRW(mideleg, zero)")
     lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
     lines.append("")
 

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
@@ -43,31 +43,24 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
                 [
                     "",
                     "# Setup mstatus and mtvec",
-                    "csrci mstatus, 8",
-                    "csrci mtvec, 3",
+                    "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
+                    "csrci mtvec, 3",  # Clear mtvec.MODE (bits 1:0)
                 ]
             )
 
             # Set mtvec.MODE if needed
             if mtvec_mode:
-                lines.append("csrsi mtvec, 1")
+                lines.append("csrsi mtvec, 1")  # Set mtvec.MODE to vectored (01)
 
             # Set mstatus.MPIE (not MIE) because mret copies MPIE→MIE when transitioning to U-mode.
             # Setting MIE directly would be overwritten by mret's automatic MPIE restoration.
-            if mstatus_mie:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",  # MPIE bit mask
-                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",  # Set MPIE
-                    ]
-                )
-            else:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",  # MPIE bit mask
-                        f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",  # Clear MPIE
-                    ]
-                )
+            cmd = ["CSRC", "CSRS"][mstatus_mie]  # CSRC if 0, CSRS if 1
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
+                    f"{cmd}(mstatus, x{r_scratch})",
+                ]
+            )
 
             # Enable MTIE
             lines.extend(
@@ -130,28 +123,21 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
             lines.extend(
                 [
                     "",
-                    "csrci mstatus, 8",
-                    "csrci mtvec, 3",
+                    "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
+                    "csrci mtvec, 3",  # Clear mtvec.MODE (bits 1:0)
                 ]
             )
 
             if mtvec_mode:
-                lines.append("csrsi mtvec, 1")
+                lines.append("csrsi mtvec, 1")  # Set mtvec.MODE to vectored (01)
 
-            if mstatus_mie:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",
-                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
-                    ]
-                )
-            else:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",
-                        f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
-                    ]
-                )
+            cmd = ["CSRC", "CSRS"][mstatus_mie]  # CSRC if 0, CSRS if 1
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
+                    f"{cmd}(mstatus, x{r_scratch})",
+                ]
+            )
 
             # Enable MSIE
             lines.extend(
@@ -210,28 +196,21 @@ def _generate_user_mei_tests(test_data: TestData) -> list[str]:
             lines.extend(
                 [
                     "",
-                    "csrci mstatus, 8",
-                    "csrci mtvec, 3",
+                    "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
+                    "csrci mtvec, 3",  # Clear mtvec.MODE (bits 1:0)
                 ]
             )
 
             if mtvec_mode:
-                lines.append("csrsi mtvec, 1")
+                lines.append("csrsi mtvec, 1")  # Set mtvec.MODE to vectored (01)
 
-            if mstatus_mie:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",
-                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
-                    ]
-                )
-            else:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",
-                        f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
-                    ]
-                )
+            cmd = ["CSRC", "CSRS"][mstatus_mie]  # CSRC if 0, CSRS if 1
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
+                    f"{cmd}(mstatus, x{r_scratch})",
+                ]
+            )
 
             # Enable MEIE
             lines.extend(
@@ -291,32 +270,25 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
                 [
                     "",
                     f"LI(x{r_scratch}, 0x200008)",
-                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+                    f"CSRC(mstatus, x{r_scratch})",
                 ]
             )
 
             # Set MIE if needed
-            if mie_val:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",
-                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
-                    ]
-                )
-            else:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",
-                        f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
-                    ]
-                )
+            cmd = ["CSRC", "CSRS"][mie_val]  # CSRC if 0, CSRS if 1
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
+                    f"{cmd}(mstatus, x{r_scratch})",
+                ]
+            )
 
             # Set TW if needed
             if tw_val:
                 lines.extend(
                     [
                         f"LI(x{r_scratch}, 0x200000)",
-                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                        f"CSRS(mstatus, x{r_scratch})",
                     ]
                 )
 
@@ -370,7 +342,7 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
         "",
         "# Set TW=1 for entire test block",
         f"LI(x{r_scratch}, 0x200000)",
-        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+        f"CSRS(mstatus, x{r_scratch})",
         "",
     ]
 
@@ -382,34 +354,27 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
             lines.extend(
                 [
                     "",
-                    "csrci mstatus, 8",
+                    "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
                     f"LI(x{r_scratch}, 0x80)",
-                    f"CSRRC(x{r_scratch}, mie, x{r_scratch})",
+                    f"CSRC(mie, x{r_scratch})",
                 ]
             )
 
             # Set MIE if needed
-            if mie_val:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",
-                        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
-                    ]
-                )
-            else:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",
-                        f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
-                    ]
-                )
+            cmd = ["CSRC", "CSRS"][mie_val]  # CSRC if 0, CSRS if 1
+            lines.extend(
+                [
+                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
+                    f"{cmd}(mstatus, x{r_scratch})",
+                ]
+            )
 
             # Set MTIE if needed
             if mtie_val:
                 lines.extend(
                     [
                         f"LI(x{r_scratch}, 0x80)",
-                        f"CSRRS(x{r_scratch}, mie, x{r_scratch})",
+                        f"CSRS(mie, x{r_scratch})",
                     ]
                 )
 
@@ -418,7 +383,6 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
 
             lines.extend(
                 [
-                    "nop",
                     "RVTEST_GOTO_LOWER_MODE Umode",
                     "",
                 ]
@@ -444,11 +408,13 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
     return lines
 
 
-@add_priv_test_generator("InterruptsU", required_extensions=["Sm", "I", "Zicsr"])
+@add_priv_test_generator("InterruptsU", required_extensions=["Sm", "U", "I", "Zicsr"])
 def make_interruptsu(test_data: TestData) -> list[str]:
     """Generate tests for InterruptsU user-mode interrupt behavior."""
 
-    # Consume t2 and t5 for interrupt subroutines throughout the test
+    # Consume t2 and t5 - reserved by trap handler in arch_test.h for interrupt clearing subroutines
+    # The trap handler uses these registers when calling RVMODEL_CLR_*_INT macros
+    # See: tests/env/arch_test.h, trap handler interrupt dispatch logic
     test_data.int_regs.consume_registers([7, 30])
 
     lines: list[str] = []

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
@@ -52,10 +52,8 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
             if mtvec_mode:
                 lines.append("csrsi mtvec, 1")
             
-            # Set mstatus.MIE if needed
-            # if mstatus_mie:
-            #     lines.append("csrsi mstatus, 8")
-            # Set mstatus.MPIE (bit 7) instead of MIE (bit 3)
+            # Set mstatus.MPIE (not MIE) because mret copies MPIE→MIE when transitioning to U-mode.
+            # Setting MIE directly would be overwritten by mret's automatic MPIE restoration.
             if mstatus_mie:
                 lines.extend([
                     f"LI(x{r_scratch}, 0x80)",  # MPIE bit mask
@@ -76,12 +74,8 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
             # Go to U-mode
             lines.append("RVTEST_GOTO_LOWER_MODE Umode")
             
-            # Trigger interrupt - label right before trigger
+            # Trigger interrupt
             lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
-
-            lines.extend([
-                "RVTEST_IDLE_FOR_INTERRUPT",
-            ])
             
             lines.extend(indent(set_mtimer_int(r_mtime, r_mtimecmp, r_temp, r_temp2)))
             
@@ -132,8 +126,6 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
             if mtvec_mode:
                 lines.append("csrsi mtvec, 1")
             
-            # if mstatus_mie:
-            #     lines.append("csrsi mstatus, 8")
             if mstatus_mie:
                 lines.extend([
                     f"LI(x{r_scratch}, 0x80)",
@@ -157,9 +149,7 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
             lines.extend([
                 test_data.add_testcase(binname, coverpoint, covergroup),
                 "    RVTEST_SET_MSW_INT",
-                "    nop",
-                "    nop",
-                "    nop",
+                "    RVTEST_IDLE_FOR_INTERRUPT",
             ])
             
             lines.extend([
@@ -226,9 +216,7 @@ def _generate_user_mei_tests(test_data: TestData) -> list[str]:
             lines.extend([
                 test_data.add_testcase(binname, coverpoint, covergroup),
                 "    RVTEST_SET_MEXT_INT",
-                "    nop",
-                "    nop",
-                "    nop",
+                "    RVTEST_IDLE_FOR_INTERRUPT",
             ])
             
             lines.extend([
@@ -380,7 +368,7 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
                 "",
             ])
             
-            # WFI - label right before (should trap with illegal instruction)
+            # WFI
             lines.extend([
                 test_data.add_testcase(binname, coverpoint, covergroup),
                 "    wfi",

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
@@ -20,7 +20,7 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_user_mti"
 
-    r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch = test_data.int_regs.get_registers(5, exclude_regs=[0, 2, 7, 30])
+    r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch = test_data.int_regs.get_registers(5, exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -54,43 +54,27 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
 
             # Set mstatus.MPIE (not MIE) because mret copies MPIE→MIE when transitioning to U-mode.
             # Setting MIE directly would be overwritten by mret's automatic MPIE restoration.
-            cmd = ["CSRC", "CSRS"][mstatus_mie]  # CSRC if 0, CSRS if 1
             lines.extend(
                 [
                     f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
-                    f"{cmd}(mstatus, x{r_scratch})",
-                ]
-            )
-
-            # Enable MTIE
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x80)",
+                    f"{'CSRS' if mstatus_mie else 'CSRC'}(mstatus, x{r_scratch})",
+                    f"LI(x{r_scratch}, 0x80)",  # Enable MTIE
                     f"CSRW(mie, x{r_scratch})",
+                    "RVTEST_GOTO_LOWER_MODE Umode",  # Go to U-mode
+                    test_data.add_testcase(binname, coverpoint, covergroup),
                 ]
             )
-
-            # Go to U-mode
-            lines.append("RVTEST_GOTO_LOWER_MODE Umode")
-
-            # Trigger interrupt
-            lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
 
             lines.extend(indent(set_mtimer_int(r_mtime, r_mtimecmp, r_temp, r_temp2)))
 
             lines.extend(
                 [
                     "RVTEST_IDLE_FOR_INTERRUPT",
-                ]
-            )
-
-            # Return to M-mode and cleanup
-            lines.extend(
-                [
-                    "RVTEST_GOTO_MMODE",
+                    "RVTEST_GOTO_MMODE",  # Return to M-mode and cleanup
                     "nop",
                 ]
             )
+
             lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
 
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch])
@@ -102,7 +86,7 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_user_msi"
 
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2, 7, 30])
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -131,35 +115,16 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
             if mtvec_mode:
                 lines.append("csrsi mtvec, 1")  # Set mtvec.MODE to vectored (01)
 
-            cmd = ["CSRC", "CSRS"][mstatus_mie]  # CSRC if 0, CSRS if 1
             lines.extend(
                 [
                     f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
-                    f"{cmd}(mstatus, x{r_scratch})",
-                ]
-            )
-
-            # Enable MSIE
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x08)",
+                    f"{'CSRS' if mstatus_mie else 'CSRC'}(mstatus, x{r_scratch})",
+                    f"LI(x{r_scratch}, 0x08)",  # Enable MSIE
                     f"CSRW(mie, x{r_scratch})",
-                ]
-            )
-
-            lines.append("RVTEST_GOTO_LOWER_MODE Umode")
-
-            # Trigger - label right before
-            lines.extend(
-                [
+                    "RVTEST_GOTO_LOWER_MODE Umode",
                     test_data.add_testcase(binname, coverpoint, covergroup),
-                    "    RVTEST_SET_MSW_INT",
-                    "    RVTEST_IDLE_FOR_INTERRUPT",
-                ]
-            )
-
-            lines.extend(
-                [
+                    "RVTEST_SET_MSW_INT",
+                    "RVTEST_IDLE_FOR_INTERRUPT",
                     "RVTEST_GOTO_MMODE",
                     "nop",
                     "RVTEST_CLR_MSW_INT",
@@ -175,7 +140,7 @@ def _generate_user_mei_tests(test_data: TestData) -> list[str]:
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_user_mei"
 
-    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2, 7, 30])
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -204,34 +169,16 @@ def _generate_user_mei_tests(test_data: TestData) -> list[str]:
             if mtvec_mode:
                 lines.append("csrsi mtvec, 1")  # Set mtvec.MODE to vectored (01)
 
-            cmd = ["CSRC", "CSRS"][mstatus_mie]  # CSRC if 0, CSRS if 1
             lines.extend(
                 [
                     f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
-                    f"{cmd}(mstatus, x{r_scratch})",
-                ]
-            )
-
-            # Enable MEIE
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x800)",
+                    f"{'CSRS' if mstatus_mie else 'CSRC'}(mstatus, x{r_scratch})",
+                    f"LI(x{r_scratch}, 0x800)",  # Enable MEIE
                     f"CSRW(mie, x{r_scratch})",
-                ]
-            )
-
-            lines.append("RVTEST_GOTO_LOWER_MODE Umode")
-
-            lines.extend(
-                [
+                    "RVTEST_GOTO_LOWER_MODE Umode",
                     test_data.add_testcase(binname, coverpoint, covergroup),
-                    "    RVTEST_SET_MEXT_INT",
-                    "    RVTEST_IDLE_FOR_INTERRUPT",
-                ]
-            )
-
-            lines.extend(
-                [
+                    "RVTEST_SET_MEXT_INT",
+                    "RVTEST_IDLE_FOR_INTERRUPT",
                     "RVTEST_GOTO_MMODE",
                     "nop",
                     "RVTEST_CLR_MEXT_INT",
@@ -247,9 +194,7 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_wfi"
 
-    r_mtime, r_mtimecmp, r_temp, r_temp2, r_t1, r_t2, r_scratch = test_data.int_regs.get_registers(
-        7, exclude_regs=[0, 2, 7, 30]
-    )
+    r_mtime, r_mtimecmp, r_temp, r_temp2, r_t1, r_t2, r_scratch = test_data.int_regs.get_registers(7, exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -275,11 +220,10 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
             )
 
             # Set MIE if needed
-            cmd = ["CSRC", "CSRS"][mie_val]  # CSRC if 0, CSRS if 1
             lines.extend(
                 [
                     f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
-                    f"{cmd}(mstatus, x{r_scratch})",
+                    f"{'CSRS' if mie_val else 'CSRC'}(mstatus, x{r_scratch})",
                 ]
             )
 
@@ -293,14 +237,7 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
                 )
 
             # Enable MTIE
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRW(mie, x{r_scratch})",
-                ]
-            )
-
-            lines.append("RVTEST_GOTO_LOWER_MODE Umode")
+            lines.extend([f"LI(x{r_scratch}, 0x80)", f"CSRW(mie, x{r_scratch})", "RVTEST_GOTO_LOWER_MODE Umode"])
 
             # Set timer to fire soon
             lines.extend(indent(set_mtimer_int_soon(r_mtime, r_mtimecmp, r_temp, r_t1, r_t2, r_temp2)))
@@ -311,14 +248,10 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
                     test_data.add_testcase(binname, coverpoint, covergroup),
                     "    wfi",
                     "    nop",
+                    "    RVTEST_GOTO_MMODE",
                 ]
             )
 
-            lines.extend(
-                [
-                    "RVTEST_GOTO_MMODE",
-                ]
-            )
             lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
 
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp, r_temp2, r_t1, r_t2, r_scratch])
@@ -330,7 +263,7 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_wfi_timeout"
 
-    r_temp, r_mtimecmp, r_scratch = test_data.int_regs.get_registers(3, exclude_regs=[0, 2, 7, 30])
+    r_temp, r_mtimecmp, r_scratch = test_data.int_regs.get_registers(3, exclude_regs=[0])
 
     lines = [
         comment_banner(
@@ -357,15 +290,8 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
                     "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
                     f"LI(x{r_scratch}, 0x80)",
                     f"CSRC(mie, x{r_scratch})",
-                ]
-            )
-
-            # Set MIE if needed
-            cmd = ["CSRC", "CSRS"][mie_val]  # CSRC if 0, CSRS if 1
-            lines.extend(
-                [
                     f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
-                    f"{cmd}(mstatus, x{r_scratch})",
+                    f"{'CSRS' if mie_val else 'CSRC'}(mstatus, x{r_scratch})",
                 ]
             )
 
@@ -385,24 +311,12 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
                 [
                     "RVTEST_GOTO_LOWER_MODE Umode",
                     "",
-                ]
-            )
-
-            # WFI
-            lines.extend(
-                [
                     test_data.add_testcase(binname, coverpoint, covergroup),
-                    "    wfi",
-                    "    nop",
-                ]
-            )
-
-            lines.extend(
-                [
+                    "wfi",
+                    "nop",
                     "RVTEST_GOTO_MMODE",
                 ]
             )
-            lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
 
     test_data.int_regs.return_registers([r_temp, r_mtimecmp, r_scratch])
     return lines
@@ -412,14 +326,9 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
 def make_interruptsu(test_data: TestData) -> list[str]:
     """Generate tests for InterruptsU user-mode interrupt behavior."""
 
-    # Consume t2 and t5 - reserved by trap handler in arch_test.h for interrupt clearing subroutines
-    # The trap handler uses these registers when calling RVMODEL_CLR_*_INT macros
-    # See: tests/env/arch_test.h, trap handler interrupt dispatch logic
-    test_data.int_regs.consume_registers([7, 30])
-
     lines: list[str] = []
 
-    r_temp, r_mtimecmp = test_data.int_regs.get_registers(2, exclude_regs=[0, 2, 7, 30])
+    r_temp, r_mtimecmp = test_data.int_regs.get_registers(2, exclude_regs=[0])
 
     # Initial setup - clear any pending timer
     lines.extend(
@@ -440,8 +349,5 @@ def make_interruptsu(test_data: TestData) -> list[str]:
     lines.extend(_generate_user_mei_tests(test_data))
     lines.extend(_generate_user_wfi_tests(test_data))
     lines.extend(_generate_user_wfi_timeout_tests(test_data))
-
-    # Return the consumed registers before test ends
-    test_data.int_regs.return_registers([7, 30])
 
     return lines

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
@@ -54,8 +54,6 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
                 ]
             )
 
-            # lines.extend(*set_mtimer_int(r_mtime, r_mtimecmp, r_temp, r_temp2))
-
             for _ in range(5000):
                 lines.append("    nop")
 
@@ -67,8 +65,6 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
                     *clr_mtimer_int(r_temp, r_mtimecmp),
                 ]
             )
-
-            # lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
 
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch])
     return lines
@@ -251,8 +247,6 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
                     *clr_mtimer_int(r_temp, r_mtimecmp),
                 ]
             )
-
-            # lines.extend(*clr_mtimer_int(r_temp, r_mtimecmp))
 
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp, r_temp2, r_t1, r_t2, r_scratch])
     return lines

--- a/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
+++ b/generators/testgen/src/testgen/priv/extensions/InterruptsU.py
@@ -10,7 +10,7 @@
 """InterruptsU privileged extension test generator for user-mode interrupts."""
 
 from testgen.asm.helpers import comment_banner
-from testgen.asm.interrupts import clr_mtimer_int, set_mtimer_int, set_mtimer_int_soon
+from testgen.asm.interrupts import clr_mtimer_int, indent, set_mtimer_int, set_mtimer_int_soon
 from testgen.data.state import TestData
 from testgen.priv.registry import add_priv_test_generator
 
@@ -19,9 +19,11 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
     """Generate undelegated MTI interrupt tests from U-mode."""
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_user_mti"
-
-    r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch = test_data.int_regs.get_registers(5)
-
+    
+    r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch = test_data.int_regs.get_registers(
+        5, exclude_regs=[0, 2, 7, 30]
+    )
+    
     lines = [
         comment_banner(
             "cp_user_mti",
@@ -31,53 +33,69 @@ def _generate_user_mti_tests(test_data: TestData) -> list[str]:
         ),
         "",
     ]
-
+    
     # Cross: mtvec.MODE x mstatus.MIE (2x2 = 4 bins)
     for mtvec_mode in [0, 1]:
         for mstatus_mie in [0, 1]:
             mode_name = ["direct", "vectored"][mtvec_mode]
             mie_name = f"mie_{mstatus_mie}"
             binname = f"{mode_name}_{mie_name}"
-
-            lines.extend(
-                [
-                    "",
-                    "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
-                    "csrci mtvec, 3",  # Clear mtvec.MODE (bits 1:0)
-                ]
-            )
-
+            
+            lines.extend([
+                "",
+                "# Setup mstatus and mtvec",
+                "csrci mstatus, 8",
+                "csrci mtvec, 3",
+            ])
+            
+            # Set mtvec.MODE if needed
             if mtvec_mode:
                 lines.append("csrsi mtvec, 1")
+            
+            # Set mstatus.MIE if needed
+            # if mstatus_mie:
+            #     lines.append("csrsi mstatus, 8")
+            # Set mstatus.MPIE (bit 7) instead of MIE (bit 3)
+            if mstatus_mie:
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x80)",  # MPIE bit mask
+                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",  # Set MPIE
+                ])
+            else:
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x80)",  # MPIE bit mask
+                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",  # Clear MPIE
+                ])
+            
+            # Enable MTIE
+            lines.extend([
+                f"LI(x{r_scratch}, 0x80)",
+                f"CSRW(mie, x{r_scratch})",
+            ])
+            
+            # Go to U-mode
+            lines.append("RVTEST_GOTO_LOWER_MODE Umode")
+            
+            # Trigger interrupt - label right before trigger
+            lines.append(test_data.add_testcase(binname, coverpoint, covergroup))
 
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"{'CSRS' if mstatus_mie else 'CSRC'}(mstatus, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x80)",
-                    f"CSRW(mie, x{r_scratch})",
-                    "RVTEST_GOTO_LOWER_MODE Umode",
-                    test_data.add_testcase(binname, coverpoint, covergroup),
-                    *set_mtimer_int(r_mtime, r_mtimecmp, r_temp, r_temp2),
-                ]
-            )
-
-            lines.extend(
-                [
-                    f"    LI(x{r_scratch}, 2500)",  # 2500 iterations × 2 instructions = 5000 cycles
-                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
-                    f"    bnez x{r_scratch}, 1b",
-                ]
-            )
-
-            lines.extend(
-                [
-                    "RVTEST_GOTO_MMODE",
-                    "nop",
-                    *clr_mtimer_int(r_temp, r_mtimecmp),
-                ]
-            )
-
+            lines.extend([
+                "RVTEST_IDLE_FOR_INTERRUPT",
+            ])
+            
+            lines.extend(indent(set_mtimer_int(r_mtime, r_mtimecmp, r_temp, r_temp2)))
+            
+            lines.extend([
+                "RVTEST_IDLE_FOR_INTERRUPT",
+            ])
+            
+            # Return to M-mode and cleanup
+            lines.extend([
+                "RVTEST_GOTO_MMODE",
+                "nop",
+            ])
+            lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
+    
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp, r_temp2, r_scratch])
     return lines
 
@@ -86,9 +104,9 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
     """Generate undelegated MSI interrupt tests from U-mode."""
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_user_msi"
-
-    r_scratch = test_data.int_regs.get_register()
-
+    
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2, 7, 30])
+    
     lines = [
         comment_banner(
             "cp_user_msi",
@@ -98,52 +116,58 @@ def _generate_user_msi_tests(test_data: TestData) -> list[str]:
         ),
         "",
     ]
-
+    
     for mtvec_mode in [0, 1]:
         for mstatus_mie in [0, 1]:
             mode_name = ["direct", "vectored"][mtvec_mode]
             mie_name = f"mie_{mstatus_mie}"
             binname = f"{mode_name}_{mie_name}"
-
-            lines.extend(
-                [
-                    "",
-                    "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
-                    "csrci mtvec, 3",  # Clear mtvec.MODE (bits 1:0)
-                ]
-            )
-
+            
+            lines.extend([
+                "",
+                "csrci mstatus, 8",
+                "csrci mtvec, 3",
+            ])
+            
             if mtvec_mode:
-                lines.append("csrsi mtvec, 1")  # Set mtvec.MODE to vectored (01)
-
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
-                    f"{'CSRS' if mstatus_mie else 'CSRC'}(mstatus, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x08)",  # Enable MSIE
-                    f"CSRW(mie, x{r_scratch})",
-                    "RVTEST_GOTO_LOWER_MODE Umode",
-                    test_data.add_testcase(binname, coverpoint, covergroup),
-                    "RVTEST_SET_MSW_INT",
-                ]
-            )
-
-            lines.extend(
-                [
-                    f"    LI(x{r_scratch}, 2500)",  # 2500 iterations × 2 instructions = 5000 cycles
-                    f"1:  addi x{r_scratch}, x{r_scratch}, -1",
-                    f"    bnez x{r_scratch}, 1b",
-                ]
-            )
-
-            lines.extend(
-                [
-                    "RVTEST_GOTO_MMODE",
-                    "nop",
-                    "RVTEST_CLR_MSW_INT",
-                ]
-            )
-
+                lines.append("csrsi mtvec, 1")
+            
+            # if mstatus_mie:
+            #     lines.append("csrsi mstatus, 8")
+            if mstatus_mie:
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                ])
+            else:
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+                ])
+            
+            # Enable MSIE
+            lines.extend([
+                f"LI(x{r_scratch}, 0x08)",
+                f"CSRW(mie, x{r_scratch})",
+            ])
+            
+            lines.append("RVTEST_GOTO_LOWER_MODE Umode")
+            
+            # Trigger - label right before
+            lines.extend([
+                test_data.add_testcase(binname, coverpoint, covergroup),
+                "    RVTEST_SET_MSW_INT",
+                "    nop",
+                "    nop",
+                "    nop",
+            ])
+            
+            lines.extend([
+                "RVTEST_GOTO_MMODE",
+                "nop",
+                "RVTEST_CLR_MSW_INT",
+            ])
+    
     test_data.int_regs.return_registers([r_scratch])
     return lines
 
@@ -152,9 +176,9 @@ def _generate_user_mei_tests(test_data: TestData) -> list[str]:
     """Generate undelegated MEI interrupt tests from U-mode."""
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_user_mei"
-
-    r_scratch = test_data.int_regs.get_register()
-
+    
+    r_scratch = test_data.int_regs.get_register(exclude_regs=[0, 2, 7, 30])
+    
     lines = [
         comment_banner(
             "cp_user_mei",
@@ -164,40 +188,55 @@ def _generate_user_mei_tests(test_data: TestData) -> list[str]:
         ),
         "",
     ]
-
+    
     for mtvec_mode in [0, 1]:
         for mstatus_mie in [0, 1]:
             mode_name = ["direct", "vectored"][mtvec_mode]
             mie_name = f"mie_{mstatus_mie}"
             binname = f"{mode_name}_{mie_name}"
-
-            lines.extend(
-                [
-                    "",
-                    "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
-                    "csrci mtvec, 3",  # Clear mtvec.MODE (bits 1:0)
-                ]
-            )
-
+            
+            lines.extend([
+                "",
+                "csrci mstatus, 8",
+                "csrci mtvec, 3",
+            ])
+            
             if mtvec_mode:
-                lines.append("csrsi mtvec, 1")  # Set mtvec.MODE to vectored (01)
-
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
-                    f"{'CSRS' if mstatus_mie else 'CSRC'}(mstatus, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x800)",  # Enable MEIE
-                    f"CSRW(mie, x{r_scratch})",
-                    "RVTEST_GOTO_LOWER_MODE Umode",
-                    test_data.add_testcase(binname, coverpoint, covergroup),
-                    "RVTEST_SET_MEXT_INT",
-                    "RVTEST_IDLE_FOR_INTERRUPT",
-                    "RVTEST_GOTO_MMODE",
-                    "nop",
-                    "RVTEST_CLR_MEXT_INT",
-                ]
-            )
-
+                lines.append("csrsi mtvec, 1")
+            
+            if mstatus_mie:
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                ])
+            else:
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+                ])
+            
+            # Enable MEIE
+            lines.extend([
+                f"LI(x{r_scratch}, 0x800)",
+                f"CSRW(mie, x{r_scratch})",
+            ])
+            
+            lines.append("RVTEST_GOTO_LOWER_MODE Umode")
+            
+            lines.extend([
+                test_data.add_testcase(binname, coverpoint, covergroup),
+                "    RVTEST_SET_MEXT_INT",
+                "    nop",
+                "    nop",
+                "    nop",
+            ])
+            
+            lines.extend([
+                "RVTEST_GOTO_MMODE",
+                "nop",
+                "RVTEST_CLR_MEXT_INT",
+            ])
+    
     test_data.int_regs.return_registers([r_scratch])
     return lines
 
@@ -206,9 +245,11 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
     """Generate WFI tests from U-mode."""
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_wfi"
-
-    r_mtime, r_mtimecmp, r_temp, r_temp2, r_t1, r_t2, r_scratch = test_data.int_regs.get_registers(7)
-
+    
+    r_mtime, r_mtimecmp, r_temp, r_temp2, r_t1, r_t2, r_scratch = test_data.int_regs.get_registers(
+        7, exclude_regs=[0, 2, 7, 30]
+    )
+    
     lines = [
         comment_banner(
             "cp_wfi",
@@ -218,52 +259,60 @@ def _generate_user_wfi_tests(test_data: TestData) -> list[str]:
         ),
         "",
     ]
-
+    
     # Cross: MIE x TW (2x2 = 4 bins)
     for mie_val in [0, 1]:
         for tw_val in [0, 1]:
             binname = f"mie_{mie_val}_tw_{tw_val}"
-
-            lines.extend(
-                [
-                    "",
-                    f"LI(x{r_scratch}, 0x200008)",
-                    f"CSRC(mstatus, x{r_scratch})",
-                ]
-            )
-
+            
+            lines.extend([
+                "",
+                f"LI(x{r_scratch}, 0x200008)",
+                f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+            ])
+            
             # Set MIE if needed
-            lines.extend(
-                [
-                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
-                    f"{'CSRS' if mie_val else 'CSRC'}(mstatus, x{r_scratch})",
-                ]
-            )
-
+            if mie_val:
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                ])
+            else:
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+                ])
+            
             # Set TW if needed
             if tw_val:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x200000)",
-                        f"CSRS(mstatus, x{r_scratch})",
-                    ]
-                )
-
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x200000)",
+                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                ])
+            
             # Enable MTIE
-            lines.extend([f"LI(x{r_scratch}, 0x80)", f"CSRW(mie, x{r_scratch})", "RVTEST_GOTO_LOWER_MODE Umode"])
-
+            lines.extend([
+                f"LI(x{r_scratch}, 0x80)",
+                f"CSRW(mie, x{r_scratch})",
+            ])
+            
+            lines.append("RVTEST_GOTO_LOWER_MODE Umode")
+            
+            # Set timer to fire soon
+            lines.extend(indent(set_mtimer_int_soon(r_mtime, r_mtimecmp, r_temp, r_t1, r_t2, r_temp2)))
+            
             # WFI - label right before
-            lines.extend(
-                [
-                    *set_mtimer_int_soon(r_mtime, r_mtimecmp, r_temp, r_t1, r_t2, r_temp2),  # Set timer to fire soon
-                    test_data.add_testcase(binname, coverpoint, covergroup),
-                    "wfi",
-                    "nop",
-                    "RVTEST_GOTO_MMODE",
-                    *clr_mtimer_int(r_temp, r_mtimecmp),
-                ]
-            )
-
+            lines.extend([
+                test_data.add_testcase(binname, coverpoint, covergroup),
+                "    wfi",
+                "    nop",
+            ])
+            
+            lines.extend([
+                "RVTEST_GOTO_MMODE",
+            ])
+            lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
+    
     test_data.int_regs.return_registers([r_mtime, r_mtimecmp, r_temp, r_temp2, r_t1, r_t2, r_scratch])
     return lines
 
@@ -272,9 +321,11 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
     """Generate WFI timeout tests (illegal instruction) from U-mode."""
     covergroup = "InterruptsU_cg"
     coverpoint = "cp_wfi_timeout"
-
-    r_temp, r_mtimecmp, r_scratch = test_data.int_regs.get_registers(3)
-
+    
+    r_temp, r_mtimecmp, r_scratch = test_data.int_regs.get_registers(
+        3, exclude_regs=[0, 2, 7, 30]
+    )
+    
     lines = [
         comment_banner(
             "cp_wfi_timeout",
@@ -285,74 +336,96 @@ def _generate_user_wfi_timeout_tests(test_data: TestData) -> list[str]:
         "",
         "# Set TW=1 for entire test block",
         f"LI(x{r_scratch}, 0x200000)",
-        f"CSRS(mstatus, x{r_scratch})",
+        f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
         "",
     ]
-
+    
     # Cross: MIE x MTIE (2x2 = 4 bins), TW=1 fixed
     for mie_val in [0, 1]:
         for mtie_val in [0, 1]:
             binname = f"mie_{mie_val}_mtie_{mtie_val}"
-
-            lines.extend(
-                [
-                    "",
-                    "csrci mstatus, 8",  # Clear mstatus.MIE (bit 3)
+            
+            lines.extend([
+                "",
+                "csrci mstatus, 8",
+                f"LI(x{r_scratch}, 0x80)",
+                f"CSRRC(x{r_scratch}, mie, x{r_scratch})",
+            ])
+            
+            # Set MIE if needed
+            if mie_val:
+                lines.extend([
                     f"LI(x{r_scratch}, 0x80)",
-                    f"CSRC(mie, x{r_scratch})",
-                    f"LI(x{r_scratch}, 0x80)",  # mstatus.MPIE bit mask (bit 7)
-                    f"{'CSRS' if mie_val else 'CSRC'}(mstatus, x{r_scratch})",
-                ]
-            )
-
+                    f"CSRRS(x{r_scratch}, mstatus, x{r_scratch})",
+                ])
+            else:
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRRC(x{r_scratch}, mstatus, x{r_scratch})",
+                ])
+            
             # Set MTIE if needed
             if mtie_val:
-                lines.extend(
-                    [
-                        f"LI(x{r_scratch}, 0x80)",
-                        f"CSRS(mie, x{r_scratch})",
-                    ]
-                )
-
+                lines.extend([
+                    f"LI(x{r_scratch}, 0x80)",
+                    f"CSRRS(x{r_scratch}, mie, x{r_scratch})",
+                ])
+            
             # Clear timer (ensure no interrupt)
             lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
-
-            lines.extend(
-                [
-                    "RVTEST_GOTO_LOWER_MODE Umode",
-                    "",
-                    test_data.add_testcase(binname, coverpoint, covergroup),
-                    "wfi",
-                    "nop",
-                    "RVTEST_GOTO_MMODE",
-                ]
-            )
-
+            
+            lines.extend([
+                "nop",
+                "RVTEST_GOTO_LOWER_MODE Umode",
+                "",
+            ])
+            
+            # WFI - label right before (should trap with illegal instruction)
+            lines.extend([
+                test_data.add_testcase(binname, coverpoint, covergroup),
+                "    wfi",
+                "    nop",
+            ])
+            
+            lines.extend([
+                "RVTEST_GOTO_MMODE",
+            ])
+            lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
+    
     test_data.int_regs.return_registers([r_temp, r_mtimecmp, r_scratch])
     return lines
 
 
-@add_priv_test_generator("InterruptsU", required_extensions=["Sm", "U", "I", "Zicsr"])
+@add_priv_test_generator("InterruptsU", required_extensions=["Sm", "I", "Zicsr"])
 def make_interruptsu(test_data: TestData) -> list[str]:
     """Generate tests for InterruptsU user-mode interrupt behavior."""
-
+    
+    # Consume t2 and t5 for interrupt subroutines throughout the test
+    test_data.int_regs.consume_registers([7, 30])
+    
     lines: list[str] = []
-
-    r_temp, r_mtimecmp = test_data.int_regs.get_registers(2)
-
-    # Initial setup - clear any pending timer
-    lines.append("CSRW(mideleg, zero)")
+    
+    r_temp, r_mtimecmp = test_data.int_regs.get_registers(2, exclude_regs=[0, 2, 7, 30])
+    
+    # Initial setup - clear any pending timer!
+    lines.extend([
+        "",
+        "CSRW(mideleg, zero)",
+    ])
     lines.extend(clr_mtimer_int(r_temp, r_mtimecmp))
     lines.append("")
-
+    
     # Return the temporary registers
     test_data.int_regs.return_registers([r_temp, r_mtimecmp])
-
+    
     # Generate all test sections
     lines.extend(_generate_user_mti_tests(test_data))
     lines.extend(_generate_user_msi_tests(test_data))
     lines.extend(_generate_user_mei_tests(test_data))
     lines.extend(_generate_user_wfi_tests(test_data))
     lines.extend(_generate_user_wfi_timeout_tests(test_data))
-
+    
+    # Return the consumed registers before test ends
+    test_data.int_regs.return_registers([7, 30])
+    
     return lines

--- a/tests/env/rvtest_setup.h
+++ b/tests/env/rvtest_setup.h
@@ -241,7 +241,8 @@
 
     rvtest_clr_ssw_int:
       RVMODEL_CLR_SSW_INT(T2, T5)
-      csrci sip, 2
+      li T2, 2
+      csrc mip, T2              /* Always called from M-mode; mip.SSIP must be cleared via mip */
       ret
 
     rvtest_set_sext_int:

--- a/tests/env/rvtest_trap_handler.h
+++ b/tests/env/rvtest_trap_handler.h
@@ -1737,14 +1737,19 @@ excpt_\__MODE__\()hndlr_tbl:            // handler code should only touch T2..T6
 
 //------------- [H]SMode----------------
 \__MODE__\()clr_Ssw_int:                // int 1 default to just return if not defined
-                                        // S-mode software interrupts need to be reset differently when raised in M or S mode
-        .ifc \__MODE__ , M              // M-mode: mideleg.SSIP=0 so sip.SSIP is read-only; must clear via mip directly
+                                        // SSIP can be set via CSR write or external controller; clear both
+        .ifc \__MODE__ , M              // M-mode: mideleg.SSIP=0 so sip.SSIP is read-only; clear via mip
             li T2, 2
             csrc mip, T2
+            RVMODEL_CLR_SSW_INT(T2, T5)
         .else
                 .ifc \__MODE__ , S      // S-mode: mideleg.SSIP=1 so sip.SSIP mirrors mip and is writable
+                        li T2, 2
+                        csrc sip, T2
                         RVMODEL_CLR_SSW_INT(T2, T5)
                 .else
+                        li T2, 2
+                        csrc sip, T2
                         RVMODEL_CLR_SSW_INT(T2, T5)
                 .endif
         .endif

--- a/tests/env/rvtest_trap_handler.h
+++ b/tests/env/rvtest_trap_handler.h
@@ -1738,10 +1738,11 @@ excpt_\__MODE__\()hndlr_tbl:            // handler code should only touch T2..T6
 //------------- [H]SMode----------------
 \__MODE__\()clr_Ssw_int:                // int 1 default to just return if not defined
                                         // S-mode software interrupts need to be reset differently when raised in M or S mode
-        .ifc \__MODE__ , M              // Select the interrupt handler function based on current privilege mode
-            RVMODEL_CLR_SSW_INT(T2, T5)
+        .ifc \__MODE__ , M              // M-mode: mideleg.SSIP=0 so sip.SSIP is read-only; must clear via mip directly
+            li T2, 2
+            csrc mip, T2
         .else
-                .ifc \__MODE__ , S
+                .ifc \__MODE__ , S      // S-mode: mideleg.SSIP=1 so sip.SSIP mirrors mip and is writable
                         RVMODEL_CLR_SSW_INT(T2, T5)
                 .else
                         RVMODEL_CLR_SSW_INT(T2, T5)

--- a/tests/env/sail_macros.h
+++ b/tests/env/sail_macros.h
@@ -154,7 +154,8 @@
 
 // TODO: check to see if SAIL support this, and we may want to implement this in WALLY
 #undef SAIL_CLINT_SSIP_ADDRESS
-#define SAIL_CLINT_SSIP_ADDRESS (SAIL_CLINT_BASE_ADDRESS + 0xC000)
+// #define SAIL_CLINT_SSIP_ADDRESS (SAIL_CLINT_BASE_ADDRESS + 0xC000)
+#define SAIL_CLINT_SSIP_ADDRESS (0x80000000)  // dummy address for now
 #undef RVMODEL_SET_SSW_INT
 #define RVMODEL_SET_SSW_INT(_R1, _R2)        \
   li _R1, 1;                 \


### PR DESCRIPTION
This is the python generator for tests for InterruptsSstc with modified coverpoints as well to ensure reachable cross products.
The coverage is currently at 100%.
Added more helper functions into interrupts.py for more modular interrupt test generations.